### PR TITLE
New Entity ORM repair() method

### DIFF
--- a/src/Phaseolies/Database/Entity/Builder.php
+++ b/src/Phaseolies/Database/Entity/Builder.php
@@ -21,7 +21,6 @@ use Phaseolies\Utilities\Casts\CastToDate;
 use Phaseolies\Support\Facades\URL;
 use Phaseolies\Support\Contracts\Encryptable;
 use Phaseolies\Support\Collection;
-
 use Phaseolies\Database\Entity\Model;
 
 class Builder
@@ -2962,6 +2961,29 @@ class Builder
         };
 
         return $this->where($searchQuery);
+    }
+
+    /**
+     * Get records and fix/normalize data
+     *
+     * @param callable $fixer
+     * @param bool $saveChanges
+     * @return Collection
+     */
+    public function repair(callable $fixer, bool $saveChanges = false): Collection
+    {
+        $results = $this->get();
+
+        foreach ($results as $item) {
+            $original = $item->getAttributes();
+            $fixer($item);
+
+            if ($saveChanges && $item->getAttributes() !== $original) {
+                $item->save();
+            }
+        }
+
+        return $results;
     }
 
     /**

--- a/tests/Model/Query/EntityModelQueryTest.php
+++ b/tests/Model/Query/EntityModelQueryTest.php
@@ -15,6 +15,7 @@ use Phaseolies\Database\Database;
 use Phaseolies\DI\Container;
 use PHPUnit\Framework\TestCase;
 use PDO;
+use Tests\Support\Model\MockProduct;
 
 class EntityModelQueryTest extends TestCase
 {
@@ -97,7 +98,20 @@ class EntityModelQueryTest extends TestCase
             )
         ");
 
+        $this->pdo->exec("
+            CREATE TABLE product (
+                price INTEGER
+            )
+        ");
+
         // Insert test data
+        $this->pdo->exec("
+            INSERT INTO product (price) VALUES
+            (875),
+            (435),
+            (999)
+        ");
+
         $this->pdo->exec("
             INSERT INTO users (name, email, age, status, created_at) VALUES
             ('John Doe', 'john@example.com', 30, 'active', '2024-01-01 10:00:00'),
@@ -2604,5 +2618,47 @@ class EntityModelQueryTest extends TestCase
         $this->assertEquals([4], array_keys($changes['attached']));
         $this->assertEquals([2], array_keys($changes['detached']));
         $this->assertEquals([], $changes['updated']);
+    }
+
+    public function testRepairMethodFetchingRecords()
+    {
+        $products = MockProduct::repair(function ($product) {
+            $product->price = preg_replace('/[^0-9]/', '', $product->price);
+        }, false);
+
+        $this->assertEquals(3, count($products));
+    }
+
+    public function testRepairPreviewsPriceCleanupWithoutPersistingChanges()
+    {
+        $products = MockProduct::repair(function ($product) {
+            $product->price = preg_replace('/[^0-5]/', '', $product->price);
+        }, false);
+
+        foreach ($products[0] as $product) {
+            $this->assertTrue(str_contains($product->price, 5));
+        }
+
+        // Cause product 3 id price is = 999
+        foreach ($products[2] as $product) {
+            $this->assertNull($product->price);
+        }
+    }
+
+    public function testRepairMethodSaveChanges()
+    {
+        $products = MockProduct::query()
+            ->repair(function ($product) {
+                $product->price = preg_replace('/[^0-9]/', '', $product->price);
+            }, true);
+
+        foreach ($products[0] as $product) {
+            $this->assertTrue(str_contains($product->price, 5));
+        }
+
+        // Cause product 3 id price is = 999
+        foreach ($products[2] as $product) {
+            $this->assertNull($product->price);
+        }
     }
 }

--- a/tests/Support/Model/MockProduct.php
+++ b/tests/Support/Model/MockProduct.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Support\Model;
+
+use Phaseolies\Database\Entity\Model;
+
+class MockProduct extends Model
+{
+    protected $table = 'product';
+
+    protected $primaryKey = 'id';
+
+    protected $connection = 'default';
+
+    protected $timeStamps = false;
+
+    protected $creatable = ['price'];
+}


### PR DESCRIPTION
This PR introduces a new `repair()` method to the Entity ORM query builder, designed to automatically fix, normalize, and improve data quality at scale.

The method allows developers to:
1. Apply a normalization or repair callback to retrieved entities
2. Optionally, persist only the records that were actually modified
3. Preview changes without writing to the database

This provides a clean, expressive way to handle common data quality tasks such as formatting, normalization, and cleanup.

### API Overview
```php
/**
 * Get records and fix/normalize data
 *
 * @param callable $fixer
 * @param bool $saveChanges
 * @return Collection
 */
public function repair(callable $fixer, bool $saveChanges = false): Collection
```

### Example: Fix & Persist Changes
```php
User::query()
    ->where('role', 'admin')
    ->repair(function ($user) {
        $user->email = strtolower($user->email);
        $user->name  = ucwords($user->name);
    }, true); // true = save changes
```

Behavior:
1. Retrieves all matching users
2. Normalizes email and name
3. Saves only users whose attributes actually changed

### Example: Preview Changes (No Save)
```php
$users = User::query()
    ->repair(function ($user) {
        $user->phone = preg_replace('/[^0-9]/', '', $user->phone);
    }, false);
```

Behavior:
1. Returns a collection of repaired entities
2. No database writes occur
3. Useful for previews, audits, and dry runs

### Use Cases
Data normalization after imports
One-time cleanup scripts
