### PR TITLE
feat: custom Odo template directives via Odo::stamp()

### DIFF
--- a/src/Phaseolies/Support/Odo.php
+++ b/src/Phaseolies/Support/Odo.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phaseolies\Support\Odo;
+namespace Phaseolies\Support;
 
 use Phaseolies\Http\Controllers\Controller;
 

--- a/src/Phaseolies/Support/Odo/Odo.php
+++ b/src/Phaseolies/Support/Odo/Odo.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Phaseolies\Support\Odo;
+
+use Phaseolies\Http\Controllers\Controller;
+
+class Odo
+{
+    /**
+     * Register a custom odo stamp
+     *
+     * @param string $name
+     * @param \Closure $callback
+     * @return void
+     */
+    public static function stamp(string $name, \Closure $callback): void
+    {
+        if (!preg_match('/^\w+(?:->\w+)?$/x', $name)) {
+            throw new \InvalidArgumentException(
+                "The directive name [{$name}] is not valid. Directive names " .
+                    "must only contain alphanumeric characters and underscores."
+            );
+        }
+
+        Controller::$directives[$name] = $callback;
+    }
+
+    /**
+     * Get all registered directives
+     *
+     * @return array
+     */
+    public static function getDirectives(): array
+    {
+        return Controller::$directives;
+    }
+
+    /**
+     * Check if a directive exists
+     *
+     * @param string $name
+     * @return bool
+     */
+    public static function hasDirective(string $name): bool
+    {
+        return isset(Controller::$directives[$name]);
+    }
+
+    /**
+     * Remove a directive
+     *
+     * @param string $name
+     * @return void
+     */
+    public static function forgetDirective(string $name): void
+    {
+        unset(Controller::$directives[$name]);
+    }
+}

--- a/src/Phaseolies/Support/Odo/OdoCompiler.php
+++ b/src/Phaseolies/Support/Odo/OdoCompiler.php
@@ -37,7 +37,7 @@ trait OdoCompiler
      *
      * @var array
      */
-    protected static $directives = [];
+    public static $directives = [];
 
     /**
      * Compile ODO statements (directives like #if, #foreach, etc.)
@@ -55,6 +55,7 @@ trait OdoCompiler
 
         return preg_replace_callback($pattern, function ($match) {
             $directiveName = $match[1];
+            $isCompiled = false;
 
             // Handle escaped directives (##directive becomes #directive)
             if (str_starts_with($directiveName, $this->directivePrefix)) {
@@ -64,25 +65,26 @@ trait OdoCompiler
             // Check for built-in compile methods
             if (method_exists($this, $method = 'compile' . ucfirst($directiveName))) {
                 $match[0] = $this->{$method}(isset($match[3]) ? $match[3] : '');
+                $isCompiled = true;
             }
 
             // Check for custom directives
             if (isset(self::$directives[$directiveName])) {
                 $expression = isset($match[3]) ? $match[3] : '';
 
-                // Remove surrounding parentheses
                 if ((isset($expression[0]) && '(' === $expression[0])
                     && (isset($expression[strlen($expression) - 1]) && ')' === $expression[strlen($expression) - 1])
                 ) {
                     $expression = substr($expression, 1, -1);
                 }
 
-                if ($expression !== '' && $expression !== '()') {
-                    $match[0] = call_user_func(self::$directives[$directiveName], trim($expression));
-                }
+                $match[0] = call_user_func(self::$directives[$directiveName], trim($expression));
+                $isCompiled = true;
             }
 
-            return isset($match[3]) ? $match[0] : $match[0] . $match[2];
+            // If compiled, return as-is
+            // If not compiled and has no expression, preserve original with whitespace
+            return $isCompiled ? $match[0] : (isset($match[3]) ? $match[0] : $match[0] . $match[2]);
         }, $statement);
     }
 


### PR DESCRIPTION
Introduces a custom directive API for the Odo template engine, allowing developers to register their own template directives from service providers.

## New API
```php
// Registering custom directives in AppServiceProvider
use Phaseolies\Support\Odo;

public function boot(): void
{
    // Block directive
    Odo::stamp('role', function ($expression) {
        return "<?php if(auth()->user()->hasRole({$expression})): ?>";
    });

    Odo::stamp('endrole', function () {
        return "<?php endif; ?>";
    });

    // Inline directive
    Odo::stamp('datetime', function ($expression) {
        return "<?php echo date('Y-m-d', strtotime({$expression})); ?>";
    });
}
```

## HTML usages
```html
#role('admin')
    <a href="/admin">Dashboard</a>
#endrole

<span>#datetime($user->created_at)</span>
```