### PR TITLE
route parameter issue resolved for tenant based routing:

### DIFF
--- a/src/Phaseolies/Support/Router.php
+++ b/src/Phaseolies/Support/Router.php
@@ -787,7 +787,9 @@ class Router extends Kernel
             if (preg_match($routeRegex, $url, $matches)) {
                 $params = $this->extractRouteParameters($route, $matches);
                 if ($params !== false) {
-                    $request->setRouteParams($params);
+                    $existing = $request->getRouteParams();
+                    $merged = array_merge($existing, $params);
+                    $request->setRouteParams($merged);
                     return $callback;
                 }
             }
@@ -830,6 +832,8 @@ class Router extends Kernel
                 $existing        = $request->getRouteParams();
                 $existing[$m[1]] = $hostMatch[1];
                 $request->setRouteParams($existing);
+                $request->merge([$m[1] => $hostMatch[1]]);
+
                 return true;
             }
 


### PR DESCRIPTION
After the PR, the `tenant` is available via the `$request` object as well and also it will work seamlessly with route parameters

```php
#[Route(uri: '/{id}/{name}', name: 'home', domain: '{tenant}.myapp.local', middleware: ['guest'])]
public function welcome(string $tenant, int $id, string $name, Request $request)
{
    // Example URI: http://glob.myapp.local/1/hasan?country=bd
  
    dump($request->query('country'));
    dump("Tenant: {$tenant}, Project ID: {$id}");
    dump($request->tenant);
    dd($tenant);
}
```