### PR TITLE
Add Support for #[Bind] Attribute in Console Command Handle Methods

### DIFF
--- a/src/Phaseolies/DI/Container.php
+++ b/src/Phaseolies/DI/Container.php
@@ -516,12 +516,57 @@ class Container implements ArrayAccess
             $reflection = new \ReflectionFunction($callback);
         }
 
-        $dependencies = $this->resolveDependencies(
+        $dependencies = $this->resolveDependenciesWithAttributes(
             $reflection->getParameters(),
-            $parameters
+            $parameters,
+            is_array($callback) ? $callback[0] : null
         );
 
         return call_user_func_array($callback, $dependencies);
+    }
+
+    /**
+     * Resolve dependencies with attribute support
+     *
+     * @param array $parameters
+     * @param array $primitives
+     * @param object|string|null $context
+     * @return array
+     */
+    protected function resolveDependenciesWithAttributes(array $parameters, array $primitives = [], $context = null): array
+    {
+        $dependencies = [];
+
+        foreach ($parameters as $parameter) {
+            $bindAttributes = $parameter->getAttributes(\Phaseolies\Utilities\Attributes\Bind::class);
+
+            if (!empty($bindAttributes)) {
+                $bindAttribute = $bindAttributes[0]->newInstance();
+                $paramType = $parameter->getType();
+
+                if (!$paramType || $paramType->isBuiltin()) {
+                    throw new \RuntimeException(
+                        "Parameter '\${$parameter->getName()}' must be class-typed when using #[Bind]"
+                    );
+                }
+
+                $abstract = $paramType->getName();
+
+                $bindAttribute->singleton
+                    ? $this->singleton($abstract, $bindAttribute->concrete)
+                    : $this->bind($abstract, $bindAttribute->concrete);
+
+                $dependencies[] = $this->get($abstract);
+                continue;
+            }
+
+            $contextClass = is_object($context) ? get_class($context) : (string) $context;
+
+            $dependency = $this->resolveDependency($parameter, $primitives, $contextClass);
+            $dependencies[] = $dependency;
+        }
+
+        return $dependencies;
     }
 
     /**


### PR DESCRIPTION
This PR adds support for PHP 8 attributes in console command handle methods, specifically the `#[Bind]` attribute. Currently, the router supports this attribute in controller methods, but console commands lack the same functionality. This change brings feature parity between HTTP controllers and console commands.

## Changes
1. Enhanced `Container::call()` Method with Attribute Support

## Why This Change?
Previously, this would not work in console commands:
```php
class DopparApplication extends Command
{
    public function handle(
        #[Bind(UserRepository::class)] UserRepositoryInterface $userRepository,  // Attribute ignored
        User $user  // Regular dependency works
    ): int {
        // $userRepository would not be properly bound
    }
}
```

After this change, it works:
```php
class DopparApplication extends Command
{
    public function handle(
        #[Bind(UserRepository::class)] UserRepositoryInterface $userRepository,  // Now works!
        User $user  // Still works
    ): int {
        $users = $userRepository->getUsers();  // Properly resolved with binding
    }
}
```

Console commands now support the same attribute-based injection as controllers. Reduce boilerplate by using attributes for interface bindings. Bind interfaces to concrete implementations directly in method signatures.

## Breaking Changes
None. This change is fully backward compatible. Existing commands without attributes continue to work exactly as before. The container's `call()` method maintains the same signature and behavior for non-attributed parameters.