### PR TITLE
feat(validation): introduce custom Bind rule system

### DIFF
--- a/src/Phaseolies/Console/Commands/MakeRuleCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeRuleCommand.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Phaseolies\Console\Commands;
+
+use Phaseolies\Console\Schedule\Command;
+
+class MakeRuleCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $name = 'make:rule {name : The name of the rule class}';
+
+    /**
+     * The description of the console command.
+     *
+     * @var string
+     */
+    protected $description =  'Create a new validation rule class';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle(): int
+    {
+        return $this->executeWithTiming(function () {
+            $name = $this->argument('name');
+            $parts = explode('/', $name);
+            $className = array_pop($parts);
+            $namespace = 'App\\Http\\Validations\\Rules' . (count($parts) > 0 ? '\\' . implode('\\', $parts) : '');
+            $filePath = base_path('app/Http/Validations/Rules/' . str_replace('/', DIRECTORY_SEPARATOR, $name) . '.php');
+
+            // Check if rule already exists
+            if (file_exists($filePath)) {
+                $this->displayError('Rule already exists at:');
+                $this->line('<fg=white>' . str_replace(base_path(), '', $filePath) . '</>');
+                return Command::FAILURE;
+            }
+
+            // Create directory if needed
+            $directoryPath = dirname($filePath);
+            if (!is_dir($directoryPath)) {
+                mkdir($directoryPath, 0755, true);
+            }
+
+            // Generate and save rule class
+            $content = $this->generateRuleContent($namespace, $className);
+            file_put_contents($filePath, $content);
+
+            $this->displaySuccess('Rule created successfully');
+            $this->line('<fg=yellow>🛡️  File:</> <fg=white>' . str_replace(base_path('/'), '', $filePath) . '</>');
+            $this->newLine();
+            $this->line('<fg=yellow>🔒 Class:</> <fg=white>' . $className . '</>');
+
+            return Command::SUCCESS;
+        });
+    }
+
+    /**
+     * Generate rule class content.
+     */
+    protected function generateRuleContent(string $namespace, string $className): string
+    {
+        return <<<EOT
+<?php
+
+namespace {$namespace};
+
+use Phaseolies\Http\Validation\Contracts\RuleInterface;
+
+class {$className} implements RuleInterface
+{
+    /**
+     * Determine if the given field value passes the domain validation rule.
+     *
+     * @param string \$field The name of the field being validated.
+     * @param mixed \$value The value of the field to validate.
+     * @param array \$input The full input data array.
+     * @return bool
+     */
+    public function passes(string \$field, mixed \$value, array \$input): bool
+    {
+        //
+    }
+
+     /**
+     * Get the validation error message for the rule.
+     *
+     * @param string \$field The name of the field being validated.
+     * @return string
+     */
+    public function message(string \$field): string
+    {
+        //
+    }
+}
+
+EOT;
+    }
+}

--- a/src/Phaseolies/Http/Validation/Bind.php
+++ b/src/Phaseolies/Http/Validation/Bind.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Phaseolies\Http\Validation;
+
+use Phaseolies\Http\Validation\Contracts\RuleInterface;
+
+class Bind
+{
+    /**
+     * The custom rule instance to be evaluated.
+     *
+     * @var RuleInterface
+     */
+    private RuleInterface $rule;
+
+    /**
+     * Conditions that must ALL be satisfied for the rule to run
+     *
+     * @var array<string, mixed>
+     */
+    private array $conditions = [];
+
+    /**
+     * @param RuleInterface $rule
+     */
+    private function __construct(RuleInterface $rule)
+    {
+        $this->rule = $rule;
+    }
+
+    /**
+     * Bind a custom rule class to the validation pipeline.
+     *
+     * @param RuleInterface $rule
+     * @return static
+     */
+    public static function to(RuleInterface $rule): static
+    {
+        return new static($rule);
+    }
+
+    /**
+     * Set conditions that must ALL be present in the request input for this rule to be evaluated
+     *
+     * @param array<string, mixed> $conditions
+     * @return static
+     */
+    public function context(array $conditions): static
+    {
+        $this->conditions = $conditions;
+
+        return $this;
+    }
+
+    /**
+     * Evaluate the bound rule against the full request input
+     *
+     * @param string $field
+     * @param array $input
+     * @return string|null
+     */
+    public function evaluate(string $field, array $input): ?string
+    {
+        // Skip rule when any context condition is not satisfied
+        foreach ($this->conditions as $contextField => $expectedValue) {
+            if (($input[$contextField] ?? null) !== $expectedValue) {
+                return null;
+            }
+        }
+
+        $value = $input[$field] ?? null;
+
+        if (!$this->rule->passes($field, $value, $input)) {
+            return $this->rule->message($field);
+        }
+
+        return null;
+    }
+}

