### PR TITLE
feat: saveMany() now injects timestamps

### DIFF
--- a/src/Phaseolies/Database/Entity/Query/InteractsWithModelQueryProcessing.php
+++ b/src/Phaseolies/Database/Entity/Query/InteractsWithModelQueryProcessing.php
@@ -282,8 +282,15 @@ trait InteractsWithModelQueryProcessing
      */
     public static function saveMany(array $rows, int $chunkSize = 100): int
     {
-        $filteredRows = array_map(function ($row) {
-            $model = new static();
+        $model = new static();
+        $usesTimestamps = $model->timeStamps;
+        $hasCastToDate = $usesTimestamps
+            ? (new static())->propertyHasAttribute(new static(), 'timeStamps', CastToDate::class)
+            : false;
+
+        $dateTime = $hasCastToDate ? now()->startOfDay() : now();
+
+        $filteredRows = array_map(function ($row) use ($model, $usesTimestamps, $dateTime) {
             $creatable = $model->creatable;
 
             if (empty($creatable)) {
@@ -293,7 +300,14 @@ trait InteractsWithModelQueryProcessing
                 }
             }
 
-            return array_intersect_key($row, array_flip($creatable));
+            $filtered = array_intersect_key($row, array_flip($creatable));
+
+            if ($usesTimestamps) {
+                $filtered['created_at'] = $filtered['created_at'] ?? $dateTime;
+                $filtered['updated_at'] = $dateTime;
+            }
+
+            return $filtered;
         }, $rows);
 
         return static::query()->insertMany($filteredRows, $chunkSize);


### PR DESCRIPTION
### Problem
`saveMany()` was calling `insertMany()` directly without adding timestamps,
even when `$timeStamps = true` on the model, though it was intentional previously. But now it supports `$timeStamps = true`

### Before Fix
| name | email | created_at | updated_at |
|------|-------|------------|------------|
| John Doe | john@test.com | `NULL` | `NULL` |
| Jane Doe | jane@test.com | `NULL` | `NULL` |

### After Fix
| name | email | created_at | updated_at |
|------|-------|------------|------------|
| John Doe | john@test.com | `2026-03-11 08:30:00` | `2026-03-11 08:30:00` |
| Jane Doe | jane@test.com | `2026-03-11 08:30:00` | `2026-03-11 08:30:00` |

### Changes
- `saveMany()` now checks `$timeStamps` on the model before bulk insert
- `created_at` is only set if not already provided by the caller
- `updated_at` is always set to current time
- Respects `#[CastToDate]` attribute for date-only timestamps, consistent with `save()` and `create()`