### PR TITLE
New global [throttle()] helper method to ratelimit request

### DIFF
--- a/src/Phaseolies/Helpers/helpers.php
+++ b/src/Phaseolies/Helpers/helpers.php
@@ -16,6 +16,7 @@ use Phaseolies\Http\Controllers\Controller;
 use Phaseolies\Database\Database;
 use Phaseolies\DI\Container;
 use Phaseolies\Config\Config;
+use Phaseolies\Cache\RateLimiter;
 use Phaseolies\Auth\Security\Authenticate;
 use Carbon\Carbon;
 
@@ -889,5 +890,17 @@ if (!function_exists('db')) {
     function db(): Database
     {
         return app('db');
+    }
+}
+
+if (!function_exists('throttle')) {
+    /**
+     * Get a RateLimiter instance
+     *
+     * @return RateLimiter
+     */
+    function throttle(): RateLimiter
+    {
+        return app(RateLimiter::class);
     }
 }


### PR DESCRIPTION
Now using this `throttle()` helper method, we can throttle the request anywhere in doppar application.
Example:
```php
$key = 'ai-agent:' . auth()->id();

if (throttle()->tooManyAttempts($key, 10)) {
    $seconds = throttle()->availableIn($key);
    return response()->json([
        'error' => "Too many requests. Try again in {$seconds} seconds."
    ], 429);
}

throttle()->hit($key, 60); // 10 requests per minute

$response = Agent::using(OpenAI::class)
    ->withKey(env('OPENAI_API_KEY'))
    ->model('gpt-4')
    ->prompt($userInput)
    ->send();
```