### PR TITLE
remove implicit empty string to null conversion in sanitize()

### DIFF
--- a/src/Phaseolies/Database/Entity/Model.php
+++ b/src/Phaseolies/Database/Entity/Model.php
@@ -502,10 +502,6 @@ abstract class Model implements ArrayAccess, JsonSerializable, Stringable, Jsona
     {
         if (is_string($value)) {
             $value = trim($value);
-
-            if ($value === '') {
-                $value = null;
-            }
         }
 
         return $value;

--- a/tests/Model/ModelTest.php
+++ b/tests/Model/ModelTest.php
@@ -93,7 +93,7 @@ class ModelTest extends TestCase
 
         // Test empty string becomes null
         $model->email = '   ';
-        $this->assertNull($model->email);
+        $this->assertNotNull($model->email);
     }
 
     public function testMassAssignment()


### PR DESCRIPTION
Previously, sanitize() silently converted '' to null for all models, causing unexpected NULL values in the database and potential NOT NULL constraint violations when developers explicitly passed empty strings.

The base implementation now only trims whitespace:
```php
protected function sanitize($value)
{
    if (is_string($value)) {
        $value = trim($value);
    }
    return $value;
}
```
Developers who need their own required behavior can opt-in by overriding in their model: