### PR TITLE
Remove cache from can() method

### DIFF
--- a/src/Phaseolies/Auth/Security/Authenticate.php
+++ b/src/Phaseolies/Auth/Security/Authenticate.php
@@ -378,9 +378,10 @@ class Authenticate
      * Check if the user is authorized to do some action.
      *
      * @param string $scope
+     * @param mixed  ...$arguments
      * @return bool
      */
-    public function can(string $scope): bool
+    public function can(string $scope, mixed ...$arguments): bool
     {
         if (!class_exists(\Doppar\Authorizer\Support\Facades\Guard::class)) {
             throw new \RuntimeException(
@@ -388,11 +389,7 @@ class Authenticate
             );
         }
 
-        return (bool) Cache::stash(
-            "auth_scope_{$scope}_" . $this->id(),
-            3600,
-            fn() => \Doppar\Authorizer\Support\Facades\Guard::allows($scope)
-        );
+        return (bool) \Doppar\Authorizer\Support\Facades\Guard::allows($scope, ...$arguments);
     }
 
     /**

--- a/src/Phaseolies/Auth/Security/Authenticate.php
+++ b/src/Phaseolies/Auth/Security/Authenticate.php
@@ -31,13 +31,6 @@ class Authenticate
     private static $versionCheckCache = [];
 
     /**
-     * Ability request level cache
-     *
-     * @var array
-     */
-    private array $abilityCache = [];
-
-    /**
      * Get the current authenticated user
      *
      * @var Model|null

--- a/src/Phaseolies/Auth/Security/Authenticate.php
+++ b/src/Phaseolies/Auth/Security/Authenticate.php
@@ -31,6 +31,13 @@ class Authenticate
     private static $versionCheckCache = [];
 
     /**
+     * Ability check request-level memoization
+     *
+     * @var array
+     */
+    private array $abilityCache = [];
+
+    /**
      * Get the current authenticated user
      *
      * @var Model|null
@@ -389,7 +396,13 @@ class Authenticate
             );
         }
 
-        return (bool) \Doppar\Authorizer\Support\Facades\Guard::allows($scope, ...$arguments);
+        $key = $scope . ':' . md5(serialize($arguments));
+
+        if (!array_key_exists($key, $this->abilityCache)) {
+            $this->abilityCache[$key] = \Doppar\Authorizer\Support\Facades\Guard::allows($scope, ...$arguments);
+        }
+
+        return (bool) $this->abilityCache[$key];
     }
 
     /**

--- a/src/Phaseolies/Auth/Security/Authenticate.php
+++ b/src/Phaseolies/Auth/Security/Authenticate.php
@@ -31,7 +31,7 @@ class Authenticate
     private static $versionCheckCache = [];
 
     /**
-     * Ability check request-level memoization
+     * Ability request level cache
      *
      * @var array
      */
@@ -396,13 +396,7 @@ class Authenticate
             );
         }
 
-        $key = $scope . ':' . md5(serialize($arguments));
-
-        if (!array_key_exists($key, $this->abilityCache)) {
-            $this->abilityCache[$key] = \Doppar\Authorizer\Support\Facades\Guard::allows($scope, ...$arguments);
-        }
-
-        return (bool) $this->abilityCache[$key];
+        return (bool) \Doppar\Authorizer\Support\Facades\Guard::allows($scope, ...$arguments);
     }
 
     /**


### PR DESCRIPTION
The memoization idea only makes sense if can() is called repeatedly with identical arguments in the same request, which in practice rarely happens. So removed it.