### PR TITLE
remove array return and add collection return for groupByCallback

### DIFF
--- a/src/Phaseolies/Database/Entity/Builder.php
+++ b/src/Phaseolies/Database/Entity/Builder.php
@@ -3005,7 +3005,10 @@ class Builder
             $grouped[$key][] = $item;
         }
 
-        return $grouped;
+        return array_map(
+            fn($items) => new Collection($this->modelClass, $items),
+            $grouped
+        );
     }
 
     /**


### PR DESCRIPTION
Previously, we just returned an array; now we return it as a collection
```php
return array_map(
            fn($items) => new Collection($this->modelClass, $items),
            $grouped
        );
```
