### PR TITLE
Fix file path in CLI output

### DIFF
--- a/src/Phaseolies/Console/Commands/MakeAuthorizerCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeAuthorizerCommand.php
@@ -52,12 +52,8 @@ class MakeAuthorizerCommand extends Command
             file_put_contents($filePath, $content);
 
             $this->displaySuccess('Authorizer created successfully');
-            $this->line('<fg=yellow>🛡️ File:</> <fg=white>' . str_replace(base_path(), '', $filePath) . '</>');
+            $this->line('<fg=yellow>🛡️  File:</> <fg=white>' . str_replace(base_path('/'), '', $filePath) . '</>');
             $this->newLine();
-            $this->line('<fg=yellow>📌 Class:</> <fg=white>' . $className . '</>');
-            if ($model) {
-                $this->line('<fg=yellow>🏷️ Model:</> <fg=white>' . $model . '</>');
-            }
 
             return Command::SUCCESS;
         });
@@ -91,7 +87,7 @@ EOT;
         $modelType = 'App\\Models\\' . $model;
 
         return <<<EOT
-    /**
+/**
      * Determine whether the user can view any models.
      *
      * @param \App\Models\User \${$userVar}

--- a/src/Phaseolies/Console/Commands/MakeConsoleCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeConsoleCommand.php
@@ -49,7 +49,7 @@ class MakeConsoleCommand extends Command
             file_put_contents($filePath, $content);
 
             $this->displaySuccess('Command created successfully');
-            $this->line('<fg=yellow>📁 File:</> <fg=white>' . str_replace(base_path(), '', $filePath) . '</>');
+            $this->line('<fg=yellow>📁 File:</> <fg=white>' . str_replace(base_path('/'), '', $filePath) . '</>');
             $this->newLine();
             $this->line('<fg=yellow>📌 Command Name:</> <fg=white>doppar:' . $this->convertToKebabCase($className) . '</>');
 

--- a/src/Phaseolies/Console/Commands/MakeControllerCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeControllerCommand.php
@@ -242,7 +242,7 @@ class MakeControllerCommand extends Command
      */
     protected function outputFilePath(string $label, string $path): void
     {
-        $this->line('<fg=yellow>' . $label . ':</> <fg=white>' . str_replace(base_path(), '', $path) . '</>');
+        $this->line('<fg=yellow>' . $label . ':</> <fg=white>' . str_replace(base_path('/'), '', $path) . '</>');
     }
 
     /**

--- a/src/Phaseolies/Console/Commands/MakeHookCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeHookCommand.php
@@ -52,7 +52,7 @@ class MakeHookCommand extends Command
             file_put_contents($filePath, $content);
 
             $this->displaySuccess('Hook created successfully');
-            $this->line('<fg=yellow>📁 File:</> <fg=white>' . str_replace(base_path(), '', $filePath) . '</>');
+            $this->line('<fg=yellow>📁 File:</> <fg=white>' . str_replace(base_path('/'), '', $filePath) . '</>');
             $this->newLine();
             $this->line('<fg=yellow>📌 Hook Class:</> <fg=white>' . $className . '</>');
 

--- a/src/Phaseolies/Console/Commands/MakeMailCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeMailCommand.php
@@ -58,7 +58,7 @@ class MakeMailCommand extends Command
             file_put_contents($filePath, $content);
 
             $this->displaySuccess('Mailable created successfully');
-            $this->line('<fg=yellow>📧 File:</> <fg=white>' . str_replace(base_path(), '', $filePath) . '</>');
+            $this->line('<fg=yellow>📧 File:</> <fg=white>' . str_replace(base_path('/'), '', $filePath) . '</>');
             $this->newLine();
             $this->line('<fg=yellow>✉️  Class:</> <fg=white>' . $className . '</>');
 

--- a/src/Phaseolies/Console/Commands/MakeMiddlewareCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeMiddlewareCommand.php
@@ -52,7 +52,7 @@ class MakeMiddlewareCommand extends Command
             file_put_contents($filePath, $content);
 
             $this->displaySuccess('Middleware created successfully');
-            $this->line('<fg=yellow>🛡️  File:</> <fg=white>' . str_replace(base_path(), '', $filePath) . '</>');
+            $this->line('<fg=yellow>🛡️  File:</> <fg=white>' . str_replace(base_path('/'), '', $filePath) . '</>');
             $this->newLine();
             $this->line('<fg=yellow>🔒 Class:</> <fg=white>' . $className . '</>');
 

--- a/src/Phaseolies/Console/Commands/MakeModelCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeModelCommand.php
@@ -73,7 +73,7 @@ class MakeModelCommand extends Command
             file_put_contents($filePath, $content);
 
             $this->displaySuccess('Model created successfully');
-            $this->line('<fg=yellow>📦 File:</> <fg=white>' . str_replace(base_path(), '', $filePath) . '</>');
+            $this->line('<fg=yellow>📦 File:</> <fg=white>' . str_replace(base_path('/'), '', $filePath) . '</>');
             $this->newLine();
             $this->line('<fg=yellow>📌 Class:</> <fg=white>' . $className . '</>');
 
@@ -86,7 +86,7 @@ class MakeModelCommand extends Command
                 $this->newLine();
                 $this->line('<bg=blue;options=bold> MIGRATION </> Created migration:');
                 $this->newLine();
-                $this->line('<fg=white>' . str_replace(base_path(), '', $migrationFile) . '</>');
+                $this->line('<fg=white>' . str_replace(base_path('/'), '', $migrationFile) . '</>');
             }
 
             return Command::SUCCESS;

--- a/src/Phaseolies/Console/Commands/MakeProviderCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeProviderCommand.php
@@ -50,7 +50,7 @@ class MakeProviderCommand extends Command
             file_put_contents($filePath, $content);
 
             $this->displaySuccess('Provider created successfully');
-            $this->line('<fg=yellow>📦 File:</> <fg=white>' . str_replace(base_path(), '', $filePath) . '</>');
+            $this->line('<fg=yellow>📦 File:</> <fg=white>' . str_replace(base_path('/'), '', $filePath) . '</>');
             $this->newLine();
             $this->line('<fg=yellow>📌 Class:</> <fg=white>' . $name . '</>');
 

--- a/src/Phaseolies/Console/Commands/MakeRequestCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeRequestCommand.php
@@ -58,7 +58,7 @@ class MakeRequestCommand extends Command
             file_put_contents($filePath, $content);
 
             $this->displaySuccess('Request created successfully');
-            $this->line('<fg=yellow>📁 File:</> <fg=white>' . str_replace(base_path(), '', $filePath) . '</>');
+            $this->line('<fg=yellow>📁 File:</> <fg=white>' . str_replace(base_path('/'), '', $filePath) . '</>');
             $this->newLine();
             $this->line('<fg=yellow>📌 Class:</> <fg=white>' . $className . '</>');
 

--- a/src/Phaseolies/Console/Commands/Presenter/PresenterCommand.php
+++ b/src/Phaseolies/Console/Commands/Presenter/PresenterCommand.php
@@ -50,7 +50,7 @@ class PresenterCommand extends Command
             file_put_contents($filePath, $content);
 
             $this->displaySuccess('Presenters created successfully');
-            $this->line('<fg=yellow>📁 File:</> <fg=white>' . str_replace(base_path(), '', $filePath) . '</>');
+            $this->line('<fg=yellow>📁 File:</> <fg=white>' . str_replace(base_path('/'), '', $filePath) . '</>');
             $this->newLine();
 
             return Command::SUCCESS;


### PR DESCRIPTION
This PR fixes an issue where the file path shown in the CLI output after creating a service like controller, middleware etc was incorrect and not clickable.

Previous output
```php
 ❯ php pool make:controller PaymentController    

 SUCCESS  Controller created successfully

📁 File: /app/Http/Controllers/PaymentController.php

📌 Type: Standard controller

⏱ Time: 0.0025s (2515 μs)
```

Current output
```
 ❯ php pool make:controller PaymentController    

 SUCCESS  Controller created successfully

📁 File: app/Http/Controllers/PaymentController.php

📌 Type: Standard controller

⏱ Time: 0.0025s (2515 μs)
```

Improves developer experience by ensuring generated file paths are accurate and clickable.