### PR TITLE
Boot-time Frozen Services via #[Immutable]

### DIFF
--- a/src/Phaseolies/DI/Attributes/Immutable.php
+++ b/src/Phaseolies/DI/Attributes/Immutable.php
@@ -4,17 +4,6 @@ namespace Phaseolies\DI\Attributes;
 
 use Attribute;
 
-/**
- * #[Immutable] — Freeze a Service After Boot
- *
- * When applied to a class, the container will wrap the resolved instance
- * in an ImmutableProxy. Any attempt to mutate a property at runtime will
- * throw an ImmutableViolationException.
- *
- * Usage:
- *   #[Immutable]
- *   class PaymentService { ... }
- */
 #[Attribute(Attribute::TARGET_CLASS)]
 final class Immutable
 {

--- a/src/Phaseolies/DI/Attributes/Immutable.php
+++ b/src/Phaseolies/DI/Attributes/Immutable.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Phaseolies\DI\Attributes;
+
+use Attribute;
+
+/**
+ * #[Immutable] — Freeze a Service After Boot
+ *
+ * When applied to a class, the container will wrap the resolved instance
+ * in an ImmutableProxy. Any attempt to mutate a property at runtime will
+ * throw an ImmutableViolationException.
+ *
+ * Usage:
+ *   #[Immutable]
+ *   class PaymentService { ... }
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+final class Immutable
+{
+    public function __construct() {}
+}

--- a/src/Phaseolies/DI/Concerns/EnforcesImmutability.php
+++ b/src/Phaseolies/DI/Concerns/EnforcesImmutability.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Phaseolies\DI\Concerns;
+
+use Phaseolies\DI\Exceptions\ImmutableViolationException;
+
+trait EnforcesImmutability
+{
+    /**
+     * Holds all public property values after they are unset on freeze()
+     *
+     * @var array
+     */
+    private array $__immutableProperties = [];
+
+    /**
+     * Whether this instance has been frozen by the container
+     *
+     * @var bool
+     */
+    private bool $__frozen = false;
+
+    /**
+     * Called by Container::freezeIfImmutable() after build() completes
+     *
+     * Snapshots all public instance properties into the internal map,
+     * then unsets them — forcing future access through __get/__set.
+     *
+     * @return void
+     */
+    public function freeze(): void
+    {
+        $reflector = new \ReflectionClass(static::class);
+
+        foreach ($reflector->getProperties(\ReflectionProperty::IS_PUBLIC) as $property) {
+            if ($property->isStatic()) {
+                continue;
+            }
+
+            $name = $property->getName();
+
+            $this->__immutableProperties[$name] = $property->isInitialized($this)
+                ? $property->getValue($this)
+                : null;
+
+            unset($this->$name);
+        }
+
+        $this->__frozen = true;
+    }
+
+    /**
+     * Check if the instance is frozen
+     *
+     * @return bool
+     */
+    public function isFrozen(): bool
+    {
+        return $this->__frozen;
+    }
+
+    /**
+     * Serve reads from the frozen snapshot
+     *
+     * @throws ImmutableViolationException on write attempts after freeze()
+     * @throws \RuntimeException on access to undefined properties
+     * @return mixed
+     */
+    public function __get(string $name): mixed
+    {
+        if (array_key_exists($name, $this->__immutableProperties)) {
+            return $this->__immutableProperties[$name];
+        }
+
+        throw new \RuntimeException(
+            "Property \${$name} does not exist on " . static::class
+        );
+    }
+
+    /**
+     * Block all writes once frozen
+     *
+     * @throws ImmutableViolationException
+     * @return void
+     */
+    public function __set(string $name, mixed $value): void
+    {
+        if ($this->__frozen) {
+            throw new ImmutableViolationException(static::class, $name);
+        }
+
+        $this->$name = $value;
+    }
+
+    /**
+     * Forward isset() checks to the frozen map
+     *
+     * @return bool
+     */
+    public function __isset(string $name): bool
+    {
+        return isset($this->__immutableProperties[$name]);
+    }
+
+    /**
+     * Block unset() — it is a mutation
+     *
+     * @throws ImmutableViolationException
+     * @return void
+     */
+    public function __unset(string $name): void
+    {
+        throw new ImmutableViolationException(static::class, $name);
+    }
+
+    /**
+     * Prevent cloning of frozen services
+     *
+     * @throws ImmutableViolationException
+     * @return void
+     */
+    public function __clone(): void
+    {
+        if ($this->__frozen) {
+            throw new ImmutableViolationException(static::class, '__clone');
+        }
+    }
+}

--- a/src/Phaseolies/DI/Container.php
+++ b/src/Phaseolies/DI/Container.php
@@ -3,6 +3,7 @@
 namespace Phaseolies\DI;
 
 use ArrayAccess;
