### PR TITLE
feat: Add #[Throttle] Attribute for Rate Limiting

### DIFF
--- a/src/Phaseolies/Support/Router.php
+++ b/src/Phaseolies/Support/Router.php
@@ -1054,6 +1054,28 @@ class Router extends Kernel
     }
 
     /**
+     * Process Throttle attribute from controller method
+     *
+     * @param \ReflectionMethod $method
+     * @return void
+     */
+    protected function processThrottleAttribute(\ReflectionMethod $method): void
+    {
+        $throttleAttributes = $method->getAttributes(\Phaseolies\Utilities\Attributes\Throttle::class);
+
+        if (empty($throttleAttributes)) {
+            return;
+        }
+
+        $throttle = $throttleAttributes[0]->newInstance();
+
+        // Convert to middleware format: throttle:60,1
+        $middlewareKey = "throttle:{$throttle->maxAttempts},{$throttle->decayMinutes}";
+
+        $this->middleware($middlewareKey);
+    }
+
+    /**
      * Handle attributes based middleware defination
      *
      * @param array $callback
@@ -1080,6 +1102,7 @@ class Router extends Kernel
             $methodMiddlewareAttributes = $method->getAttributes(Middleware::class);
             $this->processAttributesMiddlewares($methodMiddlewareAttributes);
             $this->processRateLimitAnnotation($method);
+            $this->processThrottleAttribute($method);
         }
     }
 

--- a/src/Phaseolies/Utilities/Attributes/Throttle.php
+++ b/src/Phaseolies/Utilities/Attributes/Throttle.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Phaseolies\Utilities\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final class Throttle
+{
+    /**
+     * Rate limit configuration
+     *
+     * @param int $maxAttempts Maximum requests allowed
+     * @param int $decayMinutes Time window in minutes
+     */
+    public function __construct(
+        public int $maxAttempts = 60,
+        public int $decayMinutes = 1
+    ) {}
+}


### PR DESCRIPTION
Adds a new `#[Throttle]` attribute for declarative rate limiting on controller methods, providing a modern alternative to docblock annotations and route-level rate limit parameters.

Currently, Doppar supports rate limiting through:
- Docblock annotations - `@RateLimit 60/1`
- Route attribute parameters - `#[Route('/api/users', rateLimit: 60)]`

This PR introduces a new `#[Throttle]` attribute for declarative rate limiting on controller methods.

## Before (Docblock Annotation)
```php
/**
 * Search API endpoint
 * 
 * @RateLimit 60/1
 */
#[Route('/api/search', methods: ['GET'])]
public function search(Request $request)
{
    return SearchService::query($request->input('q'));
}
```

## Before (Route Attribute Parameter)
```php
#[Route('/api/search', methods: ['GET'], rateLimit: 60, rateLimitDecay: 1)]
public function search(Request $request)
{
    return SearchService::query($request->input('q'));
}
```

## Before (With Middleware)
```php
#[Route('/api/search', methods: ['GET'], middleware: ['throttle:60,1'])]
public function search(Request $request)
{
    return SearchService::query($request->input('q'));
}
```

## After (New #[Throttle] Attribute) 
```php
#[Route('/api/search', methods: ['GET'])]
#[Throttle(maxAttempts: 10, decayMinutes: 1)]
public function search(Request $request)
{
    return SearchService::query($request->input('q'));
}
```

Result: 10 requests per minute

In a future major version, we may deprecate docblock annotations and route parameters in favor of attributes.