### PR TITLE
Some collection method added

### DIFF
--- a/src/Phaseolies/Support/Collection.php
+++ b/src/Phaseolies/Support/Collection.php
@@ -814,4 +814,34 @@ class Collection extends RamseyCollection implements IteratorAggregate, ArrayAcc
 
         return $this;
     }
+
+    /**
+     * Pass the collection to a callback and return the result
+     *
+     * @param callable $callback
+     * @return mixed
+     */
+    public function pipe(callable $callback): mixed
+    {
+        return $callback($this);
+    }
+
+    /**
+     * Get the sum of values
+     *
+     * @param string|callable|null $callback
+     * @return int|float
+     */
+    public function sum($callback = null): int|float
+    {
+        if ($callback === null) {
+            return array_sum($this->data);
+        }
+
+        if (is_string($callback)) {
+            return $this->pluck($callback)->sum();
+        }
+
+        return $this->map($callback)->sum();
+    }
 }

--- a/src/Phaseolies/Support/Collection.php
+++ b/src/Phaseolies/Support/Collection.php
@@ -935,4 +935,28 @@ class Collection extends RamseyCollection implements IteratorAggregate, ArrayAcc
 
         return $this->map($callback)->max();
     }
+
+    /**
+     * Get a single item that matches the criteria, or throw an exception.
+     *
+     * @param callable|null $callback
+     * @return mixed
+     * @throws \RuntimeException
+     */
+    public function sole(?callable $callback = null): mixed
+    {
+        $filtered = $callback ? $this->filter($callback) : $this;
+
+        $count = $filtered->count();
+
+        if ($count === 0) {
+            throw new \RuntimeException('No items found matching the criteria');
+        }
+
+        if ($count > 1) {
+            throw new \RuntimeException("Multiple items found ({$count} items), expected exactly one");
+        }
+
+        return $filtered->first();
+    }
 }

--- a/src/Phaseolies/Support/Collection.php
+++ b/src/Phaseolies/Support/Collection.php
@@ -844,4 +844,32 @@ class Collection extends RamseyCollection implements IteratorAggregate, ArrayAcc
 
         return $this->map($callback)->sum();
     }
+
+    /**
+     * Find duplicate items in the collection.
+     *
+     * @param string|null $key
+     * @return static
+     */
+    public function duplicates(?string $key = null): self
+    {
+        $seen = [];
+        $duplicates = [];
+
+        foreach ($this->data as $item) {
+            $value = $key !== null
+                ? (is_array($item) ? ($item[$key] ?? null) : ($item->$key ?? null))
+                : $item;
+
+            $serialized = is_scalar($value) ? (string) $value : serialize($value);
+
+            if (isset($seen[$serialized])) {
+                $duplicates[] = $item;
+            } else {
+                $seen[$serialized] = true;
+            }
+        }
+
+        return new static($this->model, $duplicates);
+    }
 }

