### PR TITLE
Prevent fatal errors in app() helper on PHP 8.5

### DIFF
--- a/src/Phaseolies/Helpers/helpers.php
+++ b/src/Phaseolies/Helpers/helpers.php
@@ -60,11 +60,17 @@ if (!function_exists('app')) {
      */
     function app($abstract = null, array $parameters = [])
     {
+        $container = Container::getInstance();
+
         if (is_null($abstract)) {
-            return Container::getInstance();
+            return $container;
         }
 
-        return Container::getInstance()->get($abstract, $parameters);
+        if (!$container->has($abstract)) {
+            return null;
+        }
+
+        return $container->get($abstract, $parameters);
     }
 }
 


### PR DESCRIPTION
This PR updates the `app()` helper and related helper functions to handle unbound container services gracefully. On PHP 8.5, calling `app('request')` or similar services during `post-create project scripts` was causing fatal errors:
```
Target [request] is not bound in container and is not a class
```
Without this fix, Doppar installations on PHP 8.5 fail during setup due to unbound container services. This addresses those fatal errors while maintaining proper container resolution behavior.