### PR TITLE
New partition() collection method

### DIFF
--- a/src/Phaseolies/Support/Collection.php
+++ b/src/Phaseolies/Support/Collection.php
@@ -736,4 +736,29 @@ class Collection extends RamseyCollection implements IteratorAggregate, ArrayAcc
 
         return new static($this->model, $chunks);
     }
+
+    /**
+     * Split collection into two groups based on condition
+     *
+     * @param callable $callback
+     * @return array [passedCollection, failedCollection]
+     */
+    public function partition(callable $callback): array
+    {
+        $passed = [];
+        $failed = [];
+
+        foreach ($this->data as $key => $item) {
+            if ($callback($item, $key)) {
+                $passed[] = $item;
+            } else {
+                $failed[] = $item;
+            }
+        }
+
+        return [
+            new static($this->model, $passed),
+            new static($this->model, $failed)
+        ];
+    }
 }

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -1286,4 +1286,33 @@ class CollectionTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $collection->chunk(0);
     }
+
+
+    public function testPartitionDividesCollectionByCondition()
+    {
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, [1, 2, 3, 4, 5, 6]);
+
+        [$even, $odd] = $collection->partition(fn($num) => $num % 2 === 0);
+
+        $this->assertEquals([2, 4, 6], $even->all());
+        $this->assertEquals([1, 3, 5], $odd->all());
+    }
+
+    public function testPartitionWithObjects()
+    {
+        $users = [
+            ['name' => 'Alice', 'active' => true],
+            ['name' => 'Bob', 'active' => false],
+            ['name' => 'Charlie', 'active' => true],
+        ];
+
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, $users);
+
+        [$active, $inactive] = $collection->partition(fn($user) => $user['active']);
+
+        $this->assertCount(2, $active);
+        $this->assertCount(1, $inactive);
+    }
 }


### PR DESCRIPTION
Split the collection into two groups based on a condition. Returns [passed, failed]

Example usages:
```php
// Separate active and inactive users
[$active, $inactive] = $users->partition(fn($user) => $user['active']);

// Split passing and failing grades
[$passed, $failed] = $grades->partition(fn($grade) => $grade >= 60);

// Separate in-stock and out-of-stock items
[$inStock, $outOfStock] = $products->partition(
    fn($p) => $p['quantity'] > 0
);
```