--- a/src/Phaseolies/Support/Collection.php
+++ b/src/Phaseolies/Support/Collection.php
@@ -827,25 +827,6 @@ class Collection extends RamseyCollection implements IteratorAggregate, ArrayAcc
     }
 
     /**
-     * Get the sum of values
-     *
-     * @param string|callable|null $callback
-     * @return int|float
-     */
-    public function sum($callback = null): int|float
-    {
-        if ($callback === null) {
-            return array_sum($this->data);
-        }
-
-        if (is_string($callback)) {
-            return $this->pluck($callback)->sum();
-        }
-
-        return $this->map($callback)->sum();
-    }
-
-    /**
      * Find duplicate items in the collection.
      *
      * @param string|null $key
@@ -871,5 +852,87 @@ class Collection extends RamseyCollection implements IteratorAggregate, ArrayAcc
         }
 
         return new static($this->model, $duplicates);
+    }
+
+    /**
+     * Get the sum of values
+     *
+     * @param string|callable|null $callback
+     * @return int|float
+     */
+    public function sum($callback = null): int|float
+    {
+        if ($callback === null) {
+            return array_sum($this->data);
+        }
+
+        if (is_string($callback)) {
+            return $this->pluck($callback)->sum();
+        }
+
+        return $this->map($callback)->sum();
+    }
+
+    /**
+     * Get the average (mean) value.
+     *
+     * @param string|callable|null $callback
+     * @return int|float|null
+     */
+    public function avg($callback = null): int|float|null
+    {
+        $count = $this->count();
+
+        if ($count === 0) {
+            return null;
+        }
+
+        return $this->sum($callback) / $count;
+    }
+
+    /**
+     * Get the minimum value.
+     *
+     * @param string|callable|null $callback
+     * @return mixed
+     */
+    public function min($callback = null): mixed
+    {
+        if ($this->isEmpty()) {
+            return null;
+        }
+
+        if ($callback === null) {
+            return min($this->data);
+        }
+
+        if (is_string($callback)) {
+            return $this->pluck($callback)->min();
+        }
+
+        return $this->map($callback)->min();
+    }
+
+    /**
+     * Get the maximum value.
+     *
+     * @param string|callable|null $callback
+     * @return mixed
+     */
+    public function max($callback = null): mixed
+    {
+        if ($this->isEmpty()) {
+            return null;
+        }
+
+        if ($callback === null) {
+            return max($this->data);
+        }
+
+        if (is_string($callback)) {
+            return $this->pluck($callback)->max();
+        }
+
+        return $this->map($callback)->max();
     }
 }

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -1372,4 +1372,24 @@ class CollectionTest extends TestCase
         $this->assertSame($collection, $result);
         $this->assertEquals([1, 2, 3], $collection->all());
     }
+
+    public function testPipePassesCollectionToCallback()
+    {
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, [1, 2, 3]);
+
+        $result = $collection->pipe(fn($col) => $col->sum());
+
+        $this->assertEquals(6, $result);
+    }
+
+    public function testPipeCanReturnAnything()
+    {
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, ['a', 'b', 'c']);
+
+        $result = $collection->pipe(fn($col) => implode(',', $col->all()));
+
+        $this->assertEquals('a,b,c', $result);
+    }
 }

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -1392,4 +1392,33 @@ class CollectionTest extends TestCase
 
         $this->assertEquals('a,b,c', $result);
     }
+
+    public function testDuplicatesFindsRepeatedValues()
+    {
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, [1, 2, 2, 3, 3, 3, 4]);
+
+        $duplicates = $collection->duplicates();
+
+        // Should return all duplicate occurrences except the first
+        $this->assertEquals([2, 3, 3], $duplicates->all());
+    }
+
+    public function testDuplicatesWithKey()
+    {
+        $users = [
+            ['id' => 1, 'email' => 'alice@example.com'],
+            ['id' => 2, 'email' => 'bob@example.com'],
+            ['id' => 3, 'email' => 'alice@example.com'],
+            ['id' => 4, 'email' => 'charlie@example.com'],
+        ];
+
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, $users);
+
+        $duplicates = $collection->duplicates('email');
+
+        $this->assertCount(1, $duplicates);
+        $this->assertEquals('alice@example.com', $duplicates->first()['email']);
+    }
 }

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -1532,4 +1532,48 @@ class CollectionTest extends TestCase
 
         $this->assertEquals(200, $collection->max('price'));
     }
+
+    public function testSoleReturnsOnlyItem()
+    {
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, [42]);
+
+        $this->assertEquals(42, $collection->sole());
+    }
+
+    public function testSoleWithCallback()
+    {
+        $users = [
+            ['id' => 1, 'name' => 'Alice', 'active' => true],
+            ['id' => 2, 'name' => 'Bob', 'active' => false],
+            ['id' => 3, 'name' => 'Charlie', 'active' => true],
+        ];
+
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, $users);
+
+        $inactive = $collection->sole(fn($user) => !$user['active']);
+
+        $this->assertEquals('Bob', $inactive['name']);
+    }
+
+    public function testSoleThrowsWhenEmpty()
+    {
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, []);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('No items found');
+        $collection->sole();
+    }
+
+    public function testSoleThrowsWhenMultiple()
+    {
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, [1, 2, 3]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Multiple items found');
+        $collection->sole();
+    }
 }

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -1421,4 +1421,115 @@ class CollectionTest extends TestCase
         $this->assertCount(1, $duplicates);
         $this->assertEquals('alice@example.com', $duplicates->first()['email']);
     }
