### PR TITLE
console command handle() method dependency injection

### DIFF
--- a/src/Phaseolies/Console/Commands/AppBoostCommand.php
+++ b/src/Phaseolies/Console/Commands/AppBoostCommand.php
@@ -27,7 +27,7 @@ class AppBoostCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function() {
             $commands = [

--- a/src/Phaseolies/Console/Commands/ClearCacheCommand.php
+++ b/src/Phaseolies/Console/Commands/ClearCacheCommand.php
@@ -26,7 +26,7 @@ class ClearCacheCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->withTiming(function() {
             $cacheDir = base_path('storage/framework/cache');

--- a/src/Phaseolies/Console/Commands/ClearConfigCommand.php
+++ b/src/Phaseolies/Console/Commands/ClearConfigCommand.php
@@ -25,7 +25,7 @@ class ClearConfigCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->withTiming(function () {
             app('config')->clearCache();

--- a/src/Phaseolies/Console/Commands/ClearRouteCacheCommand.php
+++ b/src/Phaseolies/Console/Commands/ClearRouteCacheCommand.php
@@ -27,7 +27,7 @@ class ClearRouteCacheCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->withTiming(function() {
             Route::clearRouteCache();

--- a/src/Phaseolies/Console/Commands/ClearSessionCommand.php
+++ b/src/Phaseolies/Console/Commands/ClearSessionCommand.php
@@ -25,7 +25,7 @@ class ClearSessionCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->withTiming(function() {
             $sessionDir = base_path('storage/framework/sessions');

--- a/src/Phaseolies/Console/Commands/ConfigCacheCommand.php
+++ b/src/Phaseolies/Console/Commands/ConfigCacheCommand.php
@@ -25,7 +25,7 @@ class ConfigCacheCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->withTiming(function() {
             Config::clearCache();

--- a/src/Phaseolies/Console/Commands/Cron/CronDaemonCommand.php
+++ b/src/Phaseolies/Console/Commands/Cron/CronDaemonCommand.php
@@ -26,7 +26,7 @@ class CronDaemonCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         $action = $this->argument('action');
 

--- a/src/Phaseolies/Console/Commands/Cron/CronFinishCommand.php
+++ b/src/Phaseolies/Console/Commands/Cron/CronFinishCommand.php
@@ -25,7 +25,7 @@ class CronFinishCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         $finishId = $this->argument('finish_id');
         $shouldReleaseLock = (bool)$this->argument('release_lock');

--- a/src/Phaseolies/Console/Commands/Cron/CronListCommand.php
+++ b/src/Phaseolies/Console/Commands/Cron/CronListCommand.php
@@ -27,7 +27,7 @@ class CronListCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function() {
             $schedule = new Schedule();

--- a/src/Phaseolies/Console/Commands/Cron/CronRunCommand.php
+++ b/src/Phaseolies/Console/Commands/Cron/CronRunCommand.php
@@ -460,7 +460,7 @@ class CronRunCommand extends Command
         if ($process->isSuccessful()) {
             // Only show success for non-second-based
             if (!$command->isSecondSchedule()) {
-                $this->displayInfo('Success: ' . $command->getCommand());
+                $this->info('Success: ' . $command->getCommand());
             }
         } else {
             $this->displayError('Error: ' . $command->getCommand());

--- a/src/Phaseolies/Console/Commands/Cron/CronRunCommand.php
+++ b/src/Phaseolies/Console/Commands/Cron/CronRunCommand.php
@@ -35,7 +35,7 @@ class CronRunCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         $isDaemon = $this->option('daemon');
 

--- a/src/Phaseolies/Console/Commands/DeleteCronLockFile.php
+++ b/src/Phaseolies/Console/Commands/DeleteCronLockFile.php
@@ -25,7 +25,7 @@ class DeleteCronLockFile extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->withTiming(function () {
             $cacheDir = base_path() . '/storage/schedule';

--- a/src/Phaseolies/Console/Commands/DopparInstallCommand.php
+++ b/src/Phaseolies/Console/Commands/DopparInstallCommand.php
@@ -27,7 +27,7 @@ class DopparInstallCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         if ($this->confirm('Do you want to install authentication?', false)) {
             $this->installAuthentication();

--- a/src/Phaseolies/Console/Commands/KeyGenerateCommand.php
+++ b/src/Phaseolies/Console/Commands/KeyGenerateCommand.php
@@ -26,7 +26,7 @@ class KeyGenerateCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function() {
             $randomKey = base64_encode(random_bytes(32));

--- a/src/Phaseolies/Console/Commands/MakeAuthCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeAuthCommand.php
@@ -26,7 +26,7 @@ class MakeAuthCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function () {
             if ($this->authFilesExist()) {

--- a/src/Phaseolies/Console/Commands/MakeAuthorizerCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeAuthorizerCommand.php
@@ -25,7 +25,7 @@ class MakeAuthorizerCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function() {
             $name = $this->argument('name');

--- a/src/Phaseolies/Console/Commands/MakeConsoleCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeConsoleCommand.php
@@ -25,7 +25,7 @@ class MakeConsoleCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function() {
             $name = $this->argument('name');
@@ -112,7 +112,7 @@ class {$className} extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return Command::SUCCESS;
     }

--- a/src/Phaseolies/Console/Commands/MakeControllerCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeControllerCommand.php
@@ -27,7 +27,7 @@ class MakeControllerCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function () {
             [$name, $routeName, $isInvokable, $isResource, $isApi, $isComplete] = $this->parseFlags();

--- a/src/Phaseolies/Console/Commands/MakeHookCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeHookCommand.php
@@ -25,7 +25,7 @@ class MakeHookCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function() {
             $name = $this->argument('name');

--- a/src/Phaseolies/Console/Commands/MakeMailCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeMailCommand.php
@@ -25,7 +25,7 @@ class MakeMailCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function() {
             $name = $this->argument('name');

--- a/src/Phaseolies/Console/Commands/MakeMiddlewareCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeMiddlewareCommand.php
@@ -25,7 +25,7 @@ class MakeMiddlewareCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function() {
             $name = $this->argument('name');

--- a/src/Phaseolies/Console/Commands/MakeModelCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeModelCommand.php
@@ -45,7 +45,7 @@ class MakeModelCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function() {
             $name = $this->argument('name');

--- a/src/Phaseolies/Console/Commands/MakePasswordCommand.php
+++ b/src/Phaseolies/Console/Commands/MakePasswordCommand.php
@@ -26,7 +26,7 @@ class MakePasswordCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function () {
             $password = $this->argument('password');

--- a/src/Phaseolies/Console/Commands/MakeProviderCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeProviderCommand.php
@@ -25,7 +25,7 @@ class MakeProviderCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function() {
             $name = $this->argument('name');

--- a/src/Phaseolies/Console/Commands/MakeRequestCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeRequestCommand.php
@@ -25,7 +25,7 @@ class MakeRequestCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function() {
             $name = $this->argument('name');

--- a/src/Phaseolies/Console/Commands/Migrations/AddColumnMigrationCommand.php
+++ b/src/Phaseolies/Console/Commands/Migrations/AddColumnMigrationCommand.php
@@ -37,7 +37,7 @@ class AddColumnMigrationCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function() {
             $name = $this->argument('name');

--- a/src/Phaseolies/Console/Commands/Migrations/CreateMigrationCommand.php
+++ b/src/Phaseolies/Console/Commands/Migrations/CreateMigrationCommand.php
@@ -46,7 +46,7 @@ class CreateMigrationCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function() {
             $name = $this->argument('name');

--- a/src/Phaseolies/Console/Commands/Migrations/CreateSeedCommand.php
+++ b/src/Phaseolies/Console/Commands/Migrations/CreateSeedCommand.php
@@ -25,7 +25,7 @@ class CreateSeedCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function() {
             $name = $this->argument('name');

--- a/src/Phaseolies/Console/Commands/Migrations/DBSeedCommand.php
+++ b/src/Phaseolies/Console/Commands/Migrations/DBSeedCommand.php
@@ -26,7 +26,7 @@ class DBSeedCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function () {
             $seedName = $this->argument('seed');

--- a/src/Phaseolies/Console/Commands/Migrations/MigrateCommand.php
+++ b/src/Phaseolies/Console/Commands/Migrations/MigrateCommand.php
@@ -42,7 +42,7 @@ class MigrateCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function () {
             $connection = $this->option('connection') ?: config('database.default');

--- a/src/Phaseolies/Console/Commands/Migrations/MigrateRefreshCommand.php
+++ b/src/Phaseolies/Console/Commands/Migrations/MigrateRefreshCommand.php
@@ -45,7 +45,7 @@ class MigrateRefreshCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function () {
             $connection = $this->option('connection') ?: config('database.default');

--- a/src/Phaseolies/Console/Commands/PaginationPublishCommand.php
+++ b/src/Phaseolies/Console/Commands/PaginationPublishCommand.php
@@ -25,7 +25,7 @@ class PaginationPublishCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function() {
             $paginationPath = resource_path('views/vendor/pagination');

--- a/src/Phaseolies/Console/Commands/Presenter/BundleCommand.php
+++ b/src/Phaseolies/Console/Commands/Presenter/BundleCommand.php
@@ -25,7 +25,7 @@ class BundleCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function () {
             $name = $this->argument('name');

--- a/src/Phaseolies/Console/Commands/Presenter/PresenterCommand.php
+++ b/src/Phaseolies/Console/Commands/Presenter/PresenterCommand.php
@@ -25,7 +25,7 @@ class PresenterCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function () {
             $name = $this->argument('name');

--- a/src/Phaseolies/Console/Commands/RouteCacheCommand.php
+++ b/src/Phaseolies/Console/Commands/RouteCacheCommand.php
@@ -26,7 +26,7 @@ class RouteCacheCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function () {
             $cacheDir = base_path('storage/framework/cache');

--- a/src/Phaseolies/Console/Commands/RouteListCommand.php
+++ b/src/Phaseolies/Console/Commands/RouteListCommand.php
@@ -27,7 +27,7 @@ class RouteListCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function () {
 

--- a/src/Phaseolies/Console/Commands/Server/ServerStartCommand.php
+++ b/src/Phaseolies/Console/Commands/Server/ServerStartCommand.php
@@ -30,7 +30,7 @@ class ServerStartCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function () {
             $port = $this->argument('port');

--- a/src/Phaseolies/Console/Commands/Server/ServerStopCommand.php
+++ b/src/Phaseolies/Console/Commands/Server/ServerStopCommand.php
@@ -26,7 +26,7 @@ class ServerStopCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function() {
             $port = $this->argument('port');

--- a/src/Phaseolies/Console/Commands/SetCreatablePropertyCommand.php
+++ b/src/Phaseolies/Console/Commands/SetCreatablePropertyCommand.php
@@ -25,7 +25,7 @@ class SetCreatablePropertyCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         $tableName = $this->argument("table");
 

--- a/src/Phaseolies/Console/Commands/StorageLinkCommand.php
+++ b/src/Phaseolies/Console/Commands/StorageLinkCommand.php
@@ -27,7 +27,7 @@ class StorageLinkCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function() {
             $links = config('filesystem.links');

--- a/src/Phaseolies/Console/Commands/StorageUnlinkCommand.php
+++ b/src/Phaseolies/Console/Commands/StorageUnlinkCommand.php
@@ -26,7 +26,7 @@ class StorageUnlinkCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function() {
             $linkPath = public_path('storage');

--- a/src/Phaseolies/Console/Commands/Tests/UnitTestCommand.php
+++ b/src/Phaseolies/Console/Commands/Tests/UnitTestCommand.php
@@ -29,7 +29,7 @@ class UnitTestCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         $startTime = microtime(true);
 

--- a/src/Phaseolies/Console/Commands/VendorPublishCommand.php
+++ b/src/Phaseolies/Console/Commands/VendorPublishCommand.php
@@ -37,7 +37,7 @@ class VendorPublishCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function () {
             $provider = $this->option('provider');

--- a/src/Phaseolies/Console/Commands/ViewCacheCommand.php
+++ b/src/Phaseolies/Console/Commands/ViewCacheCommand.php
@@ -34,7 +34,7 @@ class ViewCacheCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->executeWithTiming(function() {
             $viewPath = base_path('resources/views');

--- a/src/Phaseolies/Console/Commands/ViewClearCommand.php
+++ b/src/Phaseolies/Console/Commands/ViewClearCommand.php
@@ -26,7 +26,7 @@ class ViewClearCommand extends Command
      *
      * @return int
      */
-    protected function handle(): int
+    public function handle(): int
     {
         return $this->withTiming(function() {
             $viewCacheDir = base_path('storage/framework/views');

--- a/src/Phaseolies/Console/Schedule/Command.php
+++ b/src/Phaseolies/Console/Schedule/Command.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Phaseolies\Support\Facades\Log;
 use Phaseolies\DI\Container;
 
 abstract class Command extends SymfonyCommand
@@ -145,7 +146,8 @@ abstract class Command extends SymfonyCommand
 
             return is_int($result) ? $result : self::SUCCESS;
         } catch (\Throwable $e) {
-            return self::FAILURE;
+            Log::error($e);
+            throw new \Exception($e->getMessage());
         }
     }
 

--- a/src/Phaseolies/Console/Schedule/Command.php
+++ b/src/Phaseolies/Console/Schedule/Command.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Phaseolies\DI\Container;
 
 abstract class Command extends SymfonyCommand
 {
@@ -132,15 +133,21 @@ abstract class Command extends SymfonyCommand
         $this->input = $input;
         $this->output = $output;
 
-        return $this->handle();
-    }
+        if (!method_exists($this, 'handle')) {
+            throw new \LogicException(
+                sprintf('Command [%s] must have a handle() method.', static::class)
+            );
+        }
 
-    /**
-     * Execute the console command.
-     *
-     * @return int
-     */
-    abstract protected function handle(): int;
+        try {
+            $container = Container::getInstance();
+            $result = $container->call([$this, 'handle']);
+
+            return is_int($result) ? $result : self::SUCCESS;
+        } catch (\Throwable $e) {
+            return self::FAILURE;
+        }
+    }
 
     /**
      * Get the value of a command argument.

--- a/src/Phaseolies/DI/Container.php
+++ b/src/Phaseolies/DI/Container.php
@@ -495,11 +495,11 @@ class Container implements ArrayAccess
     /**
      * Call the given callback with dependency injection
      *
-     * @param callable $callback
+     * @param $callback
      * @param array $parameters
      * @return mixed
      */
-    public function call(callable $callback, array $parameters = []): mixed
+    public function call($callback, array $parameters = []): mixed
     {
         if (is_array($callback)) {
             $reflection = new \ReflectionMethod($callback[0], $callback[1]);

--- a/src/Phaseolies/DI/Container.php
+++ b/src/Phaseolies/DI/Container.php
@@ -495,12 +495,19 @@ class Container implements ArrayAccess
     /**
      * Call the given callback with dependency injection
      *
-     * @param $callback
+     * @param callable $callback
      * @param array $parameters
      * @return mixed
      */
-    public function call($callback, array $parameters = []): mixed
+    public function call(callable $callback, array $parameters = []): mixed
     {
+        if (!is_callable($callback)) {
+            throw new \TypeError(sprintf(
+                'Callback must be callable, %s given',
+                is_object($callback) ? get_class($callback) : gettype($callback)
+            ));
+        }
+
         if (is_array($callback)) {
             $reflection = new \ReflectionMethod($callback[0], $callback[1]);
         } elseif (is_object($callback) && method_exists($callback, '__invoke')) {

--- a/tests/Application/ContainerTest.php
+++ b/tests/Application/ContainerTest.php
@@ -1913,11 +1913,11 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(ConcreteRepository::class, $service->repository);
     }
 
-    // public function testInvalidCallableThrows()
-    // {
-    //     $this->expectException(\TypeError::class);
-    //     $this->container->call('not_a_callable');
-    // }
+    public function testInvalidCallableThrows()
+    {
+        $this->expectException(\TypeError::class);
+        $this->container->call('not_a_callable');
+    }
 
     public function testUnresolvableDependencyThrows()
     {

--- a/tests/Application/ContainerTest.php
+++ b/tests/Application/ContainerTest.php
@@ -1913,11 +1913,11 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(ConcreteRepository::class, $service->repository);
     }
 
-    public function testInvalidCallableThrows()
-    {
-        $this->expectException(\TypeError::class);
-        $this->container->call('not_a_callable');
-    }
+    // public function testInvalidCallableThrows()
+    // {
+    //     $this->expectException(\TypeError::class);
+    //     $this->container->call('not_a_callable');
+    // }
 
     public function testUnresolvableDependencyThrows()
     {


### PR DESCRIPTION
The doppar console commands did not support dependency injection in the handle method. Developers could not type-hint services or models directly in the method signature.

The handle method now supports automatic dependency injection. Services, models, or other resolvable classes can be type-hinted directly in the method signature:

```php
public function handle(Tag $tag): int
{
    dd($tag->first()->toArray());

    return Command::SUCCESS;
}

```

This makes command classes cleaner and allows leveraging the container for automatic resolution of dependencies.