### PR TITLE
fix: reorder parameters to comply with PHP 8+ syntax rules

### DIFF
--- a/src/Phaseolies/Support/File.php
+++ b/src/Phaseolies/Support/File.php
@@ -246,7 +246,7 @@ class File extends \SplFileInfo
      * @param string $fileName
      * @return boolean
      */
-    public function storeAs(?callable $callback = null, string $path, string $fileName = ''): bool
+    public function storeAs(string $path, string $fileName = '', ?callable $callback = null): bool
     {
         if (! is_callable($callback)) {
             return false;


### PR DESCRIPTION
Fixes a fatal error in PHP 8.0+. Optional parameter `$callback` declared before required parameter `$path` is implicitly treated as a required parameter.

<!--
If you are unsure which branch your pull request should be sent to, please read: https://doppar.com/versions/3.x/contributions.html#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->