### PR TITLE
feat: add #blank, #solo, #inject, and #slot directives to Odo templat…

### DIFF
--- a/src/Phaseolies/Http/Controllers/Controller.php
+++ b/src/Phaseolies/Http/Controllers/Controller.php
@@ -109,37 +109,33 @@ class Controller extends View
     protected const MAX_COMPILE_RETRIES = 3;
 
     /**
+     * Counter for tracking solo block uniqueness
+     *
+     * @var int
+     */
+    protected int $soloCounter = 0;
+
+    /**
+     * Tracks which solo blocks have already rendered
+     *
+     * @var array
+     */
+    protected array $soloStack = [];
+
+    /**
      * Constructor to initialize the template engine with default settings
      */
     public function __construct()
     {
         parent::__construct();
-
-        // Set the file extension for template files (changed to .odo.php)
         $this->setFileExtension('.odo.php');
-
-        // Set the directory where view files are stored
         $this->setViewFolder('resources/views' . DIRECTORY_SEPARATOR);
-
-        // Set the directory where cached files are stored
         $this->setCacheFolder('storage/framework/views' . DIRECTORY_SEPARATOR);
-
-        // Create the cache folder if it doesn't exist
         $this->createCacheFolder();
-
-        // Set the directory where cached files are stored
         $this->setSymlinkPathFolder('storage/app/public' . DIRECTORY_SEPARATOR);
-
-        // Create the cache folder if it doesn't exist
         $this->createPublicSymlinkFolder();
-
-        // Set the format for echoing variables in templates
         $this->setEchoFormat('$this->e(%s)');
-
-        // Initialize arrays for blocks, block stacks, and loop stacks
         $this->loopStacks = [];
-
-        // Load custom syntax from config if available
         $this->loadCustomSyntax();
     }
 

--- a/src/Phaseolies/Support/Odo/OdoCondition.php
+++ b/src/Phaseolies/Support/Odo/OdoCondition.php
@@ -541,4 +541,111 @@ trait OdoCondition
     {
         return "<?php endif; ?>";
     }
+
+    /**
+     * Usage: #blank($variable)
+     * Renders block when variable is empty, null, or an empty array/string
+     *
+     * @param mixed $variable
+     * @return string
+     */
+    protected function compileBlank($variable): string
+    {
+        return "<?php if(empty{$variable}): ?>";
+    }
+
+    /**
+     * Usage: #endblank
+     *
+     * @return string
+     */
+    protected function compileEndblank(): string
+    {
+        return "<?php endif; ?>";
+    }
+
+    /**
+     * Usage: #notblank($variable)
+     * Renders block when variable is NOT empty
+     *
+     * @param mixed $variable
+     * @return string
+     */
+    protected function compileNotblank($variable): string
+    {
+        return "<?php if(!empty{$variable}): ?>";
+    }
+
+    /**
+     * Usage: #endnotblank
+     *
+     * @return string
+     */
+    protected function compileEndnotblank(): string
+    {
+        return "<?php endif; ?>";
+    }
+
+    /**
+     * Usage: #solo
+     * Renders its content only once, even if inside a loop
+     *
+     * @return string
+     */
+    protected function compileSolo(): string
+    {
+        return "<?php if(!isset(\$__solo['" . ($this->soloCounter ?? $this->soloCounter = 0) . "'])): \$__solo['" . $this->soloCounter++ . "'] = true; ?>";
+    }
+
+    /**
+     * Usage: #endsolo
+     *
+     * @return string
+     */
+    protected function compileEndsolo(): string
+    {
+        return "<?php endif; ?>";
+    }
+
+    /**
+     * Usage: #inject('stack-name')
+     * Pushes content into a named stack
+     *
+     * @param string $expression
+     * @return string
+     */
+    protected function compileInject($expression): string
+    {
+        if (isset($expression[0]) && '(' === $expression[0]) {
+            $expression = substr($expression, 1, -1);
+        }
+
+        return "<?php \$this->startInject({$expression}); ?>";
+    }
+
+    /**
+     * Usage: #endinject
+     *
+     * @return string
+     */
+    protected function compileEndinject(): string
+    {
+        return "<?php \$this->endInject(); ?>";
+    }
+
+    /**
+     * Usage: #slot('stack-name')
+     * Outputs all content pushed into a named stack
+     *
+     * @param string $expression
+     * @return string
+     */
+    protected function compileSlot($expression): string
+    {
+        if (isset($expression[0]) && '(' === $expression[0]) {
+            $expression = substr($expression, 1, -1);
+        }
+
+        return "<?php echo \$this->renderSlot({$expression}); ?>";
+    }
 }