+
+    public function testSumCalculatesTotal()
+    {
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, [1, 2, 3, 4, 5]);
+
+        $this->assertEquals(15, $collection->sum());
+    }
+
+    public function testSumWithKey()
+    {
+        $items = [
+            ['price' => 100],
+            ['price' => 200],
+            ['price' => 300],
+        ];
+
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, $items);
+
+        $this->assertEquals(600, $collection->sum('price'));
+    }
+
+    public function testSumWithCallback()
+    {
+        $items = [
+            ['quantity' => 2, 'price' => 10],
+            ['quantity' => 3, 'price' => 20],
+        ];
+
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, $items);
+
+        $total = $collection->sum(fn($item) => $item['quantity'] * $item['price']);
+
+        $this->assertEquals(80, $total);
+    }
+
+    public function testAvgCalculatesAverage()
+    {
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, [1, 2, 3, 4, 5]);
+
+        $this->assertEquals(3, $collection->avg());
+    }
+
+    public function testAvgWithKey()
+    {
+        $users = [
+            ['age' => 20],
+            ['age' => 30],
+            ['age' => 40],
+        ];
+
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, $users);
+
+        $this->assertEquals(30, $collection->avg('age'));
+    }
+
+    public function testAvgWithEmptyCollection()
+    {
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, []);
+
+        $this->assertNull($collection->avg());
+    }
+
+    public function testMinReturnsSmallestValue()
+    {
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, [5, 2, 8, 1, 9]);
+
+        $this->assertEquals(1, $collection->min());
+    }
+
+    public function testMaxReturnsLargestValue()
+    {
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, [5, 2, 8, 1, 9]);
+
+        $this->assertEquals(9, $collection->max());
+    }
+
+    public function testMinWithKey()
+    {
+        $items = [
+            ['price' => 100],
+            ['price' => 50],
+            ['price' => 200],
+        ];
+
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, $items);
+
+        $this->assertEquals(50, $collection->min('price'));
+    }
+
+    public function testMaxWithKey()
+    {
+        $items = [
+            ['price' => 100],
+            ['price' => 50],
+            ['price' => 200],
+        ];
+
+        $modelClass = get_class($this->makeTestModel(0, ""));
+        $collection = new Collection($modelClass, $items);
+
+        $this->assertEquals(200, $collection->max('price'));
+    }
 }


### PR DESCRIPTION
### duplicate usages example
```php
// Find duplicate emails
$users = User::all();
$duplicateEmails = $users->duplicates('email');

if ($duplicateEmails->isNotEmpty()) {
    Log::warning("Found duplicate emails", $duplicateEmails->all());
}

// Find duplicate orders
$orders = Order::all();
$duplicateOrders = $orders->duplicates('transaction_id');

// Simple duplicates
$numbers = new Collection(Model::class, [1, 2, 2, 3, 3, 3, 4]);
$dupes = $numbers->duplicates(); // [2, 3, 3] (all but first occurrence)
```

### sole example
Get exactly one item or throw an exception
```php
// Get user by unique email
try {
    $user = User::all()->sole(fn($u) => $u['email'] === 'admin@example.com');
} catch (\RuntimeException $e) {
    // Either no user found or multiple users found
    Log::error($e->getMessage());
}
```

### pipe example
Execute a callback without modifying the collection
```php
$csv = $users->pipe(function($collection) {
    return $collection
        ->map(fn($u) => implode(',', $u))
        ->implode("\n");
});
```