### PR TITLE
Fix: PHP 8.5 Compatibility – Null Array Offset Deprecation

### DIFF
--- a/src/Phaseolies/Http/Response/ResponseHeaderBag.php
+++ b/src/Phaseolies/Http/Response/ResponseHeaderBag.php
@@ -162,7 +162,11 @@ class ResponseHeaderBag extends HeaderBag
 
     public function setCookie(Cookie $cookie): void
     {
-        $this->cookies[$cookie->getDomain()][$cookie->getPath()][$cookie->getName()] = $cookie;
+        $domain = $cookie->getDomain() ?? '';
+        $path   = $cookie->getPath() ?? '/';
+        $name   = $cookie->getName();
+
+        $this->cookies[$domain][$path][$name] = $cookie;
         $this->headerNames['set-cookie'] = 'Set-Cookie';
     }
 
@@ -171,7 +175,8 @@ class ResponseHeaderBag extends HeaderBag
      */
     public function removeCookie(string $name, ?string $path = '/', ?string $domain = null): void
     {
-        $path ??= '/';
+        $domain = $domain ?? '';
+        $path   = $path ?? '/';
 
         unset($this->cookies[$domain][$path][$name]);
 

--- a/src/Phaseolies/Translation/Translator.php
+++ b/src/Phaseolies/Translation/Translator.php
@@ -125,11 +125,11 @@ class Translator extends FileLoader
         // Handle regular translations (group.item)
         if (strpos($key, '.') !== false) {
             list($group, $item) = explode('.', $key, 2);
-            return ['', $group, $item];
+            return [null, $group, $item];
         }
 
         // Fallback for simple keys
-        return ['', '*', $key];
+        return [null, '*', $key];
     }
 
     /**

--- a/src/Phaseolies/Translation/Translator.php
+++ b/src/Phaseolies/Translation/Translator.php
@@ -125,11 +125,11 @@ class Translator extends FileLoader
         // Handle regular translations (group.item)
         if (strpos($key, '.') !== false) {
             list($group, $item) = explode('.', $key, 2);
-            return [null, $group, $item];
+            return ['', $group, $item];
         }
 
         // Fallback for simple keys
-        return [null, '*', $key];
+        return ['', '*', $key];
     }
 
     /**


### PR DESCRIPTION
This PR resolves PHP 8.5 deprecation warnings:
> Using null as an array offset is deprecated, use an empty string instead

The issue occurred because null values were being used as array keys in the Translator class `($this->loaded[$namespace][$group][$locale]).`