### PR TITLE
Add 5 new Entity ORM methods for improved query ergonomics

### DIFF
--- a/src/Phaseolies/Database/Entity/Builder.php
+++ b/src/Phaseolies/Database/Entity/Builder.php
@@ -3055,6 +3055,154 @@ class Builder
     }
 
     /**
+     * Sample random records using reservoir sampling (memory efficient)
+     *
+     * @param int $count
+     * @return Collection
+     */
+    public function sample(int $count): Collection
+    {
+        $reservoir = [];
+        $index = 0;
+
+        $this->cursor(function ($item) use (&$reservoir, &$index, $count) {
+            if ($index < $count) {
+                $reservoir[] = $item;
+            } else {
+                $j = mt_rand(0, $index);
+                if ($j < $count) {
+                    $reservoir[$j] = $item;
+                }
+            }
+            $index++;
+        });
+
+        return new Collection($this->modelClass, $reservoir);
+    }
+
+    /**
+     * Execute multiple queries in parallel using promises
+     *
+     * @param array $queries
+     * @return array
+     */
+    public function parallel(array $queries): array
+    {
+        $fibers = [];
+        $results = [];
+
+        foreach ($queries as $key => $queryCallback) {
+            $query = clone $this;
+            $queryCallback($query);
+
+            $fibers[$key] = new \Fiber(function () use ($query) {
+                return $query->get();
+            });
+
+            $fibers[$key]->start();
+        }
+
+        foreach ($fibers as $key => $fiber) {
+            if (!$fiber->isTerminated()) {
+                $results[$key] = $fiber->resume();
+            } else {
+                $results[$key] = $fiber->getReturn();
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Get records with validation errors
+     *
+     * @param array $rules
+     * @return array [valid, invalid]
+     */
+    public function validate(array $rules): array
+    {
+        $results = $this->get();
+        $valid = [];
+        $invalid = [];
+
+        foreach ($results as $item) {
+            $errors = [];
+
+            foreach ($rules as $field => $rule) {
+                $value = $item->$field ?? null;
+
+                if (is_callable($rule)) {
+                    if (!$rule($value, $item)) {
+                        $errors[$field] = "Validation failed for {$field}";
+                    }
+                } elseif ($rule === 'required' && empty($value)) {
+                    $errors[$field] = "{$field} is required";
+                }
+            }
+
+            if (empty($errors)) {
+                $valid[] = $item;
+            } else {
+                $item->validation_errors = $errors;
+                $invalid[] = $item;
+            }
+        }
+
+        return [
+            'valid' => new Collection($this->modelClass, $valid),
+            'invalid' => new Collection($this->modelClass, $invalid)
+        ];
+    }
+
+    /**
+     * Get records and apply side effects without modifying them
+     *
+     * @param callable $callback
+     * @return Collection
+     */
+    public function tap(callable $callback): Collection
+    {
+        $results = $this->get();
+
+        $callback($results);
+
+        return $results;
+    }
+
+    /**
+     * Get records with their age/duration since a timestamp
+     *
+     * @param string $timestampColumn
+     * @param string $unit (seconds, minutes, hours, days)
+     * @return Collection
+     */
+    public function withAge(string $timestampColumn, string $unit = 'days'): Collection
+    {
+        $results = $this->get();
+        $now = time();
+
+        $divisors = [
+            'seconds' => 1,
+            'minutes' => 60,
+            'hours' => 3600,
+            'days' => 86400,
+            'weeks' => 604800,
+            'months' => 2592000,
+            'years' => 31536000
+        ];
+
+        $divisor = $divisors[$unit] ?? 86400;
+
+        foreach ($results as $item) {
+            $timestamp = strtotime($item->$timestampColumn);
+            $item->age = ($now - $timestamp) / $divisor;
+            $item->age_unit = $unit;
+        }
+
+        return $results;
+    }
+
+    /**
      * Convert camelCase to snake_case for column names
      *
      * @param string $input

--- a/tests/Model/Query/EntityModelQueryTest.php
+++ b/tests/Model/Query/EntityModelQueryTest.php
@@ -2723,4 +2723,51 @@ class EntityModelQueryTest extends TestCase
 
         $this->assertCount(1, $processed);
     }
+
+    public function testSample()
+    {
+        $products = MockProduct::sample(3);
+
+        $this->assertCount(3, $products);
+    }
+
+    public function testParallel()
+    {
+        // We have only 1 product price greater than 900
+        $processed = MockProduct::parallel([
+            'bigger' => fn($q) => $q->where('price', '>', 900),
+            'lower'  => fn($q) => $q->where('price', '<', 500),
+        ]);
+
+        // Should get only 1
+        $this->assertCount(1, $processed['bigger']);
+
+        // Should get only 1
+        $this->assertCount(1, $processed['lower']);
+    }
+
+    public function testValidate()
+    {
+        ['valid' => $valid, 'invalid' => $invalid] = MockUser::validate([
+            'email' => fn($v) => filter_var($v, FILTER_VALIDATE_EMAIL),
+            'name'  => 'required',
+        ]);
+
+        // All the users have name and valid email
+        $this->assertCount(0, $invalid);
+    }
+
+    public function testWithAge(): void
+    {
+        $users = MockUser::withAge('created_at', 'hours');
+
+        foreach ($users as $user) {
+            // All the users created in 2024-01-01
+            $this->assertTrue($user->age > 24);
+            $this->assertTrue($user->age > 48);
+            $this->assertTrue($user->age > 72);
+            $this->assertTrue($user->age > 150);
+            $this->assertFalse($user->age > 10000000000);
+        }
+    }
 }


### PR DESCRIPTION
This PR introduces five new ORM helper methods to improve query readability, reduce boilerplate, and support common data-access patterns

New Methods Added
- validate() - Allows inline validation of model attributes directly from a query, returning valid and invalid records in a structured way.
- sample() - Fetches a random subset of records from a query, useful for testing, previews, or analytics sampling.
- withAge() - Dynamically calculates the age of a record based on a timestamp column and exposes it as a computed property.
- tap() - Enables side-effects (logging, metrics, debugging) on query results without modifying the returned collection.
- parallel() - Executes multiple scoped queries in parallel from a single model, returning grouped results for cleaner and more expressive data access.

### validate()
Validate model attributes directly from a query and separate valid and invalid records.
```php
['valid' => $valid, 'invalid' => $invalid] = User::validate([
    'email' => fn ($v) => filter_var($v, FILTER_VALIDATE_EMAIL),
    'name'  => 'required',
]);

return $invalid
```
### sample()
Retrieve a random subset of records from a model.
```php
$sample = User::sample(10); // usefull for big data
```

### withAge()
Compute the age of records dynamically based on a timestamp column.
```php
$tickets = Ticket::query()
    ->where('status', 'open')
    ->withAge('created_at', 'hours');

foreach ($tickets as $ticket) {
    if ($ticket->age > 24) {
        echo "Ticket #{$ticket->id} is {$ticket->age} hours old";
    }
}
```

### tap()
Execute side effects (logging, debugging, metrics) without modifying the query result.
```php
$users = User::query()
    ->where('status', 1)
    ->tap(function ($collection) {
        info("Found {$collection->count()} active users");
    });
```

### parallel()
Run multiple queries in parallel and return grouped results.
```php
$results = User::parallel([
    'admins' => fn ($q) => $q->where('role', 'admin'),
    'users'  => fn ($q) => $q->where('role', 'editor'),
]);
```
