### PR TITLE
fix: orWhere() null handling delegates to whereNull() with correct boolean

### DIFF
--- a/src/Phaseolies/Database/Entity/Builder.php
+++ b/src/Phaseolies/Database/Entity/Builder.php
@@ -235,6 +235,14 @@ class Builder
             $operator = '=';
         }
 
+        if ($value === null) {
+            if ($operator === '=') {
+                return $this->whereNull($field, 'OR');
+            } elseif ($operator === '!=') {
+                return $this->whereNull($field, 'OR', true);
+            }
+        }
+
         $this->conditions[] = ['OR', $field, $operator, $value];
 
         return $this;


### PR DESCRIPTION
orWhere('col', null) was generating OR col = ? with a null binding instead of OR col IS NULL. Fixed by adding the same null guard where() has, delegating to whereNull($field, 'OR') and whereNull($field, 'OR', true) for != case. No new methods needed since whereNull() already accepts a $boolean parameter.