+use Phaseolies\DI\Attributes\Immutable;
 
 class Container implements ArrayAccess
 {
@@ -154,7 +155,7 @@ class Container implements ArrayAccess
      * @param class-string<T> $abstract
      * @param array $parameters
      * @return T
-     * @throws RuntimeException
+     * @throws \RuntimeException
      */
     public function get(string $abstract, array $parameters = []): mixed
     {
@@ -240,7 +241,7 @@ class Container implements ArrayAccess
      * @param class-string<T> $concrete
      * @param array $parameters
      * @return T
-     * @throws RuntimeException
+     * @throws \RuntimeException
      */
     public function build(string $concrete, array $parameters = []): object
     {
@@ -257,16 +258,36 @@ class Container implements ArrayAccess
         $constructor = $reflector->getConstructor();
 
         if (is_null($constructor)) {
-            return new $concrete(...$parameters);
+            $instance = new $concrete(...$parameters);
+        } else {
+            $dependencies = $this->resolveDependencies(
+                $constructor->getParameters(),
+                $parameters,
+                $concrete
+            );
+            $instance = $reflector->newInstanceArgs($dependencies);
         }
 
-        $dependencies = $this->resolveDependencies(
-            $constructor->getParameters(),
-            $parameters,
-            $concrete
-        );
+        $this->freezeIfImmutable($reflector, $instance);
 
-        return $reflector->newInstanceArgs($dependencies);
+        return $instance;
+    }
+
+    /**
+     * Freeze the instance if the class has the #[Immutable] attribute and uses the EnforcesImmutability trait.
+     *
+     * @param \ReflectionClass $reflector
+     * @param object $instance
+     * @return void
+     */
+    private function freezeIfImmutable(\ReflectionClass $reflector, object $instance): void
+    {
+        $hasAttribute = !empty($reflector->getAttributes(Immutable::class));
+        $usesTrait    = method_exists($instance, 'freeze') && method_exists($instance, 'isFrozen');
+
+        if ($hasAttribute && $usesTrait) {
+            $instance->freeze();
+        }
     }
 
     /**
@@ -292,7 +313,7 @@ class Container implements ArrayAccess
     /**
      * Resolve a single dependency
      *
-     * @param ReflectionParameter $parameter
+     * @param \ReflectionParameter $parameter
      * @param array $primitives
      * @param string $className
      * @return mixed

--- a/src/Phaseolies/DI/Exceptions/ImmutableViolationException.php
+++ b/src/Phaseolies/DI/Exceptions/ImmutableViolationException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Phaseolies\DI\Exceptions;
+
+use RuntimeException;
+
+class ImmutableViolationException extends RuntimeException
+{
+    public function __construct(string $class, string $property)
+    {
+        parent::__construct(
+            "Cannot mutate property \${$property} on immutable service [{$class}]. " .
+                "Services marked #[Immutable] are frozen after instantiation."
+        );
+    }
+}

--- a/tests/Application/ContainerTest.php
+++ b/tests/Application/ContainerTest.php
@@ -2801,6 +2801,51 @@ class ContainerTest extends TestCase
         $b = $this->container->get(MockMutableService::class);
         $this->assertEquals(1, $b->count);
     }
+
+    // =========================================================================
+    // SINGLETON BEHAVIOUR WITH IMMUTABLE
+    // =========================================================================
+
+    public function testImmutableSingletonReturnsSameInstance()
+    {
+        $this->container->singleton(MockPaymentService::class);
+
+        $first  = $this->container->get(MockPaymentService::class);
+        $second = $this->container->get(MockPaymentService::class);
+
+        $this->assertSame($first, $second);
+    }
+
+    public function testImmutableSingletonIsFrozenOnFirstResolve()
+    {
+        $this->container->singleton(MockPaymentService::class);
+        $first = $this->container->get(MockPaymentService::class);
+
+        $this->assertTrue($first->isFrozen());
+    }
+
+    public function testImmutableSingletonBlocksMutationOnSecondResolve()
+    {
+        $this->container->singleton(MockPaymentService::class);
+        $this->container->get(MockPaymentService::class);
+
+        $second = $this->container->get(MockPaymentService::class);
+
+        $this->expectException(ImmutableViolationException::class);
+        $second->taxRate = 0.0;
+    }
+
+    public function testImmutableSingletonBothReferencesAreFrozen()
+    {
+        $this->container->singleton(MockPaymentService::class);
+
+        $first  = $this->container->get(MockPaymentService::class);
+        $second = $this->container->get(MockPaymentService::class);
+
+        $this->assertTrue($first->isFrozen());
+        $this->assertTrue($second->isFrozen());
+        $this->assertSame($first, $second);
+    }
 }
 
 function config_mock(string $key, mixed $default = null): mixed

--- a/tests/Application/ContainerTest.php
+++ b/tests/Application/ContainerTest.php
@@ -2429,4 +2429,61 @@ class ContainerTest extends TestCase
 
         $this->assertTrue($service->isFrozen());
     }
+
+    // =========================================================================
+    // PROPERTY READ TESTS
+    // =========================================================================
+
+    public function testReadStringPropertyAfterFreeze()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+        $this->assertEquals('stripe', $service->gateway);
+    }
+
+    public function testReadFloatPropertyAfterFreeze()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+        $this->assertEquals(0.08, $service->taxRate);
+    }
+
+    public function testReadBoolPropertyAfterFreeze()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+        $this->assertFalse($service->liveMode);
+    }
+
+    public function testReadIntPropertyAfterFreeze()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+        $this->assertEquals(3, $service->retries);
+    }
+
+    public function testReadArrayPropertyAfterFreeze()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+        $this->assertEquals(['card', 'bank'], $service->methods);
+    }
+
+    public function testAllPropertiesRetainCorrectValuesAfterFreeze()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+
+        $this->assertEquals('stripe',         $service->gateway);
+        $this->assertEquals(0.08,             $service->taxRate);
+        $this->assertFalse($service->liveMode);
+        $this->assertEquals(3,                $service->retries);
+        $this->assertEquals(['card', 'bank'], $service->methods);
+    }
+
+    public function testIssetOnFrozenPropertyReturnsTrue()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+        $this->assertTrue(isset($service->gateway));
+    }
+
+    public function testIssetOnNonExistentPropertyReturnsFalse()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+        $this->assertFalse(isset($service->nonExistent));
+    }
 }

--- a/tests/Application/ContainerTest.php
+++ b/tests/Application/ContainerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Application;
 
 use Phaseolies\DI\Container;
+use Phaseolies\DI\Exceptions\ImmutableViolationException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Tests\Application\Mock\Abstracts\AbstractClass;
@@ -2538,4 +2539,152 @@ class ContainerTest extends TestCase
         $this->assertEquals(0.00, $result['tax']);
         $this->assertEquals(0.00, $result['total']);
     }
+
+    // =========================================================================
+    // MUTATION BLOCKING TESTS — core immutability contract
+    // =========================================================================
+
+    public function testWriteStringPropertyAfterFreezeThrows()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+
+        $this->expectException(ImmutableViolationException::class);
+        $service->gateway = 'paypal';
+    }
+
+    public function testWriteFloatPropertyAfterFreezeThrows()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+
+        $this->expectException(ImmutableViolationException::class);
+        $service->taxRate = 0.0;
+    }
+
+    public function testWriteBoolPropertyAfterFreezeThrows()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+
+        $this->expectException(ImmutableViolationException::class);
+        $service->liveMode = true;
+    }
+
+    public function testWriteIntPropertyAfterFreezeThrows()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+
+        $this->expectException(ImmutableViolationException::class);
+        $service->retries = 99;
+    }
+
+    public function testWriteArrayPropertyAfterFreezeThrows()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+
+        $this->expectException(ImmutableViolationException::class);
+        $service->methods = ['crypto'];
+    }
+
+    public function testWriteNewDynamicPropertyAfterFreezeThrows()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+
+        $this->expectException(ImmutableViolationException::class);
+        $service->brandNewProp = 'sneaky';
+    }
+
+    public function testUnsetPropertyAfterFreezeThrows()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+
+        $this->expectException(ImmutableViolationException::class);
+        unset($service->gateway);
+    }
+
+    public function testExceptionMessageContainsClassName()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+
+        try {
+            $service->taxRate = 0.0;
+            $this->fail('Expected ImmutableViolationException');
+        } catch (ImmutableViolationException $e) {
+            $this->assertStringContainsString('MockPaymentService', $e->getMessage());
+        }
+    }
+
+    public function testExceptionMessageContainsPropertyName()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+
+        try {
+            $service->taxRate = 0.0;
+            $this->fail('Expected ImmutableViolationException');
+        } catch (ImmutableViolationException $e) {
+            $this->assertStringContainsString('taxRate', $e->getMessage());
+        }
+    }
+
+    public function testExceptionMessageContainsBothClassAndProperty()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+
+        try {
+            $service->gateway = 'paypal';
+            $this->fail('Expected ImmutableViolationException');
+        } catch (ImmutableViolationException $e) {
+            $this->assertStringContainsString('MockPaymentService', $e->getMessage());
+            $this->assertStringContainsString('gateway',            $e->getMessage());
+        }
+    }
+
+    public function testPropertyValueUnchangedAfterBlockedWrite()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+
+        try {
+            $service->taxRate = 0.0;
+        } catch (ImmutableViolationException $e) {
+            // expected — swallow
+        }
+
+        $this->assertEquals(0.08, $service->taxRate);
+    }
+
+    public function testGatewayUnchangedAfterBlockedWrite()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+
+        try {
+            $service->gateway = 'paypal';
+        } catch (ImmutableViolationException $e) {
+            // expected — swallow
+        }
+
+        $this->assertEquals('stripe', $service->gateway);
+    }
+
+    public function testAllWriteAttemptsThrow()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+        $caught  = 0;
+
+        $attempts = [
+            fn() => ($service->gateway  = 'paypal'),
+            fn() => ($service->taxRate  = 0.0),
+            fn() => ($service->liveMode = true),
+            fn() => ($service->retries  = 99),
+        ];
+
+        foreach ($attempts as $attempt) {
+            try {
+                $attempt();
+            } catch (ImmutableViolationException $e) {
+                $caught++;
+            }
+        }
+
+        $this->assertEquals(4, $caught);
+    }
+
+    
 }

--- a/tests/Application/ContainerTest.php
+++ b/tests/Application/ContainerTest.php
@@ -2846,6 +2846,50 @@ class ContainerTest extends TestCase
         $this->assertTrue($second->isFrozen());
         $this->assertSame($first, $second);
     }
+
+    // =========================================================================
+    // TRANSIENT BEHAVIOUR WITH IMMUTABLE
+    // =========================================================================
+
+    public function testImmutableTransientReturnsDifferentInstances()
+    {
+        $first  = $this->container->make(MockPaymentService::class);
+        $second = $this->container->make(MockPaymentService::class);
+
+        $this->assertNotSame($first, $second);
+    }
+
+    public function testImmutableTransientEachInstanceIsFrozen()
+    {
+        $first  = $this->container->make(MockPaymentService::class);
+        $second = $this->container->make(MockPaymentService::class);
+
+        $this->assertTrue($first->isFrozen());
+        $this->assertTrue($second->isFrozen());
+    }
+
+    public function testImmutableTransientMutationBlockedOnBothInstances()
+    {
+        $first  = $this->container->make(MockPaymentService::class);
+        $second = $this->container->make(MockPaymentService::class);
+
+        $firstThrew  = false;
+        $secondThrew = false;
+
+        try {
+            $first->gateway  = 'paypal';
+        } catch (ImmutableViolationException $e) {
+            $firstThrew  = true;
+        }
+        try {
+            $second->gateway = 'paypal';
+        } catch (ImmutableViolationException $e) {
+            $secondThrew = true;
+        }
+
+        $this->assertTrue($firstThrew);
+        $this->assertTrue($secondThrew);
+    }
 }
 
 function config_mock(string $key, mixed $default = null): mixed

--- a/tests/Application/ContainerTest.php
+++ b/tests/Application/ContainerTest.php
@@ -2686,5 +2686,23 @@ class ContainerTest extends TestCase
         $this->assertEquals(4, $caught);
     }
 
-    
+    // =========================================================================
+    // CLONE PROTECTION TESTS
+    // =========================================================================
+
+    public function testCloningFrozenServiceThrows()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+
+        $this->expectException(ImmutableViolationException::class);
+        $cloned = clone $service;
+    }
+
+    public function testCloningUnfrozenServiceIsAllowed()
+    {
+        $service = new MockPaymentService(); // not through container — not frozen yet
+        $cloned  = clone $service;
+
+        $this->assertNotSame($service, $cloned);
+    }
 }

--- a/tests/Application/ContainerTest.php
+++ b/tests/Application/ContainerTest.php
@@ -2,72 +2,74 @@
 
 namespace Tests\Application;
 
-use TypeError;
-use Tests\Application\Mock\StaticCallableClass;
-use Tests\Application\Mock\SimpleClass;
-use Tests\Application\Mock\Services\ConcreteServiceLayer;
-use Tests\Application\Mock\Services\ConcreteService;
-use Tests\Application\Mock\Services\AlternateDependency;
-use Tests\Application\Mock\Repository\ConcreteRepository;
-use Tests\Application\Mock\Providers\TestServiceProvider;
-use Tests\Application\Mock\Providers\ProviderWithDependencies;
-use Tests\Application\Mock\Providers\BootableServiceProvider;
-use Tests\Application\Mock\Providers\BootableProviderWithDependencies;
-use Tests\Application\Mock\Providers\AnotherServiceProvider;
-use Tests\Application\Mock\MixedOptionalClass;
-use Tests\Application\Mock\InvokableClass;
-use Tests\Application\Mock\Interfaces\UnboundInterface;
-use Tests\Application\Mock\Interfaces\TestInterface;
-use Tests\Application\Mock\Interfaces\ServiceLayerInterface;
-use Tests\Application\Mock\Interfaces\ServiceInterface;
-use Tests\Application\Mock\Interfaces\RepositoryInterface;
-use Tests\Application\Mock\Interfaces\DependencyInterface;
-use Tests\Application\Mock\Interfaces\ConnectionInterface;
-use Tests\Application\Mock\ExtendedSimpleClass;
-use Tests\Application\Mock\DeepNestedClass;
-use Tests\Application\Mock\DatabaseConnection;
-use Tests\Application\Mock\Counter;
-use Tests\Application\Mock\Controllers\ControllerClass;
-use Tests\Application\Mock\ConcreteImplementation;
-use Tests\Application\Mock\ConcreteDependency;
-use Tests\Application\Mock\ComplexDependencyGraph;
-use Tests\Application\Mock\ComplexConstructorClass;
-use Tests\Application\Mock\ClassWithoutConstructor;
-use Tests\Application\Mock\ClassWithVariadic;
-use Tests\Application\Mock\ClassWithUnresolvablePrimitive;
-use Tests\Application\Mock\ClassWithUnboundDependency;
-use Tests\Application\Mock\ClassWithTypedVariadic;
-use Tests\Application\Mock\ClassWithString;
-use Tests\Application\Mock\ClassWithOptionalDependency;
-use Tests\Application\Mock\ClassWithOnlyOptionals;
-use Tests\Application\Mock\ClassWithNullableDefault;
-use Tests\Application\Mock\ClassWithNullableClass;
-use Tests\Application\Mock\ClassWithNullable;
-use Tests\Application\Mock\ClassWithNestedDependency;
-use Tests\Application\Mock\ClassWithMultiplePrimitives;
-use Tests\Application\Mock\ClassWithMultipleDependencies;
-use Tests\Application\Mock\ClassWithMixedRequiredOptional;
-use Tests\Application\Mock\ClassWithMixedParams;
-use Tests\Application\Mock\ClassWithManyParams;
-use Tests\Application\Mock\ClassWithInt;
-use Tests\Application\Mock\ClassWithFloat;
-use Tests\Application\Mock\ClassWithEmptyConstructor;
-use Tests\Application\Mock\ClassWithDependencyChain;
-use Tests\Application\Mock\ClassWithDependencyAndVariadic;
-use Tests\Application\Mock\ClassWithDependency;
-use Tests\Application\Mock\ClassWithDefaults;
-use Tests\Application\Mock\ClassWithBool;
-use Tests\Application\Mock\ClassWithArray;
-use Tests\Application\Mock\ClassWithAllDefaults;
-use Tests\Application\Mock\CircularC;
-use Tests\Application\Mock\CircularB;
-use Tests\Application\Mock\CircularA;
-use Tests\Application\Mock\CallableClass;
-use Tests\Application\Mock\ApplicationClass;
-use Tests\Application\Mock\Abstracts\AbstractClass;
-use RuntimeException;
 use Phaseolies\DI\Container;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Tests\Application\Mock\Abstracts\AbstractClass;
+use Tests\Application\Mock\ApplicationClass;
+use Tests\Application\Mock\CallableClass;
+use Tests\Application\Mock\CircularA;
+use Tests\Application\Mock\CircularB;
+use Tests\Application\Mock\CircularC;
+use Tests\Application\Mock\ClassWithAllDefaults;
+use Tests\Application\Mock\ClassWithArray;
+use Tests\Application\Mock\ClassWithBool;
+use Tests\Application\Mock\ClassWithDefaults;
+use Tests\Application\Mock\ClassWithDependency;
+use Tests\Application\Mock\ClassWithDependencyAndVariadic;
+use Tests\Application\Mock\ClassWithDependencyChain;
+use Tests\Application\Mock\ClassWithEmptyConstructor;
+use Tests\Application\Mock\ClassWithFloat;
+use Tests\Application\Mock\ClassWithInt;
+use Tests\Application\Mock\ClassWithManyParams;
+use Tests\Application\Mock\ClassWithMixedParams;
+use Tests\Application\Mock\ClassWithMixedRequiredOptional;
+use Tests\Application\Mock\ClassWithMultipleDependencies;
+use Tests\Application\Mock\ClassWithMultiplePrimitives;
+use Tests\Application\Mock\ClassWithNestedDependency;
+use Tests\Application\Mock\ClassWithNullable;
+use Tests\Application\Mock\ClassWithNullableClass;
+use Tests\Application\Mock\ClassWithNullableDefault;
+use Tests\Application\Mock\ClassWithOnlyOptionals;
+use Tests\Application\Mock\ClassWithOptionalDependency;
+use Tests\Application\Mock\ClassWithoutConstructor;
+use Tests\Application\Mock\ClassWithString;
+use Tests\Application\Mock\ClassWithTypedVariadic;
+use Tests\Application\Mock\ClassWithUnboundDependency;
+use Tests\Application\Mock\ClassWithUnresolvablePrimitive;
+use Tests\Application\Mock\ClassWithVariadic;
+use Tests\Application\Mock\ComplexConstructorClass;
+use Tests\Application\Mock\ComplexDependencyGraph;
+use Tests\Application\Mock\ConcreteDependency;
+use Tests\Application\Mock\ConcreteImplementation;
+use Tests\Application\Mock\Controllers\ControllerClass;
+use Tests\Application\Mock\Counter;
+use Tests\Application\Mock\DatabaseConnection;
+use Tests\Application\Mock\DeepNestedClass;
+use Tests\Application\Mock\ExtendedSimpleClass;
+use Tests\Application\Mock\Interfaces\ConnectionInterface;
+use Tests\Application\Mock\Interfaces\DependencyInterface;
+use Tests\Application\Mock\Interfaces\RepositoryInterface;
+use Tests\Application\Mock\Interfaces\ServiceInterface;
+use Tests\Application\Mock\Interfaces\ServiceLayerInterface;
+use Tests\Application\Mock\Interfaces\TestInterface;
+use Tests\Application\Mock\Interfaces\UnboundInterface;
+use Tests\Application\Mock\InvokableClass;
+use Tests\Application\Mock\MixedOptionalClass;
+use Tests\Application\Mock\Providers\AnotherServiceProvider;
+use Tests\Application\Mock\Providers\BootableProviderWithDependencies;
+use Tests\Application\Mock\Providers\BootableServiceProvider;
+use Tests\Application\Mock\Providers\ProviderWithDependencies;
+use Tests\Application\Mock\Providers\TestServiceProvider;
+use Tests\Application\Mock\Repository\ConcreteRepository;
+use Tests\Application\Mock\Services\AlternateDependency;
+use Tests\Application\Mock\Services\ConcreteService;
+use Tests\Application\Mock\Services\ConcreteServiceLayer;
+use Tests\Application\Mock\Services\MockPaymentService;
+use Tests\Application\Mock\SimpleClass;
+use Tests\Application\Mock\StaticCallableClass;
+use TypeError;
+
 class ContainerTest extends TestCase
 {
     protected Container $container;
@@ -970,7 +972,7 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(ConcreteDependency::class, $instance->dependency);
     }
 
-     public function testMakeWithParameters()
+    public function testMakeWithParameters()
     {
         $instance = $this->container->make(ClassWithString::class, ['name' => 'Test']);
         $this->assertEquals('Test', $instance->name);
@@ -1130,7 +1132,7 @@ class ContainerTest extends TestCase
 
     public function testIsResolvingDuringResolution()
     {
-        $this->container->bind('service', function() {
+        $this->container->bind('service', function () {
             return $this->container->isResolving('service') ? 'resolving' : 'not';
         });
 
@@ -1325,7 +1327,7 @@ class ContainerTest extends TestCase
 
     public function testCallableWithContainerParameter()
     {
-        $this->container->bind('test', function(Container $container) {
+        $this->container->bind('test', function (Container $container) {
             return $container->has('dependency') ? 'has' : 'not';
         });
 
@@ -1335,7 +1337,7 @@ class ContainerTest extends TestCase
 
     public function testCallableWithParameters()
     {
-        $this->container->bind('test', function(Container $c, array $params) {
+        $this->container->bind('test', function (Container $c, array $params) {
             return $params['value'] ?? 'default';
         });
 
@@ -1346,7 +1348,7 @@ class ContainerTest extends TestCase
     public function testNestedCallableResolution()
     {
         $this->container->bind('inner', fn() => 'inner_value');
-        $this->container->bind('outer', function(Container $c) {
+        $this->container->bind('outer', function (Container $c) {
             return $c->get('inner') . '_outer';
         });
 
@@ -1439,11 +1441,11 @@ class ContainerTest extends TestCase
 
     public function testNestedContainerCalls()
     {
-        $this->container->bind('level1', function(Container $c) {
+        $this->container->bind('level1', function (Container $c) {
             return $c->get('level2') . ':1';
         });
 
-        $this->container->bind('level2', function(Container $c) {
+        $this->container->bind('level2', function (Container $c) {
             return $c->get('level3') . ':2';
         });
 
@@ -1570,7 +1572,7 @@ class ContainerTest extends TestCase
     // COMPLEX SCENARIOS
     //====================================
 
-     public function testDependencyGraphWithSingletons()
+    public function testDependencyGraphWithSingletons()
     {
         $this->container->singleton(DependencyInterface::class, ConcreteDependency::class);
         $this->container->bind(ServiceInterface::class, ConcreteService::class);
@@ -1585,7 +1587,7 @@ class ContainerTest extends TestCase
     public function testComplexDependencyWithExtend()
     {
         $this->container->bind(DependencyInterface::class, ConcreteDependency::class);
-        $this->container->extend(DependencyInterface::class, function($dep, $c) {
+        $this->container->extend(DependencyInterface::class, function ($dep, $c) {
             $dep->extended = true;
             return $dep;
         });
@@ -1612,11 +1614,11 @@ class ContainerTest extends TestCase
         $this->assertEquals([], $instance->items);
     }
 
-   //========================================
-   // EDGE CASES
-   //========================================
+    //========================================
+    // EDGE CASES
+    //========================================
 
-   public function testBindingWithSpecialCharacters()
+    public function testBindingWithSpecialCharacters()
     {
         $this->container->bind('service.name', fn() => 'value');
         $this->assertEquals('value', $this->container->get('service.name'));
@@ -1732,7 +1734,7 @@ class ContainerTest extends TestCase
 
     public function testDependencyWithFactory()
     {
-        $this->container->bind(DependencyInterface::class, function() {
+        $this->container->bind(DependencyInterface::class, function () {
             static $counter = 0;
             $dep = new ConcreteDependency();
             $dep->id = ++$counter;
@@ -1747,7 +1749,7 @@ class ContainerTest extends TestCase
 
     public function testSingletonWithFactory()
     {
-        $this->container->singleton(DependencyInterface::class, function() {
+        $this->container->singleton(DependencyInterface::class, function () {
             static $counter = 0;
             $dep = new ConcreteDependency();
             $dep->id = ++$counter;
@@ -1764,7 +1766,7 @@ class ContainerTest extends TestCase
     public function testExtendWithComplexLogic()
     {
         $this->container->bind('service', fn() => ['base' => true]);
-        $this->container->extend('service', function($original, $c) {
+        $this->container->extend('service', function ($original, $c) {
             $original['extended'] = true;
             $original['dependency'] = $c->has('dep') ? 'yes' : 'no';
             return $original;
@@ -1835,7 +1837,7 @@ class ContainerTest extends TestCase
     {
         $this->container->bind(DependencyInterface::class, ConcreteDependency::class);
 
-        $result = $this->container->call(function(DependencyInterface $dep) {
+        $result = $this->container->call(function (DependencyInterface $dep) {
             return get_class($dep);
         });
 
@@ -1986,7 +1988,7 @@ class ContainerTest extends TestCase
         $this->assertTrue($this->container->has('provider_service'));
     }
 
-     public function testServiceProviderBootReceivesDependencies()
+    public function testServiceProviderBootReceivesDependencies()
     {
         $this->container->bind(DependencyInterface::class, ConcreteDependency::class);
         $provider = new BootableProviderWithDependencies();
@@ -2027,7 +2029,7 @@ class ContainerTest extends TestCase
     public function testExtendPreservesSingletonBehavior()
     {
         $this->container->singleton('service', fn() => new \stdClass());
-        $this->container->extend('service', function($obj) {
+        $this->container->extend('service', function ($obj) {
             $obj->extended = true;
             return $obj;
         });
@@ -2042,7 +2044,7 @@ class ContainerTest extends TestCase
     public function testExtendPreservesTransientBehavior()
     {
         $this->container->bind('service', fn() => new \stdClass());
-        $this->container->extend('service', function($obj) {
+        $this->container->extend('service', function ($obj) {
             $obj->extended = true;
             return $obj;
         });
@@ -2197,7 +2199,7 @@ class ContainerTest extends TestCase
 
     public function testCallWithClosureBindTo()
     {
-        $closure = function() {
+        $closure = function () {
             return $this->container->has('test') ? 'yes' : 'no';
         };
 
@@ -2370,7 +2372,7 @@ class ContainerTest extends TestCase
         // Setup complex scenario
         $this->container->singleton(DependencyInterface::class, ConcreteDependency::class);
         $this->container->bind(ServiceInterface::class, ConcreteService::class);
-        $this->container->extend(DependencyInterface::class, function($dep) {
+        $this->container->extend(DependencyInterface::class, function ($dep) {
             $dep->extended = true;
             return $dep;
         });
@@ -2385,5 +2387,46 @@ class ContainerTest extends TestCase
         // Check alias
         $aliased = $this->container->get('service');
         $this->assertInstanceOf(ConcreteService::class, $aliased);
+    }
+
+    // =========================================================================
+    // FREEZE STATE TESTS
+    // =========================================================================
+
+    public function testServiceIsNotFrozenBeforeContainerResolves()
+    {
+        $service = new MockPaymentService();
+        $this->assertFalse($service->isFrozen());
+    }
+
+    public function testServiceIsFrozenAfterMake()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+        $this->assertTrue($service->isFrozen());
+    }
+
+    public function testServiceIsFrozenAfterSingletonResolves()
+    {
+        $this->container->singleton(MockPaymentService::class);
+        $service = $this->container->get(MockPaymentService::class);
+        $this->assertTrue($service->isFrozen());
+    }
+
+    public function testManualFreezeWorks()
+    {
+        $service = new MockPaymentService();
+        $this->assertFalse($service->isFrozen());
+        $service->freeze();
+        $this->assertTrue($service->isFrozen());
+    }
+
+    public function testFreezeIsIdempotent()
+    {
+        $service = new MockPaymentService();
+        $service->freeze();
+        // $service->freeze(); // second call must not throw
+        // Phaseolies\DI\Exceptions\ImmutableViolationException: Cannot mutate property $gateway on immutable service [Tests\Application\Mock\Services\MockPaymentService]. Services marked #[Immutable] are frozen after instantiation.
+
+        $this->assertTrue($service->isFrozen());
     }
 }

--- a/tests/Application/ContainerTest.php
+++ b/tests/Application/ContainerTest.php
@@ -66,6 +66,7 @@ use Tests\Application\Mock\Repository\ConcreteRepository;
 use Tests\Application\Mock\Services\AlternateDependency;
 use Tests\Application\Mock\Services\ConcreteService;
 use Tests\Application\Mock\Services\ConcreteServiceLayer;
+use Tests\Application\Mock\Services\MockMutableService;
 use Tests\Application\Mock\Services\MockPaymentService;
 use Tests\Application\Mock\SimpleClass;
 use Tests\Application\Mock\StaticCallableClass;
@@ -2705,4 +2706,104 @@ class ContainerTest extends TestCase
 
         $this->assertNotSame($service, $cloned);
     }
+
+
+    // =========================================================================
+    // PRE-FREEZE (BOOT WINDOW) TESTS
+    // =========================================================================
+
+    public function testWriteBeforeFreezeSucceeds()
+    {
+        $service          = new MockPaymentService();
+        $service->gateway = 'paypal'; // not frozen — must succeed
+
+        $this->assertEquals('paypal', $service->gateway);
+    }
+
+    public function testMultipleWritesBeforeFreezeAllSucceed()
+    {
+        $service           = new MockPaymentService();
+        $service->gateway  = 'paypal';
+        $service->taxRate  = 0.15;
+        $service->liveMode = true;
+
+        $this->assertEquals('paypal', $service->gateway);
+        $this->assertEquals(0.15,     $service->taxRate);
+        $this->assertTrue($service->liveMode);
+    }
+
+    public function testFreezeSnapshotsValuesSetBeforeFreeze()
+    {
+        $service           = new MockPaymentService();
+        $service->gateway  = 'braintree';
+        $service->taxRate  = 0.10;
+        $service->liveMode = true;
+        $service->freeze();
+
+        $this->assertEquals('braintree', $service->gateway);
+        $this->assertEquals(0.10,        $service->taxRate);
+        $this->assertTrue($service->liveMode);
+    }
+
+    public function testWriteAfterManualFreezeThrows()
+    {
+        $service          = new MockPaymentService();
+        $service->gateway = 'braintree'; // ok — pre-freeze
+        $service->freeze();
+
+        $this->expectException(ImmutableViolationException::class);
+        $service->gateway = 'paypal'; // must throw — post-freeze
+    }
+
+    public function testServiceProviderBootWindowPattern()
+    {
+        // Simulates a ServiceProvider configuring the service before binding
+        $payment          = new MockPaymentService();
+        $payment->gateway = config_mock('payment.gateway', 'braintree');
+        $payment->taxRate = config_mock('payment.tax_rate', 0.15);
+
+        $this->container->singleton(MockPaymentService::class, fn() => $payment);
+
+        $resolved = $this->container->get(MockPaymentService::class);
+
+        $this->assertEquals('braintree', $resolved->gateway);
+        $this->assertEquals(0.15,        $resolved->taxRate);
+    }
+
+    // =========================================================================
+    // MUTABLE SERVICE CONTROL — non-immutable services must be unaffected
+    // =========================================================================
+
+    public function testMutableServiceCanBeModified()
+    {
+        $service        = $this->container->make(MockMutableService::class);
+        $service->state = 'modified';
+
+        $this->assertEquals('modified', $service->state);
+    }
+
+    public function testMutableServiceMethodMutatesState()
+    {
+        $service = $this->container->make(MockMutableService::class);
+        $service->increment();
+        $service->increment();
+
+        $this->assertEquals(2, $service->count);
+    }
+
+    public function testMutableSingletonStateIsShared()
+    {
+        $this->container->singleton(MockMutableService::class);
+
+        $a = $this->container->get(MockMutableService::class);
+        $a->increment();
+
+        $b = $this->container->get(MockMutableService::class);
+        $this->assertEquals(1, $b->count);
+    }
+}
+
+function config_mock(string $key, mixed $default = null): mixed
+{
+    return $default;
 }

--- a/tests/Application/ContainerTest.php
+++ b/tests/Application/ContainerTest.php
@@ -66,6 +66,7 @@ use Tests\Application\Mock\Repository\ConcreteRepository;
 use Tests\Application\Mock\Services\AlternateDependency;
 use Tests\Application\Mock\Services\ConcreteService;
 use Tests\Application\Mock\Services\ConcreteServiceLayer;
+use Tests\Application\Mock\Services\MockMailerService;
 use Tests\Application\Mock\Services\MockMutableService;
 use Tests\Application\Mock\Services\MockPaymentService;
 use Tests\Application\Mock\Services\MockServiceWithConstructor;
@@ -2935,6 +2936,50 @@ class ContainerTest extends TestCase
         $this->assertEquals('default', $service->name);
         $this->assertEquals(0,         $service->value);
         $this->assertTrue($service->isFrozen());
+    }
+
+    // =========================================================================
+    // MULTIPLE IMMUTABLE SERVICES
+    // =========================================================================
+
+    public function testMultipleImmutableServicesAreIndependentlyFrozen()
+    {
+        $payment = $this->container->make(MockPaymentService::class);
+        $mailer  = $this->container->make(MockMailerService::class);
+
+        $this->assertTrue($payment->isFrozen());
+        $this->assertTrue($mailer->isFrozen());
+    }
+
+    public function testMultipleImmutableServicesGuardedIndependently()
+    {
+        $payment = $this->container->make(MockPaymentService::class);
+        $mailer  = $this->container->make(MockMailerService::class);
+
+        $paymentThrew = false;
+        $mailerThrew  = false;
+
+        try {
+            $payment->gateway  = 'paypal';
+        } catch (ImmutableViolationException $e) {
+            $paymentThrew = true;
+        }
+        try {
+            $mailer->host      = 'smtp.hacked.com';
+        } catch (ImmutableViolationException $e) {
+            $mailerThrew  = true;
+        }
+
+        $this->assertTrue($paymentThrew);
+        $this->assertTrue($mailerThrew);
+    }
+
+    public function testMailerServiceReadsWorkAfterFreeze()
+    {
+        $mailer = $this->container->make(MockMailerService::class);
+
+        $this->assertEquals('smtp.example.com', $mailer->host);
+        $this->assertEquals(587,                $mailer->port);
     }
 }
 

--- a/tests/Application/ContainerTest.php
+++ b/tests/Application/ContainerTest.php
@@ -68,6 +68,7 @@ use Tests\Application\Mock\Services\ConcreteService;
 use Tests\Application\Mock\Services\ConcreteServiceLayer;
 use Tests\Application\Mock\Services\MockMutableService;
 use Tests\Application\Mock\Services\MockPaymentService;
+use Tests\Application\Mock\Services\MockServiceWithConstructor;
 use Tests\Application\Mock\SimpleClass;
 use Tests\Application\Mock\StaticCallableClass;
 use TypeError;
@@ -2889,6 +2890,51 @@ class ContainerTest extends TestCase
 
         $this->assertTrue($firstThrew);
         $this->assertTrue($secondThrew);
+    }
+
+    // =========================================================================
+    // CONSTRUCTOR INJECTION WITH IMMUTABLE
+    // =========================================================================
+
+    public function testImmutableServiceWithConstructorArgsIsFrozen()
+    {
+        $service = $this->container->make(MockServiceWithConstructor::class, [
+            'name'  => 'doppar',
+            'value' => 42,
+        ]);
+
+        $this->assertTrue($service->isFrozen());
+    }
+
+    public function testImmutableServiceWithConstructorArgsPreservesValues()
+    {
+        $service = $this->container->make(MockServiceWithConstructor::class, [
+            'name'  => 'doppar',
+            'value' => 42,
+        ]);
+
+        $this->assertEquals('doppar', $service->name);
+        $this->assertEquals(42,       $service->value);
+    }
+
+    public function testImmutableServiceWithConstructorArgsMutationThrows()
+    {
+        $service = $this->container->make(MockServiceWithConstructor::class, [
+            'name'  => 'doppar',
+            'value' => 42,
+        ]);
+
+        $this->expectException(ImmutableViolationException::class);
+        $service->name = 'hacked';
+    }
+
+    public function testImmutableServiceConstructorDefaultsPreserved()
+    {
+        $service = $this->container->make(MockServiceWithConstructor::class);
+
+        $this->assertEquals('default', $service->name);
+        $this->assertEquals(0,         $service->value);
+        $this->assertTrue($service->isFrozen());
     }
 }
 

--- a/tests/Application/ContainerTest.php
+++ b/tests/Application/ContainerTest.php
@@ -2486,4 +2486,56 @@ class ContainerTest extends TestCase
         $service = $this->container->make(MockPaymentService::class);
         $this->assertFalse(isset($service->nonExistent));
     }
+
+    // =========================================================================
+    // METHOD CALL TESTS
+    // =========================================================================
+
+    public function testMethodCallAfterFreezeWorks()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+        $result  = $service->charge(100.00);
+
+        $this->assertEquals('stripe',  $result['gateway']);
+        $this->assertEquals(100.00,    $result['amount']);
+        $this->assertEquals(8.00,      $result['tax']);
+        $this->assertEquals(108.00,    $result['total']);
+        $this->assertEquals('charged', $result['status']);
+    }
+
+    public function testMethodThatReadsStringPropertyInternallyWorks()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+        $this->assertEquals('stripe', $service->getGateway());
+    }
+
+    public function testMethodThatReadsBoolPropertyInternallyWorks()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+        $this->assertFalse($service->isLive());
+    }
+
+    public function testMethodThatReadsIntPropertyInternallyWorks()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+        $this->assertEquals(3, $service->getRetries());
+    }
+
+    public function testChargeComputesTaxCorrectly()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+        $result  = $service->charge(200.00);
+
+        $this->assertEquals(16.00,  $result['tax']);
+        $this->assertEquals(216.00, $result['total']);
+    }
+
+    public function testChargeWithZeroAmount()
+    {
+        $service = $this->container->make(MockPaymentService::class);
+        $result  = $service->charge(0.00);
+
+        $this->assertEquals(0.00, $result['tax']);
+        $this->assertEquals(0.00, $result['total']);
+    }
 }

--- a/tests/Application/Mock/Services/MockImmutableWithoutTrait.php
+++ b/tests/Application/Mock/Services/MockImmutableWithoutTrait.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tests\Application\Mock\Services;
+
+use Phaseolies\DI\Attributes\Immutable;
+
+#[Immutable]
+class MockImmutableWithoutTrait
+{
+    // Has #[Immutable] but is MISSING the trait — should produce a helpful RuntimeException
+    public string $name = 'test';
+}

--- a/tests/Application/Mock/Services/MockMailerService.php
+++ b/tests/Application/Mock/Services/MockMailerService.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Application\Mock\Services;
+
+use Phaseolies\DI\Attributes\Immutable;
+use Phaseolies\DI\Concerns\EnforcesImmutability;
+
+#[Immutable]
+class MockMailerService
+{
+    use EnforcesImmutability;
+
+    public string $host = 'smtp.example.com';
+    public int $port = 587;
+}

--- a/tests/Application/Mock/Services/MockMutableService.php
+++ b/tests/Application/Mock/Services/MockMutableService.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Application\Mock\Services;
+
+class MockMutableService
+{
+    public string $state = 'initial';
+    public int    $count = 0;
+
+    public function increment(): void
+    {
+        $this->count++;
+    }
+}

--- a/tests/Application/Mock/Services/MockPaymentService.php
+++ b/tests/Application/Mock/Services/MockPaymentService.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Application\Mock\Services;
+
+use Phaseolies\DI\Attributes\Immutable;
+use Phaseolies\DI\Concerns\EnforcesImmutability;
+
+#[Immutable]
+class MockPaymentService
+{
+    use EnforcesImmutability;
+
+    public string $gateway  = 'stripe';
+    public float  $taxRate  = 0.08;
+    public bool   $liveMode = false;
+    public int    $retries  = 3;
+    public array  $methods  = ['card', 'bank'];
+
+    public function charge(float $amount): array
+    {
+        $tax   = round($amount * $this->taxRate, 2);
+        $total = round($amount + $tax, 2);
+        return [
+            'gateway' => $this->gateway,
+            'amount'  => $amount,
+            'tax'     => $tax,
+            'total'   => $total,
+            'status'  => 'charged',
+        ];
+    }
+
+    public function getGateway(): string
+    {
+        return $this->gateway;
+    }
+    public function isLive(): bool
+    {
+        return $this->liveMode;
+    }
+    public function getRetries(): int
+    {
+        return $this->retries;
+    }
+}

--- a/tests/Application/Mock/Services/MockServiceWithConstructor.php
+++ b/tests/Application/Mock/Services/MockServiceWithConstructor.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Application\Mock\Services;
+
+use Phaseolies\DI\Attributes\Immutable;
+use Phaseolies\DI\Concerns\EnforcesImmutability;
+
+#[Immutable]
+class MockServiceWithConstructor
+{
+    use EnforcesImmutability;
+
+    public string $name;
+    public int $value;
+
+    public function __construct(string $name = 'default', int $value = 0)
+    {
+        $this->name = $name;
+        $this->value = $value;
+    }
+}


### PR DESCRIPTION
Introduces a container-enforced service lifecycle boundary. Services marked `#[Immutable]` are fully configurable during the boot phase, then permanently frozen for the entire request lifecycle — at the object level, not the container level.

## Motivation
### The Problem With Mutable Singletons
In every major PHP framework today, singleton services are registered once but remain permanently mutable. Nothing prevents a controller, middleware from silently corrupting shared service state mid-request.

## Example:

```php
// Registered as a singleton in AppServiceProvider
$payment = new PaymentService('stripe', 0.08);

// Somewhere in a middleware, 3 files away...
$payment->taxRate = 0.0;    // ← no error. runs silently.
$payment->gateway  = 'paypal'; // ← corrupts every request after this

// Every subsequent inject of PaymentService now gets broken state.
// No exception. No log. No trace. Just wrong behavior.
```

This is not hypothetical. It is a class of bug that is extremely hard to trace because the mutation and the symptom are separated by request boundaries, middleware layers, and injection chains. The only defence today is code review and convention — neither is enforced at runtime.

## What This PR Does
### A Clear Lifecycle Boundary
This PR introduces a two-phase service lifecycle enforced at the object level by the container:

| Phase | Name    | What Happens                                                                                       | Key Behavior                               |
|-------|---------|----------------------------------------------------------------------------------------------------|--------------------------------------------|
| 1     | Boot    | Service is created and configured in a ServiceProvider. Properties are writable. Framework sets up gateway, tax rate, credentials from config/env. | Properties can be freely modified during setup. |
| 2     | Freeze  | Container calls freeze() after build() completes. Public properties are snapshotted and unset. Magic methods take over all future access. | Object becomes immutable; state is locked. |
| 3     | Runtime | Service is injected into controllers, closures, middleware. All reads work normally. Any write attempt throws ImmutableViolationException immediately. | Safe read-only usage; writes are blocked. |

## What Developers Write
The entire public-facing API is a single attribute and a trait. Nothing else is required from the developer.

```php
namespace App\Services;

use Phaseolies\DI\Attributes\Immutable;
use Phaseolies\DI\Concerns\EnforcesImmutability;

#[Immutable]
class PaymentService
{
    use EnforcesImmutability;
 
    public string $gateway  = 'stripe';
    public float  $taxRate  = 0.08;
    public bool   $liveMode = false;

    public function charge(float $amount): array
    {
        return [
            'total'   => $amount * (1 + $this->taxRate),
            'gateway' => $this->gateway,
        ];
    }
}
```

Mutable during boot only
```php
class AppServiceProvider extends ServiceProvider
{
    public function boot(): void
    {
        $payment = new PaymentService();
        $payment->gateway  = config('payment.gateway');   // ✓ writable
        $payment->taxRate  = config('payment.tax_rate'); // ✓ writable
        $payment->liveMode = env('APP_ENV') === 'production';

        $this->app->singleton(PaymentService::class, fn() => $payment);
        // container calls freeze() → permanently locked after this point
    }
}
```

Mutations blocked
```php
class PaymentController
{
    public function __construct(
        private readonly PaymentService $payment
    ) {}

    public function update(Request $request): array
    {
        $this->payment->charge($request->amount);  // method calls work
        echo $this->payment->gateway;             // reads work

        $this->payment->taxRate = 0.0;          // ✗ ImmutableViolationException
    }
}
```

## How This Differs From Existing Solutions
| readonly class | Doppar #[Immutable] |
|----------------|-------------------|
| ✅ Properties frozen after construction | ✅ Properties frozen after container boot |
| ✅ Engine-level enforcement — fastest possible | ✅ Configurable from config()/env() during boot |
| ✅ Works with constructor promotion | ✅ Works with ServiceProvider pattern |
| ❌ Cannot configure from config()/env() post-construction | ✅ Custom ImmutableViolationException with actionable message |
| ✅ All values must be known at new-time | ✅ Clear boot window — mutable during setup, frozen at runtime |
| ❌ Cannot be used with ServiceProvider configuration pattern | ✅ Works in controllers, closures, middleware — all paths |
| ❌ No custom exception — throws generic Error | ✅ Reads work transparently — zero API changes for consumers |
| ❌ No boot window — immutable from first line | ✅ Opt-in per service — no global impact |

## The critical distinction from readonly class
PHP's readonly freezes on construction. You cannot do this:
```php
readonly class PaymentService
{
    public function __construct(
        public string $gateway,
        public float  $taxRate,
    ) {}
}

// In ServiceProvider — THIS IS IMPOSSIBLE with readonly:
$payment = new PaymentService('', 0);     // must know values at new-time
$payment->gateway = config('payment.gateway'); // Error: readonly property

// With Doppar #[Immutable] — this works perfectly:
$payment = new PaymentService();
$payment->gateway = config('payment.gateway');   // writable during boot
$payment->taxRate = config('payment.tax_rate'); // writable during boot
// container registers singleton → freeze() called → locked forever
```

## The exception message
```php
Phaseolies\DI\Exceptions\ImmutableViolationException
Cannot mutate property $taxRate on immutable service [App\Services\PaymentService].
Services marked #[Immutable] are frozen after instantiatio
```

PHP offers no runtime method injection, no monkey patching, and no transparent proxy mechanism without extensions (e.g. ocramius/proxy-manager generates separate class files at build time). The freeze() + unset() approach works with PHP's semantics rather than against them.