### PR TITLE
Added new chunk() collection method

### DIFF
--- a/src/Phaseolies/Support/Collection.php
+++ b/src/Phaseolies/Support/Collection.php
@@ -716,4 +716,24 @@ class Collection extends RamseyCollection implements IteratorAggregate, ArrayAcc
     {
         return $this->model ?? null;
     }
+
+    /**
+     * Split collection into chunks of given size.
+     *
+     * @param int $size
+     * @return static
+     */
+    public function chunk(int $size): self
+    {
+        if ($size <= 0) {
+            throw new \InvalidArgumentException('Chunk size must be greater than 0');
+        }
+
+        $chunks = [];
+        foreach (array_chunk($this->data, $size, false) as $chunk) {
+            $chunks[] = $chunk;
+        }
+
+        return new static($this->model, $chunks);
+    }
 }

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -1249,4 +1249,41 @@ class CollectionTest extends TestCase
         $this->assertInstanceOf(Collection::class, $result);
         $this->assertCount(4, $result);
     }
+
+    public function testChunkDividesCollectionIntoChunks()
+    {
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, [1, 2, 3, 4, 5, 6, 7]);
+
+        $chunks = $collection->chunk(3);
+
+        $this->assertEquals([
+            [1, 2, 3],
+            [4, 5, 6],
+            [7]
+        ], $chunks->all());
+    }
+
+    public function testChunkWithExactDivision()
+    {
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, [1, 2, 3, 4, 5, 6]);
+
+        $chunks = $collection->chunk(2);
+
+        $this->assertEquals([
+            [1, 2],
+            [3, 4],
+            [5, 6]
+        ], $chunks->all());
+    }
+
+    public function testChunkWithInvalidSize()
+    {
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, [1, 2, 3]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $collection->chunk(0);
+    }
 }


### PR DESCRIPTION
Split a collection into smaller chunks of a specified size.

Example usages:
```php
// Process large dataset in batches
$users = User::all(); // 1000 users
$batches = $users->chunk(100);

foreach ($batches as $batch) {
    // Process 100 users at a time
}

// Create pages for display
$products = Product::all();
$pages = $products->chunk(20); // 20 items per page
```