### PR TITLE
New pipeline() entity orm method

### DIFF
--- a/src/Phaseolies/Database/Entity/Builder.php
+++ b/src/Phaseolies/Database/Entity/Builder.php
@@ -3038,6 +3038,23 @@ class Builder
     }
 
     /**
+     * Get records and apply transformations in pipeline
+     *
+     * @param array $transformers
+     * @return Collection
+     */
+    public function pipeline(array $transformers): Collection
+    {
+        $results = $this->get();
+
+        foreach ($transformers as $transformer) {
+            $results = $transformer($results);
+        }
+
+        return $results;
+    }
+
+    /**
      * Convert camelCase to snake_case for column names
      *
      * @param string $input

--- a/src/Phaseolies/Installer.php
+++ b/src/Phaseolies/Installer.php
@@ -10,13 +10,11 @@ class Installer
     {
         $io = $event->getIO();
 
-        $io->write("<info>🚀 Setting up doppar skeleton application...</info>");
+        $io->write("<info>🎉 Setting up doppar skeleton application...</info>");
 
         if (!file_exists('.env')) {
             copy('.env.example', '.env');
             $io->write("<comment>  ✓ Created .env file from .env.example</comment>");
         }
-
-        $io->write("\n<info>🎉 Doppar project setup complete</info>");
     }
 }

--- a/tests/Model/Query/EntityModelQueryTest.php
+++ b/tests/Model/Query/EntityModelQueryTest.php
@@ -2711,4 +2711,16 @@ class EntityModelQueryTest extends TestCase
             );
         }
     }
+
+    public function testPipeline()
+    {
+        // We have only 1 product price greater than 900
+        $processed = MockProduct::query()
+            ->pipeline([
+                fn($col) => $col->filter(fn($o) => $o->price > 900),
+                fn($col) => $col->take(10)
+            ]);
+
+        $this->assertCount(1, $processed);
+    }
 }


### PR DESCRIPTION
The method allows developers to apply a series of collection transformations to query results using a clean, composable pipeline pattern.

Example: Processing Completed Orders
```php
$processed = Order::query()
    ->where('status', 'completed')
    ->pipeline([
        fn ($col) => $col->filter(fn ($o) => $o->total > 100),
        fn ($col) => $col->take(10),
    ]);
```