--- a/src/Phaseolies/Support/View/View.php
+++ b/src/Phaseolies/Support/View/View.php
@@ -44,11 +44,24 @@ class View extends Factory
 
     /**
      * Stack of currently rendering view names.
-     * Useful for debugging and internal state tracking.
      *
      * @var array<int, string>
      */
     protected $renderStack = [];
+
+    /**
+     * Named stacks for inject/slot system
+     *
+     * @var array<string, array>
+     */
+    protected array $stacks = [];
+
+    /**
+     * Currently open inject stack name
+     *
+     * @var string|null
+     */
+    protected ?string $currentInject = null;
 
     public function __construct()
     {
@@ -263,6 +276,74 @@ class View extends Factory
     }
 
     /**
+     * Start capturing content for a named inject stack
+     *
+     * @param string $name
+     * @return void
+     */
+    public function startInject(string $name): void
+    {
+        if (empty($name)) {
+            throw new \InvalidArgumentException('Inject stack name must not be empty');
+        }
+
+        $this->currentInject = trim($name, "'\"");
+        ob_start();
+    }
+
+    /**
+     * End capturing and push content into the named stack
+     *
+     * @return void
+     */
+    public function endInject(): void
+    {
+        if ($this->currentInject === null) {
+            throw new \RuntimeException('Cannot end inject — no inject block is open');
+        }
+
+        $content = ob_get_clean();
+        $name = $this->currentInject;
+
+        if (!isset($this->stacks[$name])) {
+            $this->stacks[$name] = [];
+        }
+
+        $this->stacks[$name][] = $content;
+        $this->currentInject = null;
+    }
+
+    /**
+     * Render all content pushed into a named stack
+     *
+     * @param string $name
+     * @return string
+     */
+    public function renderSlot(string $name): string
+    {
+        $name = trim($name, "'\"");
+
+        if (!isset($this->stacks[$name])) {
+            return '';
+        }
+
+        return implode('', $this->stacks[$name]);
+    }
+
+    /**
+     * Check if a stack has any content
+     *
+     * @param string $name
+     * @return bool
+     */
+    public function hasSlot(string $name): bool
+    {
+        $name = trim($name, "'\"");
+
+        return !empty($this->stacks[$name]);
+    }
+
+    /**
      * Clean the block state
      *
      * @return void
@@ -272,6 +353,8 @@ class View extends Factory
         $this->blocks = [];
         $this->blockStacks = [];
         $this->parents = [];
+        $this->stacks = [];
+        $this->currentInject = null;
     }
 
     public function __destruct()


### PR DESCRIPTION
This PR introduces four new built-in directives to the Odo template engine — #blank/#endblank, #notblank/#endnotblank, #solo/#endsolo, and #inject/#slot. These directives cover common template patterns that previously required raw PHP or verbose #if workarounds.

## #blank / #endblank
```php
#blank($posts)
    <div class="alert alert-info">No posts found.</div>
#endblank

#notblank($posts)
    <p>[[ count($posts) ]] posts found.</p>
#endnotblank
```

## #solo / #endsolo
Renders its content block only once per request, even if the surrounding template or partial is included or looped multiple times. This is critical for preventing duplicate <script> and <link> tags when including partials inside loops.
```php
#foreach ($posts as $post)
    #solo
        <script src="/js/editor.js"></script>
        <link rel="stylesheet" href="/css/editor.css">
    #endsolo

    <div class="post">[[ $post->title ]]</div>
#endforeach
```

Even if the loop runs 100 times, the <script> and <link> tags are rendered exactly once. Without this directive, developers had to manage their own deduplication flags in raw PHP.

## #inject / #endinject and #slot
Introduces a named content stack system. Views and partials can push content into named stacks using #inject, and layouts can output the accumulated content anywhere using #slot. Multiple #inject calls into the same stack are rendered in the order they were pushed.

Define slot placeholders in your layout:
```php
[[-- resources/views/layouts/app.odo.php --]]
<!DOCTYPE html>
<html>
<head>
    <link rel="stylesheet" href="/css/app.css">
    #slot('styles')
</head>
<body>
    #yield('content')

    <script src="/js/app.js"></script>
    #slot('scripts')
</body>
</html>
```

Push content from any view or partial:
```php
[[-- resources/views/dashboard.odo.php --]]
#extends('layouts.app')

#inject('styles')
    <link rel="stylesheet" href="/css/dashboard.css">
#endinject

#section('content')
    <h1>Dashboard</h1>
    #include('partials.chart')
#endsection

#inject('scripts')
    <script src="/js/dashboard.js"></script>
#endinject
```


