### PR TITLE
updated ErrorHandler class triggerBeforeException method:

### DIFF
--- a/src/Phaseolies/Error/ErrorHandler.php
+++ b/src/Phaseolies/Error/ErrorHandler.php
@@ -5,6 +5,7 @@ namespace Phaseolies\Error;
 use Throwable;
 use Phaseolies\Support\LoggerService;
 use Phaseolies\Error\Factory\ErrorHandlerFactory;
+use Phaseolies\Http\Response;
 
 class ErrorHandler
 {
@@ -116,7 +117,7 @@ class ErrorHandler
             $before = app($beforeExceptionClass);
 
             if ($before->supports()) {
-                $response = app('response');
+                $response = app(Response::class);
                 $statusCode = $exception instanceof \Phaseolies\Http\Exceptions\HttpException
                     ? $exception->getStatusCode()
                     : 500;


### PR DESCRIPTION
Previously we were calling `app('response')` and now we are calling like this `app(Response::class)`