### PR TITLE
tap() intersect() and diff() collection method

### DIFF
--- a/src/Phaseolies/Support/Collection.php
+++ b/src/Phaseolies/Support/Collection.php
@@ -801,4 +801,17 @@ class Collection extends RamseyCollection implements IteratorAggregate, ArrayAcc
 
         return new static($this->model, $result);
     }
+
+    /**
+     * Execute a callback over the collection without modifying it.
+     *
+     * @param callable $callback
+     * @return $this
+     */
+    public function tap(callable $callback): self
+    {
+        $callback($this);
+
+        return $this;
+    }
 }

--- a/src/Phaseolies/Support/Collection.php
+++ b/src/Phaseolies/Support/Collection.php
@@ -781,4 +781,24 @@ class Collection extends RamseyCollection implements IteratorAggregate, ArrayAcc
 
         return new static($this->model, $result);
     }
+
+    /**
+     * Get items present in both this collection and given items
+     *
+     * @param mixed $items
+     * @return static
+     */
+    public function intersect($items): self
+    {
+        $compare = $items instanceof self ? $items->all() : (array) $items;
+
+        $result = [];
+        foreach ($this->data as $item) {
+            if (in_array($item, $compare, true)) {
+                $result[] = $item;
+            }
+        }
+
+        return new static($this->model, $result);
+    }
 }

--- a/src/Phaseolies/Support/Collection.php
+++ b/src/Phaseolies/Support/Collection.php
@@ -761,4 +761,24 @@ class Collection extends RamseyCollection implements IteratorAggregate, ArrayAcc
             new static($this->model, $failed)
         ];
     }
+
+    /**
+     * Get items not present in the given items.
+     *
+     * @param mixed $items
+     * @return static
+     */
+    public function diff($items): self
+    {
+        $compare = $items instanceof self ? $items->all() : (array) $items;
+
+        $result = [];
+        foreach ($this->data as $item) {
+            if (!in_array($item, $compare, true)) {
+                $result[] = $item;
+            }
+        }
+
+        return new static($this->model, $result);
+    }
 }

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -1336,4 +1336,25 @@ class CollectionTest extends TestCase
 
         $this->assertEquals([1, 2], $diff->all());
     }
+
+    public function testIntersectReturnsCommonItems()
+    {
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection1 = new Collection($modelClass, [1, 2, 3, 4, 5]);
+        $collection2 = new Collection($modelClass, [3, 4, 5, 6, 7]);
+
+        $intersect = $collection1->intersect($collection2);
+
+        $this->assertEquals([3, 4, 5], $intersect->all());
+    }
+
+    public function testIntersectWithArray()
+    {
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, [1, 2, 3, 4, 5]);
+
+        $intersect = $collection->intersect([2, 3, 6]);
+
+        $this->assertEquals([2, 3], $intersect->all());
+    }
 }

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -1357,4 +1357,19 @@ class CollectionTest extends TestCase
 
         $this->assertEquals([2, 3], $intersect->all());
     }
+
+    public function testTapExecutesCallbackWithoutModifying()
+    {
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, [1, 2, 3]);
+
+        $tapped = null;
+        $result = $collection->tap(function ($col) use (&$tapped) {
+            $tapped = $col->count();
+        });
+
+        $this->assertEquals(3, $tapped);
+        $this->assertSame($collection, $result);
+        $this->assertEquals([1, 2, 3], $collection->all());
+    }
 }

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -1315,4 +1315,25 @@ class CollectionTest extends TestCase
         $this->assertCount(2, $active);
         $this->assertCount(1, $inactive);
     }
+
+    public function testDiffReturnsItemsNotInOtherCollection()
+    {
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection1 = new Collection($modelClass, [1, 2, 3, 4, 5]);
+        $collection2 = new Collection($modelClass, [3, 4, 5, 6, 7]);
+
+        $diff = $collection1->diff($collection2);
+
+        $this->assertEquals([1, 2], $diff->all());
+    }
+
+    public function testDiffWithArray()
+    {
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, [1, 2, 3, 4, 5]);
+
+        $diff = $collection->diff([3, 4, 5]);
+
+        $this->assertEquals([1, 2], $diff->all());
+    }
 }


### PR DESCRIPTION
### diff() example
Get items that exist in the first collection but not in the second
```php
// Find users who haven't made purchases
$allUsers = User::all();
$purchasers = Order::all()->pluck('user_id')->unique();
$nonPurchasers = $allUsers->pluck('id')->diff($purchasers);

// Find removed features
$oldFeatures = new Collection(Model::class, ['feature1', 'feature2', 'feature3']);
$newFeatures = new Collection(Model::class, ['feature2', 'feature4']);
$removedFeatures = $oldFeatures->diff($newFeatures); // ['feature1', 'feature3']
```

### intersect() example
Get items that exist in both collections
```php
// Find users in both groups
$premiumUsers = User::where('premium', true)->get()->pluck('id');
$activeUsers = User::where('last_login > ?', $date)->get()->pluck('id');
$premiumActiveUsers = $premiumUsers->intersect($activeUsers);

// Find common interests
$user1Interests = new Collection(Model::class, ['sports', 'music', 'art']);
$user2Interests = new Collection(Model::class, ['music', 'coding', 'art']);
$commonInterests = $user1Interests->intersect($user2Interests); // ['music', 'art']
```

### tap() example
Execute a callback without modifying the collection
```php
// Debug pipeline
$result = $users
    ->filter(fn($u) => $u['active'])
    ->tap(fn($col) => Log::info("Active users: " . $col->count()))
    ->map(fn($u) => $u['email'])
    ->tap(fn($col) => Cache::set('active_emails', $col->all()))
    ->all();

// Send notification without breaking the chain
$orders = Order::pending()
    ->tap(fn($orders) => "Send notification")
    ->update(['status' => 'processing']);
```
