### PR TITLE
Fix: PHP 8.5 PDO MySQL Constant Deprecations (Backward Compatible)

### DIFF
--- a/src/Phaseolies/Database/Drivers/MySQLDriver.php
+++ b/src/Phaseolies/Database/Drivers/MySQLDriver.php
@@ -3,6 +3,7 @@
 namespace Phaseolies\Database\Drivers;
 
 use PDO;
+use Pdo\Mysql;
 use Phaseolies\Database\Contracts\Driver\DriverInterface;
 
 class MySQLDriver implements DriverInterface
@@ -30,26 +31,41 @@ class MySQLDriver implements DriverInterface
             PDO::ATTR_STRINGIFY_FETCHES => false,
         ];
 
-        if (!empty($config['options'][PDO::MYSQL_ATTR_SSL_CA])) {
-            $options[PDO::MYSQL_ATTR_SSL_CA] = $config['options'][PDO::MYSQL_ATTR_SSL_CA];
-            $options[PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] = false;
+        $sslCa = $this->mysqlAttr('ATTR_SSL_CA', 'MYSQL_ATTR_SSL_CA');
 
-            $sslOptions = [
-                PDO::MYSQL_ATTR_SSL_CERT,
-                PDO::MYSQL_ATTR_SSL_KEY,
-                PDO::MYSQL_ATTR_SSL_CAPATH,
-                PDO::MYSQL_ATTR_SSL_CIPHER
-            ];
+        if ($sslCa !== null && !empty($config['options'][$sslCa])) {
+            $options[$sslCa] = $config['options'][$sslCa];
 
-            foreach ($sslOptions as $sslOption) {
-                if (!empty($config['options'][$sslOption])) {
-                    $options[$sslOption] = $config['options'][$sslOption];
+            $verify = $this->mysqlAttr(
+                'ATTR_SSL_VERIFY_SERVER_CERT',
+                'MYSQL_ATTR_SSL_VERIFY_SERVER_CERT'
+            );
+
+            if ($verify !== null) {
+                $options[$verify] = false;
+            }
+
+            foreach (
+                [
+                    ['ATTR_SSL_CERT', 'MYSQL_ATTR_SSL_CERT'],
+                    ['ATTR_SSL_KEY', 'MYSQL_ATTR_SSL_KEY'],
+                    ['ATTR_SSL_CAPATH', 'MYSQL_ATTR_SSL_CAPATH'],
+                    ['ATTR_SSL_CIPHER', 'MYSQL_ATTR_SSL_CIPHER'],
+                ] as [$new, $old]
+            ) {
+
+                $attr = $this->mysqlAttr($new, $old);
+
+                if ($attr !== null && isset($config['options'][$attr])) {
+                    $options[$attr] = $config['options'][$attr];
                 }
             }
         }
 
-        if (!empty($config['options'][PDO::MYSQL_ATTR_INIT_COMMAND])) {
-            $options[PDO::MYSQL_ATTR_INIT_COMMAND] = $config['options'][PDO::MYSQL_ATTR_INIT_COMMAND];
+        $attr = $this->mysqlAttr('ATTR_INIT_COMMAND', 'MYSQL_ATTR_INIT_COMMAND');
+
+        if ($attr !== null && isset($config['options'][$attr])) {
+            $options[$attr] = $config['options'][$attr];
         }
 
         $pdo = new PDO(
@@ -237,5 +253,35 @@ class MySQLDriver implements DriverInterface
     public function deleteAll(PDO $pdo, string $table): int
     {
         return (int) $pdo->exec("DELETE FROM {$table}");
+    }
+
+    /**
+     * Resolve a MySQL PDO attribute constant in a version-compatible way
+     *
+     * PHP 8.5 moved MySQL-specific PDO constants from PDO::MYSQL_ATTR_*
+     * to the namespaced Pdo\Mysql::ATTR_* class and deprecated the old ones.
+     *
+     * This helper safely resolves the correct constant for:
+     *  - PHP 8.5+ (Pdo\Mysql::ATTR_*)
+     *  - PHP 8.3 / 8.4 (PDO::MYSQL_ATTR_*)
+     *
+     * If neither constant exists (e.g., extension not available),
+     * null is returned.
+     *
+     * @param string $new The new constant name (e.g. 'ATTR_SSL_CA')
+     * @param string $old The legacy constant name (e.g. 'MYSQL_ATTR_SSL_CA')
+     * @return int|null
+     */
+    private function mysqlAttr(string $new, string $old): ?int
+    {
+        if (class_exists(Mysql::class) && defined("Pdo\\Mysql::$new")) {
+            return constant("Pdo\\Mysql::$new");
+        }
+
+        if (defined("PDO::$old")) {
+            return constant("PDO::$old");
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
This PR updates the MySQLDriver to support PHP 8.5, where MySQL-specific PDO constants have been moved 
from:
```php
PDO::MYSQL_ATTR_*
```
to:
```php
Pdo\Mysql::ATTR_*
```

The legacy `PDO::MYSQL_* `constants are deprecated in PHP 8.5 and trigger fatal errors when deprecations are converted to exceptions.
