### PR TITLE
vendor:publish command updated with cache config

### DIFF
--- a/src/Phaseolies/Console/Commands/ConfigCacheCommand.php
+++ b/src/Phaseolies/Console/Commands/ConfigCacheCommand.php
@@ -3,8 +3,7 @@
 namespace Phaseolies\Console\Commands;
 
 use Phaseolies\Console\Schedule\Command;
-use Phaseolies\Support\Facades\Config;
-
+use Phaseolies\Config\Config;
 class ConfigCacheCommand extends Command
 {
     /**

--- a/src/Phaseolies/Console/Commands/VendorPublishCommand.php
+++ b/src/Phaseolies/Console/Commands/VendorPublishCommand.php
@@ -2,10 +2,11 @@
 
 namespace Phaseolies\Console\Commands;
 
-use Phaseolies\Console\Schedule\Command;
-use Phaseolies\Application;
 use RecursiveIteratorIterator;
 use RecursiveDirectoryIterator;
+use Phaseolies\Console\Schedule\Command;
+use Phaseolies\Config\Config;
+use Phaseolies\Application;
 use FilesystemIterator;
 
 class VendorPublishCommand extends Command
@@ -55,6 +56,11 @@ class VendorPublishCommand extends Command
             }
 
             $this->publishAll($force);
+
+            Config::clearCache();
+            Config::loadAll();
+            Config::cacheConfig();
+
             return Command::SUCCESS;
         });
     }


### PR DESCRIPTION
The config cache option was added to `vendor:publish` because a new config file may be published, so it is automatically cached.