### PR TITLE
fix: resolve Builder::create() crash when chaining after withoutHook()

### DIFF
--- a/src/Phaseolies/Database/Entity/Builder.php
+++ b/src/Phaseolies/Database/Entity/Builder.php
@@ -152,6 +152,22 @@ class Builder
     }
 
     /**
+     * Create a new model instance and save it to the database
+     *
+     * @param array $attributes
+     * @return Model
+     */
+    public function create(array $attributes): Model
+    {
+        $modelClass = $this->modelClass;
+        $model = new $modelClass();
+        $model->fill($attributes);
+        $model->save();
+
+        return $model;
+    }
+
+    /**
      * Set the relationship info
      *
      * @param array $info

--- a/src/Phaseolies/Database/Entity/Query/InteractsWithModelQueryProcessing.php
+++ b/src/Phaseolies/Database/Entity/Query/InteractsWithModelQueryProcessing.php
@@ -38,13 +38,13 @@ trait InteractsWithModelQueryProcessing
     /**
      * Disable the execution of model hooks for the current instance.
      *
-     * @return self
+     * @return \Phaseolies\Database\Entity\Builder
      */
-    public static function withoutHook(): self
+    public static function withoutHook(): Builder
     {
         self::$isHookShouldBeCalled = false;
 
-        return app(static::class);
+        return static::query();
     }
 
     /**


### PR DESCRIPTION
Fixed `Builder::create()` crash caused by `new static()` resolving to `Builder`  instead of the model class when called after `withoutHook()`. 

Overrode `create()`  in `Builder` to use `$this->modelClass` directly. `withoutHook()` now correctly returns a `Builder` instance for proper fluent chaining.