### PR TITLE
Fix Symfony Console deprecation: Replace add() with addCommand()

### DIFF
--- a/src/Phaseolies/Console/Console.php
+++ b/src/Phaseolies/Console/Console.php
@@ -40,7 +40,7 @@ class Console extends SymfonyApplication
     public function addCommands(array $commands): void
     {
         foreach ($commands as $command) {
-            $this->add($this->resolveCommand($command));
+            $this->addCommand($this->resolveCommand($command));
         }
     }
 


### PR DESCRIPTION
## Description
This PR fixes a deprecation warning from Symfony Console 7.4+.

## Changes
- Replaced the deprecated `add()` method with `addCommand()` in the Console class
- This ensures compatibility with Symfony Console 8.0

## Deprecation Warning Fixed
```
⛔ ERROR: Since symfony/console 7.4: The "Symfony\Component\Console\Application::add()" method is deprecated and will be removed in Symfony 8.0, use "Symfony\Component\Console\Application::addCommand()" instead.
```

## Testing
- [x] Code compiles without deprecation warnings
- [x] Backward compatible (both methods work the same way)

## References
- Symfony Console documentation: https://symfony.com/doc/current/console.html
- Deprecation notice: https://symfony.com/doc/7.4/components/console.html#registering-commands