### PR TITLE
Domain-Restricted Route Matching

### DIFF
--- a/src/Phaseolies/Support/Router.php
+++ b/src/Phaseolies/Support/Router.php
@@ -141,9 +141,13 @@ class Router extends Kernel
         $cacheableRoutes = [];
 
         foreach (self::$routes as $method => $routes) {
-            foreach ($routes as $path => $callback) {
-                if ($this->isCacheableRoute($callback)) {
-                    $cacheableRoutes[$method][$path] = $callback;
+            foreach ($routes as $path => $entry) {
+                ['callback' => $callback, 'domain' => $domain] = $this->unwrapRouteEntry($entry);
+
+                if ($this->isCacheableRoute($entry)) {
+                    $cacheableRoutes[$method][$path] = $domain
+                        ? ['__callback' => $callback, '__domain' => $domain]
+                        : $callback;
                 }
             }
         }
@@ -159,6 +163,10 @@ class Router extends Kernel
      */
     protected function isCacheableRoute($callback): bool
     {
+        if (is_array($callback) && isset($callback['__callback'], $callback['__domain'])) {
+            $callback = $callback['__callback'];
+        }
+
         if (
             is_array($callback) &&
             count($callback) === 2 &&
@@ -369,9 +377,10 @@ class Router extends Kernel
         $middleware = $route->middleware ?? [];
         $rateLimit = $route->rateLimit ?? null;
         $rateLimitDecay = $route->rateLimitDecay ?? 1;
+        $domain = $route->domain ?? null;
 
         foreach ($httpMethods as $httpMethod) {
-            $this->addRouteNameToAttributesRouting($httpMethod, $path, [$controllerClass, $method], $name);
+            $this->addRouteNameToAttributesRouting($httpMethod, $path, [$controllerClass, $method], $name, $domain);
             if (!empty($middleware)) {
                 $this->middleware($middleware);
             }
@@ -389,11 +398,12 @@ class Router extends Kernel
      * @param string $path
      * @param callable|array $callback
      * @param string|null $name
+     * @param string|null $domain
      * @return self
      */
-    protected function addRouteNameToAttributesRouting(string $method, string $path, $callback, ?string $name = null): self
+    protected function addRouteNameToAttributesRouting(string $method, string $path, $callback, ?string $name = null, ?string $domain = null): self
     {
-        $this->addRoute($method, $path, $callback);
+        $this->addRoute($method, $path, $callback, $domain);
 
         if ($name) {
             self::$namedRoutes[$name] = $this->currentRoutePath;
@@ -543,14 +553,30 @@ class Router extends Kernel
     }
 
     /**
+     * Unwrap the route entry, separating the callback from optional domain metadata.
+     *
+     * @param mixed $entry
+     * @return array{callback: mixed, domain: string|null}
+     */
+    protected function unwrapRouteEntry(mixed $entry): array
+    {
+        if (is_array($entry) && isset($entry['__callback'], $entry['__domain'])) {
+            return ['callback' => $entry['__callback'], 'domain' => $entry['__domain']];
+        }
+
+        return ['callback' => $entry, 'domain' => null];
+    }
+
+    /**
      * Add a route with group attributes applied.
      *
      * @param string $method
      * @param string $path
      * @param callable|array $callback
+     * @param string|null $domain
      * @return self
      */
-    protected function addRoute(string $method, string $path, $callback): self
+    protected function addRoute(string $method, string $path, $callback, ?string $domain = null): self
     {
         $this->failFastOnBadRouteDefinition($callback);
 
@@ -570,15 +596,12 @@ class Router extends Kernel
                 : $fullPath;
         }
 
-        // Special handling for root within a group
-        if ($path === '' && $prefix !== '') {
-            self::$routes[$method][$fullPath] = $callback;
-            $this->currentRoutePath = $fullPath;
-        } else {
-            self::$routes[$method][$fullPath] = $callback;
-            $this->currentRoutePath = $fullPath;
-        }
+        $entry = $domain
+            ? ['__callback' => $callback, '__domain' => $domain]
+            : $callback;
 
+        self::$routes[$method][$fullPath] = $entry;
+        $this->currentRoutePath = $fullPath;
         $this->currentRequestMethod = $method;
 
         if (!static::$cacheLoaded) {
@@ -635,6 +658,31 @@ class Router extends Kernel
     {
         if ($this->currentRoutePath) {
             self::$namedRoutes[$name] = $this->currentRoutePath;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Restricts the last registered route to a specific domain.
+     * Supports exact domains ('api.example.com'), wildcard subdomains
+     * ('{tenant}.example.com'), and universal wildcard ('*').
+     *
+     * @param string $domain The domain pattern to restrict to.
+     * @return self
+     */
+    public function domain(string $domain): self
+    {
+        if ($this->currentRoutePath) {
+            $method = $this->getCurrentRequestMethod();
+            $entry  = self::$routes[$method][$this->currentRoutePath];
+
+            ['callback' => $callback] = $this->unwrapRouteEntry($entry);
+
+            self::$routes[$method][$this->currentRoutePath] = [
+                '__callback' => $callback,
+                '__domain'   => $domain,
+            ];
         }
 
         return $this;
@@ -709,25 +757,32 @@ class Router extends Kernel
     public function getCallback($request): mixed
     {
         $method = $request->getMethod();
-        $url = $request->getPath();
+        $url    = $request->getPath();
+        $host   = $request->getHost();
 
         $url = ($url !== '/') ? rtrim($url, '/') : $url;
 
         $routes = self::$routes[$method] ?? [];
 
-        if (isset($routes[$url])) {
-            return $routes[$url];
-        }
+        foreach ($routes as $route => $entry) {
+            ['callback' => $callback, 'domain' => $domain] = $this->unwrapRouteEntry($entry);
 
-        foreach ($routes as $route => $callback) {
-            if ($route === $url) {
+            // Domain guard — skip routes whose domain pattern doesn't match the request host
+            if ($domain !== null && !$this->matchesDomain($host, $domain, $request)) {
                 continue;
             }
 
+            // Exact match
+            if ($route === $url) {
+                return $callback;
+            }
+
+            // Catch-all wildcard
             if ($route === '(.*)') {
                 return $callback;
             }
 
+            // Pattern match with named parameters
             $routeRegex = $this->convertRouteToRegex($route);
 
             if (preg_match($routeRegex, $url, $matches)) {
@@ -740,6 +795,50 @@ class Router extends Kernel
         }
 
         return false;
+    }
+
+    /**
+     * Match the incoming host against a route domain pattern.
+     * Supports:
+     *   - Exact domain:            'api.example.com'
+     *   - Port-qualified domain:   'localhost:8000'
+     *   - Wildcard subdomain:      '{tenant}.example.com' (injects param into route params)
+     *   - Universal wildcard:      '*'
+     *
+     * @param string $host
+     * @param string $domain
+     * @param mixed  $request
+     * @return bool
+     */
+    protected function matchesDomain(string $host, string $domain, $request): bool
+    {
+        $host = strtolower($host);
+
+        // Universal wildcard: match any host
+        if ($domain === '*') {
+            return true;
+        }
+
+        // Named subdomain wildcard: {subdomain}.example.com
+        if (preg_match('/^\{(\w+)\}\.(.+)$/', $domain, $m)) {
+            // Strip port from host before matching the suffix
+            $bareHost     = explode(':', $host)[0];
+            $domainSuffix = strtolower($m[2]);
+            $pattern      = '/^([^.]+)\.' . preg_quote($domainSuffix, '/') . '$/';
+
+            if (preg_match($pattern, $bareHost, $hostMatch)) {
+                // Inject the captured subdomain segment as a route parameter
+                $existing        = $request->getRouteParams();
+                $existing[$m[1]] = $hostMatch[1];
+                $request->setRouteParams($existing);
+                return true;
+            }
+
+            return false;
+        }
+
+        // Exact match — intentionally port-aware so 'localhost:8000' != 'localhost'
+        return $host === strtolower($domain);
     }
 
     /**

--- a/src/Phaseolies/Support/Router.php
+++ b/src/Phaseolies/Support/Router.php
@@ -758,7 +758,6 @@ class Router extends Kernel
     {
         $method = $request->getMethod();
         $url    = $request->getPath();
-        $host   = $request->getHost();
 
         $url = ($url !== '/') ? rtrim($url, '/') : $url;
 
@@ -768,7 +767,7 @@ class Router extends Kernel
             ['callback' => $callback, 'domain' => $domain] = $this->unwrapRouteEntry($entry);
 
             // Domain guard — skip routes whose domain pattern doesn't match the request host
-            if ($domain !== null && !$this->matchesDomain($host, $domain, $request)) {
+            if ($domain !== null && !$this->matchesDomain($domain, $request)) {
                 continue;
             }
 
@@ -805,13 +804,13 @@ class Router extends Kernel
      *   - Wildcard subdomain:      '{tenant}.example.com' (injects param into route params)
      *   - Universal wildcard:      '*'
      *
-     * @param string $host
      * @param string $domain
      * @param mixed  $request
      * @return bool
      */
-    protected function matchesDomain(string $host, string $domain, $request): bool
+    protected function matchesDomain(string $domain, $request): bool
     {
+        $host = $request->getHost();
         $host = strtolower($host);
 
         // Universal wildcard: match any host

--- a/src/Phaseolies/Utilities/Attributes/Route.php
+++ b/src/Phaseolies/Utilities/Attributes/Route.php
@@ -13,7 +13,8 @@ final class Route
         public ?string $name = null,
         public array $middleware = [],
         public ?int $rateLimit = null,
-        public ?int $rateLimitDecay = 1
+        public ?int $rateLimitDecay = 1,
+        public ?string $domain = null
     ) {
         if (is_string($this->methods)) {
             $this->methods = [$this->methods];


### PR DESCRIPTION
This PR adds domain-based route filtering to the Router class. Routes can now be locked to a specific hostname, a port-qualified host, a named wildcard subdomain, or a universal wildcard. A controller method will only be invoked when the incoming Host header satisfies the domain pattern defined on its route — all other hosts fall through to a 404 as normal.

## Motivation
Multi-tenant and multi-service applications running under a single Doppar installation often need to serve completely different controllers depending on the hostname. Previously, this required manual `$request->getHost()` checks scattered across controllers or middleware. Domain routing centralises that concern at the route definition layer, keeping controllers clean.

## New Features
1. domain parameter on the `#[Route]` attribute
```php
#[Route(uri: '/', methods: ['GET'], domain: 'api.example.com')]
public function index(): array { ... }
```

The domain property is optional. Omitting it preserves the existing behaviour — the route matches any host.

2. `->domain()` fluent method for file-based routes
```php
// routes/web.php
Route::get('/', [HomeController::class, 'index'])->domain('example.com');
Route::get('/status', [ApiController::class, 'status'])->domain('api.example.com')->name('api.status');
```

Chains naturally after `->name()` and `->middleware()`.

## Three domain pattern types
| Pattern Type     | Example                  | What It Matches                                           |
|-----------------|-------------------------|----------------------------------------------------------|
| Exact (bare)     | `'example.com'`          | Matches only that hostname                                |
| Port-qualified   | `'localhost:8000'`       | Matches host and port exactly                             |
| Named wildcard   | `'{tenant}.example.com'` | Matches any subdomain; injects `$tenant` as a route parameter |
| Universal        | `'*'`                    | Matches any host (useful in groups)                      |


## Wildcard subdomain injects a route parameter
```php
// Route defined as domain: '{tenant}.example.com'
// Request arrives at: acme.example.com/dashboard

public function dashboard(string $tenant): array
{
    // $tenant === 'acme'
    return ['tenant' => $tenant, 'page' => 'dashboard'];
}
```

The captured subdomain segment is merged into route params before controller resolution, so it participates in normal dependency injection with no extra setup.

## Use case
#### Multi-tenant SaaS with per-subdomain data isolation
Each customer gets their own subdomain. The tenant identifier is captured automatically and can be used to scope database queries.
```php
class TenantController
{
    #[Route(uri: '/dashboard', methods: ['GET'], domain: '{tenant}.app.com')]
    public function dashboard(string $tenant): array
    {
        $workspace = Workspace::where('slug', $tenant)->first();

        return [
            'workspace' => $workspace->name,
            'users'     => $workspace->users()->count(),
        ];
    }
}
```
Result: GET `acme.app.com/dashboard` resolves with `$tenant = 'acme'.` GET `globex.app.com/dashboard` resolves with `$tenant = 'globex'`. A request to app.com/dashboard (no subdomain) returns 404.
