### PR TITLE
New Entity ORM partition method

### DIFF
--- a/src/Phaseolies/Database/Entity/Builder.php
+++ b/src/Phaseolies/Database/Entity/Builder.php
@@ -3009,6 +3009,32 @@ class Builder
     }
 
     /**
+     * Partition results into two groups based on a callback
+     *
+     * @param callable $callback
+     * @return array [matched, unmatched]
+     */
+    public function partition(callable $callback): array
+    {
+        $results = $this->get();
+        $matched = [];
+        $unmatched = [];
+
+        foreach ($results as $item) {
+            if ($callback($item)) {
+                $matched[] = $item;
+            } else {
+                $unmatched[] = $item;
+            }
+        }
+
+        return [
+            new Collection($this->modelClass, $matched),
+            new Collection($this->modelClass, $unmatched)
+        ];
+    }
+
+    /**
      * Convert camelCase to snake_case for column names
      *
      * @param string $input

--- a/src/Phaseolies/Support/Collection.php
+++ b/src/Phaseolies/Support/Collection.php
@@ -8,8 +8,9 @@ use Phaseolies\Database\Entity\Model;
 use IteratorAggregate;
 use ArrayIterator;
 use ArrayAccess;
+use JsonSerializable;
 
-class Collection extends RamseyCollection implements IteratorAggregate, ArrayAccess
+class Collection extends RamseyCollection implements IteratorAggregate, ArrayAccess, JsonSerializable
 {
     /**
      * @var array
@@ -148,12 +149,22 @@ class Collection extends RamseyCollection implements IteratorAggregate, ArrayAcc
 
     /**
      * Required for looping data
-     * 
+     *
      * @return Traversable
      */
     public function getIterator(): Traversable
     {
         return new ArrayIterator($this->data);
+    }
+
+    /**
+     * Specify data which should be serialized to JSON
+     *
+     * @return array
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
     }
 
     /**

--- a/tests/Model/Query/EntityModelQueryTest.php
+++ b/tests/Model/Query/EntityModelQueryTest.php
@@ -2691,4 +2691,24 @@ class EntityModelQueryTest extends TestCase
             );
         }
     }
+
+    public function testPartition()
+    {
+        [$higher, $lower] = MockProduct::query()
+            ->partition(fn($product) => $product->price > 500);
+
+        // We have 2 products greater than 500
+        $this->assertCount(2, $higher);
+
+        // We have 1 products lower than 500
+        $this->assertCount(1, $lower);
+
+        foreach ($higher as $product) {
+            $this->assertGreaterThan(
+                500,
+                $product->price,
+                "Expected product ID {$product->id} to have price > 500"
+            );
+        }
+    }
 }


### PR DESCRIPTION
It returns two collections, matched vs unmatched

Example query:
```php
[$admin, $editor] = User::query()
    ->partition(fn($user) => $user->role === 'admin');

return $admin; // Collection of all admin users
```