### PR TITLE
[unit:test] command added with details and fliter options

### DIFF
--- a/src/Phaseolies/Console/Commands/Cron/CronDaemonCommand.php
+++ b/src/Phaseolies/Console/Commands/Cron/CronDaemonCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phaseolies\Console\Commands;
+namespace Phaseolies\Console\Commands\Cron;
 
 use Phaseolies\Console\Schedule\Command;
 

--- a/src/Phaseolies/Console/Commands/Cron/CronFinishCommand.php
+++ b/src/Phaseolies/Console/Commands/Cron/CronFinishCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phaseolies\Console\Commands;
+namespace Phaseolies\Console\Commands\Cron;
 
 use Phaseolies\Console\Schedule\Command;
 

--- a/src/Phaseolies/Console/Commands/Cron/CronListCommand.php
+++ b/src/Phaseolies/Console/Commands/Cron/CronListCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phaseolies\Console\Commands;
+namespace Phaseolies\Console\Commands\Cron;
 
 use App\Schedule\Schedule;
 use Phaseolies\Console\Schedule\Command;

--- a/src/Phaseolies/Console/Commands/Cron/CronRunCommand.php
+++ b/src/Phaseolies/Console/Commands/Cron/CronRunCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phaseolies\Console\Commands;
+namespace Phaseolies\Console\Commands\Cron;
 
 use App\Schedule\Schedule;
 use Phaseolies\Console\Schedule\Command;

--- a/src/Phaseolies/Console/Commands/Migrations/AddColumnMigrationCommand.php
+++ b/src/Phaseolies/Console/Commands/Migrations/AddColumnMigrationCommand.php
@@ -1,32 +1,25 @@
 <?php
 
-namespace Phaseolies\Console\Commands;
+namespace Phaseolies\Console\Commands\Migrations;
 
 use Phaseolies\Console\Schedule\Command;
 use Phaseolies\Database\Migration\MigrationCreator;
 
-class CreateMigrationCommand extends Command
+class AddColumnMigrationCommand extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $name = 'make:migration {name} {--create=} {--table=}';
+    protected $name = 'make:migration {name} {--create=} {--table=} {--column=} {--type=} {--after=}';
 
     /**
      * The description of the console command.
      *
      * @var string
      */
-    protected $description = 'Creates a new migration file';
-
-    /**
-     * The migration creator instance.
-     *
-     * @var MigrationCreator
-     */
-    protected MigrationCreator $creator;
+    protected $description = 'Creates a new migration file with optional column addition';
 
     /**
      * Create a new command instance.
@@ -34,11 +27,9 @@ class CreateMigrationCommand extends Command
      * @param MigrationCreator $creator
      * @return void
      */
-    public function __construct(MigrationCreator $creator)
+    public function __construct(protected MigrationCreator $creator)
     {
         parent::__construct();
-
-        $this->creator = $creator;
     }
 
     /**
@@ -52,6 +43,9 @@ class CreateMigrationCommand extends Command
             $name = $this->argument('name');
             $table = $this->option('table');
             $create = $this->option('create') ?: false;
+            $column = $this->option('column');
+            $type = $this->option('type');
+            $after = $this->option('after');
 
             if (!$table && is_string($create)) {
                 $table = $create;
@@ -62,11 +56,15 @@ class CreateMigrationCommand extends Command
                 $name,
                 $this->getMigrationPath(),
                 $table,
-                $create
+                $create,
+                $column,
+                $type,
+                $after
             );
 
             $this->displaySuccess('Migration created successfully.');
             $this->line("<fg=yellow>📁 File:</> <fg=white>{$file}</>");
+            
             return Command::SUCCESS;
         });
     }

--- a/src/Phaseolies/Console/Commands/Migrations/CreateMigrationCommand.php
+++ b/src/Phaseolies/Console/Commands/Migrations/CreateMigrationCommand.php
@@ -1,25 +1,32 @@
 <?php
 
-namespace Phaseolies\Console\Commands;
+namespace Phaseolies\Console\Commands\Migrations;
 
 use Phaseolies\Console\Schedule\Command;
 use Phaseolies\Database\Migration\MigrationCreator;
 
-class AddColumnMigrationCommand extends Command
+class CreateMigrationCommand extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $name = 'make:migration {name} {--create=} {--table=} {--column=} {--type=} {--after=}';
+    protected $name = 'make:migration {name} {--create=} {--table=}';
 
     /**
      * The description of the console command.
      *
      * @var string
      */
