### PR TITLE
performance bottlenecks

### DIFF
--- a/src/Phaseolies/Database/Entity/Query/InteractsWithBigDataProcessing.php
+++ b/src/Phaseolies/Database/Entity/Query/InteractsWithBigDataProcessing.php
@@ -38,11 +38,7 @@ trait InteractsWithBigDataProcessing
             $offset += $chunkSize;
 
             // prevent memory leaks
-            // unsetting and invoking garbage collection
             unset($chunkQuery, $results);
-            if (gc_enabled()) {
-                gc_collect_cycles();
-            }
         }
     }
 

--- a/src/Phaseolies/Http/Controllers/Controller.php
+++ b/src/Phaseolies/Http/Controllers/Controller.php
@@ -487,9 +487,11 @@ class Controller extends View
                     @unlink($tempFile);
                 }
 
-                // Small delay before retry to avoid race conditions
+                // Exponential backoff with jitter to prevent thundering herd
                 if ($retries < self::MAX_COMPILE_RETRIES) {
-                    usleep(10000 * $retries); // 10ms, 20ms, 30ms
+                    $baseDelay = 10000 * (2 ** ($retries - 1)); // 10ms, 20ms, 40ms, 80ms
+                    $jitter = random_int(0, $baseDelay / 4); // ±25% jitter
+                    usleep($baseDelay + $jitter);
                 }
             }
         }


### PR DESCRIPTION
This PR addresses performance bottlenecks

### Race Condition Fix
```php
// ADDED: Exponential backoff with jitter
$baseDelay = 10000 * (2 ** ($retries - 1)); // 10ms, 20ms, 40ms, 80ms
$jitter = random_int(0, $baseDelay / 4); // ±25% jitter
usleep($baseDelay + $jitter);
```