### PR TITLE
New Entity ORM Method groupByCallback

### DIFF
--- a/src/Phaseolies/Database/Entity/Builder.php
+++ b/src/Phaseolies/Database/Entity/Builder.php
@@ -2987,6 +2987,28 @@ class Builder
     }
 
     /**
+     * Get records grouped by a callback result
+     *
+     * @param callable $callback
+     * @return array
+     */
+    public function groupByCallback(callable $callback): array
+    {
+        $results = $this->get();
+        $grouped = [];
+
+        foreach ($results as $item) {
+            $key = $callback($item);
+            if (!isset($grouped[$key])) {
+                $grouped[$key] = [];
+            }
+            $grouped[$key][] = $item;
+        }
+
+        return $grouped;
+    }
+
+    /**
      * Convert camelCase to snake_case for column names
      *
      * @param string $input

--- a/tests/Model/Query/EntityModelQueryTest.php
+++ b/tests/Model/Query/EntityModelQueryTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Model\Query;
 
+use App\Models\Product;
 use Tests\Support\Model\MockUser;
 use Tests\Support\Model\MockTag;
 use Tests\Support\Model\MockPost;
@@ -2659,6 +2660,35 @@ class EntityModelQueryTest extends TestCase
         // Cause product 3 id price is = 999
         foreach ($products[2] as $product) {
             $this->assertNull($product->price);
+        }
+    }
+
+    public function testGroupByCallback()
+    {
+        $products = MockProduct::groupByCallback(function ($product) {
+            if ($product->price < 500) return 'lower_than_500';
+            if ($product->price > 500) return 'bigger_than_500';
+            return 'default';
+        });
+
+        $this->assertCount(1, $products['lower_than_500']);
+
+        foreach ($products['lower_than_500'] as $key => $product) {
+            $this->assertEquals(
+                435,
+                $product->price,
+                "Expected product ID {$product->id} to have price 435"
+            );
+        }
+
+        $this->assertCount(2, $products['bigger_than_500']);
+
+        foreach ($products['bigger_than_500'] as $product) {
+            $this->assertGreaterThan(
+                500,
+                $product->price,
+                "Expected product ID {$product->id} to have price > 500"
+            );
         }
     }
 }


### PR DESCRIPTION
This PR introduces a new `groupByCallback()` method to the Entity ORM query builder.
The method enables grouping records using custom, application-level logic, rather than being limited to database columns.

This is especially useful when grouping depends on computed values, ranges, or domain-specific rules that cannot be expressed directly in SQL.

## Example: Group Users by Age Range
```php
$groups = User::query()
  ->groupByCallback(function ($user) {
      if ($user->age < 18) return 'minor';
      if ($user->age < 65) return 'adult';
      return 'senior';
  });
```

Result structure:
```php
[
    'minor'  => Collection,
    'adult'  => Collection,
    'senior' => Collection,
]
```