### PR TITLE
fix: mergeIfMissing function:

### DIFF
--- a/src/Phaseolies/Http/Request.php
+++ b/src/Phaseolies/Http/Request.php
@@ -599,6 +599,7 @@ class Request
     public function merge(array $input): self
     {
         $this->request->replace(array_merge($this->request->all(), $input));
+        $this->input = [];
 
         return $this;
     }

--- a/src/Phaseolies/Http/Support/RequestHelper.php
+++ b/src/Phaseolies/Http/Support/RequestHelper.php
@@ -244,6 +244,7 @@ trait RequestHelper
         });
 
         $this->request->replace($data);
+        $this->input = [];
 
         return $this;
     }

--- a/src/Phaseolies/Support/Router.php
+++ b/src/Phaseolies/Support/Router.php
@@ -832,7 +832,7 @@ class Router extends Kernel
                 $existing        = $request->getRouteParams();
                 $existing[$m[1]] = $hostMatch[1];
                 $request->setRouteParams($existing);
-                $request->merge([$m[1] => $hostMatch[1]]);
+                $request->mergeIfMissing([$m[1] => $hostMatch[1]]);
 
                 return true;
             }


### PR DESCRIPTION
### Problem
When using `mergeIfMissing()` (or any method that internally calls `has()` or `input()` before mutating request data), the local `$this->input` cache gets populated and locked. Any subsequent merge into the underlying `InputBag` is invisible to `input()`, `has()`, and the `__get()` magic method because they all read from the stale cache.

Minimal reproduction:
```php
$request->mergeIfMissing(['test' => 'doppar']);

$request->all();   // returns merged data (reads directly from InputBag)
$request->test;    // returns null (reads from stale cache)
$request->input('test'); // returns `null`
$request->has('test');   // returns `false`
```
`input()` and `has()` in `RequestHelper` lazily populate `$this->input` on first access and never invalidate it:

### Fix
Invalidate `$this->input` cache inside `merge()` so any subsequent read re-fetches fresh data from the underlying `InputBag`:
```php
public function merge(array $input): self
{
    $this->request->replace(array_merge($this->request->all(), $input));
    $this->input = []; // invalidate stale cache

    return $this;
}
```

Also fixed
```php
public function nullifyBlanks(...): static
{
    // ...existing logic...
    $this->request->replace($data);
    $this->input = []; // invalidate stale cache

    return $this;
}
```

The targeted invalidation approach is the minimal, lowest-risk fix — it preserves the intended optimization while correcting the staleness bug.