-    protected $description = 'Creates a new migration file with optional column addition';
+    protected $description = 'Creates a new migration file';
+
+    /**
+     * The migration creator instance.
+     *
+     * @var MigrationCreator
+     */
+    protected MigrationCreator $creator;
 
     /**
      * Create a new command instance.
@@ -27,9 +34,11 @@ class AddColumnMigrationCommand extends Command
      * @param MigrationCreator $creator
      * @return void
      */
-    public function __construct(protected MigrationCreator $creator)
+    public function __construct(MigrationCreator $creator)
     {
         parent::__construct();
+
+        $this->creator = $creator;
     }
 
     /**
@@ -43,9 +52,6 @@ class AddColumnMigrationCommand extends Command
             $name = $this->argument('name');
             $table = $this->option('table');
             $create = $this->option('create') ?: false;
-            $column = $this->option('column');
-            $type = $this->option('type');
-            $after = $this->option('after');
 
             if (!$table && is_string($create)) {
                 $table = $create;
@@ -56,15 +62,11 @@ class AddColumnMigrationCommand extends Command
                 $name,
                 $this->getMigrationPath(),
                 $table,
-                $create,
-                $column,
-                $type,
-                $after
+                $create
             );
 
             $this->displaySuccess('Migration created successfully.');
             $this->line("<fg=yellow>📁 File:</> <fg=white>{$file}</>");
-            
             return Command::SUCCESS;
         });
     }

--- a/src/Phaseolies/Console/Commands/Migrations/CreateSeedCommand.php
+++ b/src/Phaseolies/Console/Commands/Migrations/CreateSeedCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phaseolies\Console\Commands;
+namespace Phaseolies\Console\Commands\Migrations;
 
 use Phaseolies\Console\Schedule\Command;
 

--- a/src/Phaseolies/Console/Commands/Migrations/DBSeedCommand.php
+++ b/src/Phaseolies/Console/Commands/Migrations/DBSeedCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phaseolies\Console\Commands;
+namespace Phaseolies\Console\Commands\Migrations;
 
 use Phaseolies\Console\Schedule\Command;
 use Database\Seeders\DatabaseSeeder;

--- a/src/Phaseolies/Console/Commands/Migrations/MigrateCommand.php
+++ b/src/Phaseolies/Console/Commands/Migrations/MigrateCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phaseolies\Console\Commands;
+namespace Phaseolies\Console\Commands\Migrations;
 
 use Phaseolies\Console\Schedule\Command;
 use Phaseolies\Database\Migration\Migrator;

--- a/src/Phaseolies/Console/Commands/Migrations/MigrateRefreshCommand.php
+++ b/src/Phaseolies/Console/Commands/Migrations/MigrateRefreshCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phaseolies\Console\Commands;
+namespace Phaseolies\Console\Commands\Migrations;
 
 use Phaseolies\Console\Schedule\Command;
 use Phaseolies\Support\Facades\Schema;

--- a/src/Phaseolies/Console/Commands/Tests/UnitTestCommand.php
+++ b/src/Phaseolies/Console/Commands/Tests/UnitTestCommand.php
@@ -1,0 +1,284 @@
+<?php
+
+namespace Phaseolies\Console\Commands\Tests;
+
+use Phaseolies\Console\Schedule\Command;
+use Symfony\Component\Process\Process;
+
+class UnitTestCommand extends Command
+{
+    /**
+     * The name of the console command.
+     *
+     * @var string
+     */
+    protected $name = 'unit:test
+                       {--class= : Specific test class file path to run}
+                       {--filter= : Filter tests by name pattern}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Run unit tests with detailed';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    protected function handle(): int
+    {
+        $startTime = microtime(true);
+
+        $this->displayBanner();
+
+        $classPath = $this->option('class');
+        $filter = $this->option('filter');
+
+        $command = $this->buildPHPUnitCommand($classPath, $filter);
+
+        $this->line('🔍 Running tests...', 'fg=yellow');
+        $this->newLine();
+
+        $process = new Process($command, base_path());
+        $process->setTimeout(300);
+
+        $outputBuffer = '';
+
+        $process->run(function ($type, $buffer) use (&$outputBuffer) {
+            $outputBuffer .= $buffer;
+            $this->formatAndDisplayOutput($buffer);
+        });
+
+        $exitCode = $process->getExitCode();
+
+        $duration = round(microtime(true) - $startTime, 3);
+        $this->displaySummary($outputBuffer, $duration, $exitCode);
+
+        return $exitCode;
+    }
+
+    /**
+     * Build PHPUnit command
+     *
+     * @param string|null $classPath
+     * @param string|null $filter
+     * @return array
+     */
+    private function buildPHPUnitCommand(?string $classPath, ?string $filter): array
+    {
+        $command = [base_path('vendor/bin/phpunit')];
+
+        // Add specific test file if provided
+        if ($classPath) {
+            $command[] = base_path($classPath);
+        }
+
+        if ($filter) {
+            $command[] = '--filter';
+            $command[] = $filter;
+        }
+
+        $command[] = '--testdox';
+        $command[] = '--disallow-test-output';
+        $command[] = '--colors=never';
+
+        return $command;
+    }
+
+    /**
+     * Format and display output in real-time
+     *
+     * @param string $buffer
+     * @return void
+     */
+    private function formatAndDisplayOutput(string $buffer): void
+    {
+        static $inFailureDetails = false;
+
+        $lines = explode("\n", $buffer);
+
+        foreach ($lines as $line) {
+            if (empty(trim($line))) {
+                continue;
+            }
+
+            // Skip PHPUnit header lines
+            if (
+                str_starts_with($line, 'PHPUnit') ||
+                str_starts_with($line, 'Runtime:') ||
+                str_starts_with($line, 'Configuration:') ||
+                preg_match('/^[\.FESIRw]+\s+\d+\s*\/\s*\d+/', $line) ||
+                str_starts_with($line, 'Time:')
+            ) {
+                continue;
+            }
+
+            // Detect test class headers - format: "ClassName (Namespace)"
+            if (preg_match('/^([A-Z][A-Za-z0-9 ]+)\s+\(([^)]+)\)$/', trim($line), $matches)) {
+                $this->newLine();
+                $this->line("✓ {$matches[2]}", 'fg=white;options=bold');
+                $this->line(str_repeat('─', 60), 'fg=gray');
+                $inFailureDetails = false;
+                continue;
+            }
+
+            // Detect passed tests
+            if (preg_match('/^\s*[✔✓√]\s+(.+)$/', $line, $matches)) {
+                $this->line("  ✓ {$matches[1]}", 'fg=green');
+                $inFailureDetails = false;
+                continue;
+            }
+
+            // Detect failed tests
+            if (preg_match('/^\s*[✘✗✖×xX]\s+(.+)$/u', $line, $matches)) {
+                $this->line("  ✗ {$matches[1]}", 'fg=red;options=bold');
+                $inFailureDetails = true;
+                continue;
+            }
+
+            // Detect skipped/incomplete tests
+            if (preg_match('/^\s*[→➜↩➔]\s+(.+)$/', $line, $matches)) {
+                $this->line("  ⊘ {$matches[1]}", 'fg=yellow');
+                $inFailureDetails = false;
+                continue;
+            }
+
+            // Show failure details
+            if ($inFailureDetails && preg_match('/^\s*[│├┐┴┤┼┘└┌┬](.*)$/', $line, $matches)) {
+                $detail = trim($matches[1]);
+
+                // Remove any leading box-drawing characters from the detail
+                $detail = preg_replace('/^[│├┐┴┤┼┘└┌┬\s]+/', '', $detail);
+                $detail = trim($detail);
+
+                if (!empty($detail)) {
+                    // Check if it's a failure message
+                    if (str_contains($detail, 'Failed asserting')) {
+                        $this->line("    × {$detail}", 'fg=red');
+                    }
+                    // Check if it's a file path
+                    elseif (preg_match('/^(\/[^\s]+\.php):(\d+)$/', $detail, $pathMatches)) {
+                        $this->line("    📍 {$pathMatches[1]}:{$pathMatches[2]}", 'fg=yellow');
+                    }
+                    // Show other non-empty details
+                    elseif (strlen($detail) > 1) {
+                        $this->line("    ✔ {$detail}", 'fg=gray');
+                    }
+                }
+                continue;
+            }
+
+            // Stop processing failure details when we hit summary section
+            if (str_contains($line, 'FAILURES!') || str_contains($line, 'ERRORS!') || str_contains($line, 'OK (')) {
+                $inFailureDetails = false;
+            }
+        }
+    }
+
+    /**
+     * Display an eye-catching banner
+     *
+     * @return void
+     */
+    private function displayBanner(): void
+    {
+        $this->newLine();
+        $this->line('╔══════════════════════════════════════════════════════════════╗', 'fg=cyan;options=bold');
+        $this->line('║                                                              ║', 'fg=cyan;options=bold');
+        $this->line('║              🧪  DOPPAR UNIT TEST RUNNER  🧪                 ║', 'fg=cyan;options=bold');
+        $this->line('║                                                              ║', 'fg=cyan;options=bold');
+        $this->line('╚══════════════════════════════════════════════════════════════╝', 'fg=cyan;options=bold');
+        $this->newLine();
+    }
+
+    /**
+     * Display the final summary
+     *
+     * @param string $output
+     * @param float $duration
+     * @param int $exitCode
+     * @return void
+     */
+    private function displaySummary(string $output, float $duration, int $exitCode): void
+    {
+        $this->newLine();
+        $this->line(str_repeat('═', 60), 'fg=cyan;options=bold');
+        $this->newLine();
+
+        // Summary header
+        $this->line('📊 TEST SUMMARY', 'fg=cyan;options=bold');
+        $this->line(str_repeat('─', 60), 'fg=cyan');
+        $this->newLine();
+
+        // Parse summary from PHPUnit output
+        $totalTests = 0;
+        $passedTests = 0;
+        $failedTests = 0;
+        $skippedTests = 0;
+        $assertions = 0;
+
+        // Parse "OK (X tests, Y assertions)" or "FAILURES! Tests: X, Assertions: Y, Failures: Z"
+        if (preg_match('/OK \((\d+) test[s]?, (\d+) assertion[s]?\)/', $output, $matches)) {
+            $totalTests = (int) $matches[1];
+            $passedTests = (int) $matches[1];
+            $assertions = (int) $matches[2];
+        } elseif (preg_match('/Tests:\s*(\d+),\s*Assertions:\s*(\d+)(?:,\s*Failures:\s*(\d+))?(?:,\s*Errors:\s*(\d+))?(?:,\s*Skipped:\s*(\d+))?/', $output, $matches)) {
+            $totalTests = (int) $matches[1];
+            $assertions = (int) $matches[2];
+            $failedTests = isset($matches[3]) ? (int) $matches[3] : 0;
+            $failedTests += isset($matches[4]) ? (int) $matches[4] : 0; // Add errors to failures
+            $skippedTests = isset($matches[5]) ? (int) $matches[5] : 0;
+            $passedTests = $totalTests - $failedTests - $skippedTests;
+        }
+
+        // Display stats
+        $this->line("  Total Tests:    {$totalTests}", 'fg=white;options=bold');
+        $this->line("  ✓ Passed:       {$passedTests}", 'fg=green;options=bold');
+
+        if ($failedTests > 0) {
+            $this->line("  ✗ Failed:       {$failedTests}", 'fg=red;options=bold');
+        }
+
+        if ($skippedTests > 0) {
+            $this->line("  ⊘ Skipped:      {$skippedTests}", 'fg=yellow');
+        }
+
+        if ($assertions > 0) {
+            $this->line("  📝 Assertions:  {$assertions}", 'fg=cyan');
+        }
+
+        $this->newLine();
+
+        // Success rate
+        $successRate = $totalTests > 0
+            ? round(($passedTests / $totalTests) * 100, 2)
+            : 0;
+
+        $this->line("  Success Rate:   {$successRate}%", $successRate === 100.0 ? 'fg=green;options=bold' : 'fg=yellow');
+        $this->line("  ⏱ Duration:      {$duration}s", 'fg=gray');
+
+        $this->newLine();
+
+        // Final result
+        $this->line(str_repeat('═', 60), 'fg=cyan;options=bold');
+        $this->newLine();
+
+        if ($exitCode === 0 && $totalTests > 0) {
+            $this->line('🎉 ALL TESTS PASSED! 🎉', 'fg=green;options=bold');
+            $assertionText = $assertions > 0 ? " with {$assertions} assertion(s)" : "";
+            $this->newLine();
+            $this->displaySuccess("Test suite completed successfully{$assertionText}!");
+        } else if ($totalTests === 0) {
+            $this->displayWarning('No tests were executed');
+        } else {
+            $this->line('❌ SOME TESTS FAILED', 'fg=red;options=bold');
+            $this->newLine();
+            $this->displayError("Test suite completed with {$failedTests} failure(s)");
+        }
+
+        $this->newLine();
+    }
+}


### PR DESCRIPTION
Avaiable commands
```bash
php pool unit:test # basic test ouput
php pool unit:test # details test output

# specific class test output with details
php pool unit:test --details --class=tests/Unit/Product/ProductTest.php

# specific class test output with details and filter by test class specific function
php pool unit:test --details --class=tests/Unit/Product/ProductTest.php --filter=testThatBooleanTrueIsTrue
```

### Output with success test
<img width="1004" height="761" alt="image" src="https://github.com/user-attachments/assets/93feeb62-530f-4272-8d9d-fed2fa64ebe5" />

### Output with faild test
<img width="1007" height="771" alt="image" src="https://github.com/user-attachments/assets/7bfbb117-36e6-4717-bbf2-564b275bed95" />
