### PR TITLE
fix: routing issue resolve for same origin endpoint without attr base…

### DIFF
--- a/src/Phaseolies/Console/Commands/stubs/auth/TwoFactorAuthController.stub
+++ b/src/Phaseolies/Console/Commands/stubs/auth/TwoFactorAuthController.stub
@@ -62,7 +62,7 @@ class TwoFactorAuthController extends Controller
      * @return RedirectResponse
      */
     #[Middleware([GuestMiddleware::class])]
-    #[Route('verify/2fa', name: 'verify.2fa')]
+    #[Route('verify/2fa', name: 'verify.2fa', methods: ['POST'])]
     public function verifyToken(Request $request): RedirectResponse
     {
         if (Auth::verifyTwoFactorCode($request->token)) {

--- a/src/Phaseolies/Providers/RouteServiceProvider.php
+++ b/src/Phaseolies/Providers/RouteServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Phaseolies\Providers;
 
-use Phaseolies\Support\Router;
 use Phaseolies\Support\Facades\Route;
 
 class RouteServiceProvider extends ServiceProvider
@@ -14,10 +13,6 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        // Bind the 'route' key in the container to a singleton instance of Router.
-        // This ensures that the same Router instance is returned whenever 'route' is resolved.
-        $this->app->router = app('route');
-
         $path = urldecode(
             parse_url(request()->server->get("REQUEST_URI", "/"), PHP_URL_PATH)
         );
@@ -42,19 +37,9 @@ class RouteServiceProvider extends ServiceProvider
             return;
         }
 
-        // Load the web routes file.
-        // This file typically contains the route definitions for the application.
-        require base_path('routes/web.php');
-
-        // Load the api routes file.
-        // This file typically contains the api route definitions for the application.
-        Route::group([
-            'prefix' => 'api'
-        ], function () {
-            require base_path('routes/api.php');
-        });
-
         $this->app->router->loadAttributeBasedRoutes();
+
+        Route::group(['prefix' => 'api'], fn() => require base_path('routes/api.php'));
 
         if ($this->app->router->shouldCacheRoutes()) {
             $this->app->router->cacheRoutes();

--- a/src/Phaseolies/Support/Router.php
+++ b/src/Phaseolies/Support/Router.php
@@ -894,8 +894,7 @@ class Router extends Kernel
     protected function loadRoutesFromFiles(): void
     {
         $routeFiles = [
-            base_path('routes/web.php'),
-            base_path('routes/api.php'),
+            base_path('routes/web.php')
         ];
 
         foreach ($routeFiles as $file) {


### PR DESCRIPTION
…d route:

<!--
If you are unsure which branch your pull request should be sent to, please read: https://doppar.com/versions/3.x/contributions.html#which-branch

defined the same path as
api.php
`Route::post('login', [LoginController::class, 'login'])`

web.php
```
Route::get('login', [LoginController::class, 'index'])->name('login');
Route::post('login', [LoginController::class, 'login'])->middleware('guest');
```-->

When I click the login form login button, it hits the login API endpoint. The issue is resolved now. attribute-based route and `web.php` based or `api.php` based route, all are ok now.