--- a/src/Phaseolies/Http/Validation/Contracts/RuleInterface.php
+++ b/src/Phaseolies/Http/Validation/Contracts/RuleInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Phaseolies\Http\Validation\Contracts;
+
+interface RuleInterface
+{
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param string $field
+     * @param mixed $value
+     * @param array $input
+     * @return bool
+     */
+    public function passes(string $field, mixed $value, array $input): bool;
+
+    /**
+     * Return the validation error message when the rule fails.
+     *
+     * @param string $field
+     * @return string
+     */
+    public function message(string $field): string;
+}

--- a/src/Phaseolies/Http/Validation/Rule.php
+++ b/src/Phaseolies/Http/Validation/Rule.php
@@ -6,6 +6,7 @@ use Phaseolies\Session\MessageBag;
 use Phaseolies\Http\Support\ValidationRules;
 use Phaseolies\Http\Response;
 use Phaseolies\Http\Exceptions\HttpResponseException;
+use Phaseolies\Http\Validation\Bind;
 
 trait Rule
 {
@@ -26,6 +27,15 @@ trait Rule
 
         if (is_array($input)) {
             foreach ($rules as $fieldName => $value) {
+                // Custom rule class bound via Bind::to(new Rule())->context([...])
+                if ($value instanceof Bind) {
+                    $errorMessage = $value->evaluate($fieldName, $input);
+                    if ($errorMessage) {
+                        $errors[$fieldName][] = $errorMessage;
+                    }
+                    continue;
+                }
+
                 $fieldRules = explode("|", $value);
                 foreach ($fieldRules as $rule) {
                     $ruleValue = $this->_getRuleSuffix($rule);

--- a/src/Phaseolies/Support/Validation/Sanitizer.php
+++ b/src/Phaseolies/Support/Validation/Sanitizer.php
@@ -3,6 +3,7 @@
 namespace Phaseolies\Support\Validation;
 
 use Phaseolies\Http\Support\ValidationRules;
+use Phaseolies\Http\Validation\Bind;
 
 class Sanitizer
 {
@@ -68,6 +69,15 @@ class Sanitizer
     public function validate(): bool
     {
         foreach ($this->rules as $field => $ruleString) {
+            // Custom rule class bound via Bind::to(new Rule())->context([...])
+            if ($ruleString instanceof Bind) {
+                $errorMessage = $ruleString->evaluate($field, $this->data);
+                if ($errorMessage) {
+                    $this->addError($field, $errorMessage);
+                }
+                continue;
+            }
+
             $rulesArray = explode('|', $ruleString);
 
             foreach ($rulesArray as $rule) {


### PR DESCRIPTION
## Overview

This PR adds a first-class custom rule binding API (`Bind::to()`) to Doppar, enabling framework users and package authors to register custom validation rules directly in the pipeline without modifying core files.
Key Features

- Custom rule registration: Any class implementing RuleInterface can be registered directly in the validation pipeline.
- Conditional execution: Rules can be configured to run only under specific input conditions, ensuring flexible and context-aware validation.

## Example Usage
```php
$sanitized = $request->sanitize([
    'status' => 'required|in:active,inactive,pending',
    
    // Always runs
    'domain' => Bind::to(new Domain()),      

    // Runs only when status is 'active'
    'phone'  => Bind::to(new PhoneNumber())->context(['status' => 'active'])
]);
```

- If status is "active", both Domain and PhoneNumber rules run.
- If status is "inactive" or "pending", PhoneNumber is skipped silently, while Domain still runs.

## How `context()` Works
Scenario                               | Behaviour
-------------------------------------- | -----------------------------------------------
`Bind::to(new Domain())`               | Always runs
`->context(['status' => 'active'])`    | Runs only when `$input['status'] === 'active'`
`->context(['a' => '1', 'b' => '2'])` | Runs only when all conditions match
Condition not met                      | Rule is silently skipped (treated as passing)