### PR TITLE
 (feat) Attribute-driven model casting

### DIFF
--- a/src/Phaseolies/Database/Entity/Casts/Attributes/ToArray.php
+++ b/src/Phaseolies/Database/Entity/Casts/Attributes/ToArray.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts\Attributes;
+
+use Attribute;
+use Phaseolies\Database\Entity\Casts\Type;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class ToArray extends Transform
+{
+    public function __construct()
+    {
+        parent::__construct(Type::Array);
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/Attributes/ToBoolean.php
+++ b/src/Phaseolies/Database/Entity/Casts/Attributes/ToBoolean.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts\Attributes;
+
+use Attribute;
+use Phaseolies\Database\Entity\Casts\Type;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class ToBoolean extends Transform
+{
+    public function __construct()
+    {
+        parent::__construct(Type::Boolean);
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/Attributes/ToCollection.php
+++ b/src/Phaseolies/Database/Entity/Casts/Attributes/ToCollection.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts\Attributes;
+
+use Attribute;
+use Phaseolies\Database\Entity\Casts\Type;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class ToCollection extends Transform
+{
+    public function __construct()
+    {
+        parent::__construct(Type::Collection);
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/Attributes/ToDate.php
+++ b/src/Phaseolies/Database/Entity/Casts/Attributes/ToDate.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts\Attributes;
+
+use Attribute;
+use Phaseolies\Database\Entity\Casts\Type;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class ToDate extends Transform
+{
+    public function __construct()
+    {
+        parent::__construct(Type::Date);
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/Attributes/ToDateTime.php
+++ b/src/Phaseolies/Database/Entity/Casts/Attributes/ToDateTime.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts\Attributes;
+
+use Attribute;
+use Phaseolies\Database\Entity\Casts\Type;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class ToDateTime extends Transform
+{
+    public function __construct()
+    {
+        parent::__construct(Type::DateTime);
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/Attributes/ToFloat.php
+++ b/src/Phaseolies/Database/Entity/Casts/Attributes/ToFloat.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts\Attributes;
+
+use Attribute;
+use Phaseolies\Database\Entity\Casts\Type;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class ToFloat extends Transform
+{
+    public function __construct()
+    {
+        parent::__construct(Type::Float);
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/Attributes/ToInteger.php
+++ b/src/Phaseolies/Database/Entity/Casts/Attributes/ToInteger.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts\Attributes;
+
+use Attribute;
+use Phaseolies\Database\Entity\Casts\Type;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class ToInteger extends Transform
+{
+    public function __construct()
+    {
+        parent::__construct(Type::Integer);
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/Attributes/ToJson.php
+++ b/src/Phaseolies/Database/Entity/Casts/Attributes/ToJson.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts\Attributes;
+
+use Attribute;
+use Phaseolies\Database\Entity\Casts\Type;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class ToJson extends Transform
+{
+    public function __construct()
+    {
+        parent::__construct(Type::Json);
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/Attributes/ToObject.php
+++ b/src/Phaseolies/Database/Entity/Casts/Attributes/ToObject.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts\Attributes;
+
+use Attribute;
+use Phaseolies\Database\Entity\Casts\Type;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class ToObject extends Transform
+{
+    public function __construct()
+    {
+        parent::__construct(Type::Object);
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/Attributes/ToString.php
+++ b/src/Phaseolies/Database/Entity/Casts/Attributes/ToString.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts\Attributes;
+
+use Attribute;
+use Phaseolies\Database\Entity\Casts\Type;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class ToString extends Transform
+{
+    public function __construct()
+    {
+        parent::__construct(Type::String);
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/Attributes/ToTimestamp.php
+++ b/src/Phaseolies/Database/Entity/Casts/Attributes/ToTimestamp.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts\Attributes;
+
+use Attribute;
+use Phaseolies\Database\Entity\Casts\Type;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class ToTimestamp extends Transform
+{
+    public function __construct()
+    {
+        parent::__construct(Type::Timestamp);
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/Attributes/Transform.php
+++ b/src/Phaseolies/Database/Entity/Casts/Attributes/Transform.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts\Attributes;
+
+use Attribute;
+use Phaseolies\Database\Entity\Casts\Type;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class Transform
+{
+    /**
+     * The resolved cast type string.
+     *
+     * @var string
+     */
+    public readonly string $type;
+
+    /**
+     * @param Type|string $type
+     */
+    public function __construct(Type|string $type)
+    {
+        $this->type = $type instanceof Type ? $type->value : $type;
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/CastManager.php
+++ b/src/Phaseolies/Database/Entity/Casts/CastManager.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts;
+
+use Phaseolies\Database\Entity\Casts\Contracts\CastableInterface;
+use Phaseolies\Database\Entity\Casts\Handlers\ArrayCast;
+use Phaseolies\Database\Entity\Casts\Handlers\BooleanCast;
+use Phaseolies\Database\Entity\Casts\Handlers\CollectionCast;
+use Phaseolies\Database\Entity\Casts\Handlers\DateCast;
+use Phaseolies\Database\Entity\Casts\Handlers\DateTimeCast;
+use Phaseolies\Database\Entity\Casts\Handlers\DecimalCast;
+use Phaseolies\Database\Entity\Casts\Handlers\EnumCast;
+use Phaseolies\Database\Entity\Casts\Handlers\FloatCast;
+use Phaseolies\Database\Entity\Casts\Handlers\IntegerCast;
+use Phaseolies\Database\Entity\Casts\Handlers\ObjectCast;
+use Phaseolies\Database\Entity\Casts\Handlers\StringCast;
+use Phaseolies\Database\Entity\Casts\Handlers\TimestampCast;
+
+class CastManager
+{
+    /**
+     * Map of primitive cast type strings to handler classes.
+     *
+     * @var array<string, class-string<CastableInterface>>
+     */
+    private static array $primitives = [
+        'int'        => IntegerCast::class,
+        'integer'    => IntegerCast::class,
+        'float'      => FloatCast::class,
+        'double'     => FloatCast::class,
+        'real'       => FloatCast::class,
+        'bool'       => BooleanCast::class,
+        'boolean'    => BooleanCast::class,
+        'string'     => StringCast::class,
+        'array'      => ArrayCast::class,
+        'json'       => ArrayCast::class,
+        'object'     => ObjectCast::class,
+        'collection' => CollectionCast::class,
+        'datetime'   => DateTimeCast::class,
+        'date'       => DateCast::class,
+        'timestamp'  => TimestampCast::class,
+    ];
+
+    /**
+     * Cache of resolved cast handler instances keyed by cast string.
+     *
+     * @var array<string, CastableInterface>
+     */
+    private static array $resolved = [];
+
+    /**
+     * Cast a raw database value to its PHP type on get.
+     *
+     * @param string $cast
+     * @param mixed  $value
+     * @return mixed
+     */
+    public static function get(string $cast, mixed $value): mixed
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return self::resolve($cast)->get($value);
+    }
+
+    /**
+     * Cast a PHP value to a database-compatible format on set.
+     *
+     * @param string $cast
+     * @param mixed  $value
+     * @return mixed
+     */
+    public static function set(string $cast, mixed $value): mixed
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return self::resolve($cast)->set($value);
+    }
+
+    /**
+     * Resolve the cast handler instance for a given cast string
+     *
+     * @param string $cast
+     * @return CastableInterface
+     * @throws \InvalidArgumentException
+     */
+    public static function resolve(string $cast): CastableInterface
+    {
+        if (isset(self::$resolved[$cast])) {
+            return self::$resolved[$cast];
+        }
+
+        // Primitive cast — 'integer', 'float', 'boolean', etc.
+        if (isset(self::$primitives[$cast])) {
+            return self::$resolved[$cast] = new (self::$primitives[$cast])();
+        }
+
+        // Parameterised decimal cast — 'decimal:2', 'decimal:4'
+        if (str_starts_with($cast, 'decimal:')) {
+            $precision = (int) explode(':', $cast, 2)[1];
+            return self::$resolved[$cast] = new DecimalCast($precision);
+        }
+
+        // Parameterised datetime cast — 'datetime:d/m/Y'
+        if (str_starts_with($cast, 'datetime:')) {
+            $format = explode(':', $cast, 2)[1];
+            return self::$resolved[$cast] = new DateTimeCast($format);
+        }
+
+        // Enum cast — any PHP backed or unit enum
+        if (enum_exists($cast)) {
+            return self::$resolved[$cast] = new EnumCast($cast);
+        }
+
+        // Custom cast class — must implement CastableInterface
+        if (class_exists($cast) && is_subclass_of($cast, CastableInterface::class)) {
+            return self::$resolved[$cast] = new $cast();
+        }
+
+        throw new \InvalidArgumentException(
+            "Unsupported cast type [{$cast}]. Use a built-in type, a backed enum, or a class implementing CastableInterface."
+        );
+    }
+
+    /**
+     * Flush the resolved cast handler cache.
+     *
+     * @return void
+     */
+    public static function flush(): void
+    {
+        self::$resolved = [];
+    }
+
+    /**
+     * Determine if a cast string is a complex type that requires
+     * set-casting before writing to the database.
+     *
+     * @param string $cast
+     * @return bool
+     */
+    public static function requiresSetCast(string $cast): bool
+    {
+        $complex = ['array', 'json', 'object', 'collection', 'datetime', 'date', 'timestamp'];
+
+        if (in_array($cast, $complex, true)) {
+            return true;
+        }
+
+        if (str_starts_with($cast, 'decimal:') || str_starts_with($cast, 'datetime:')) {
+            return true;
+        }
+
+        if (enum_exists($cast)) {
+            return true;
+        }
+
+        if (class_exists($cast) && is_subclass_of($cast, CastableInterface::class)) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/Contracts/CastableInterface.php
+++ b/src/Phaseolies/Database/Entity/Casts/Contracts/CastableInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts\Contracts;
+
+interface CastableInterface
+{
+    /**
+     * Cast the raw database value to a PHP type on get.
+     *
+     * @param mixed $value
+     * @return mixed
+     */
+    public function get(mixed $value): mixed;
+
+    /**
+     * Cast the PHP value to a database-compatible format on set.
+     *
+     * @param mixed $value
+     * @return mixed
+     */
+    public function set(mixed $value): mixed;
+}

--- a/src/Phaseolies/Database/Entity/Casts/Handlers/ArrayCast.php
+++ b/src/Phaseolies/Database/Entity/Casts/Handlers/ArrayCast.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts\Handlers;
+
+use Phaseolies\Database\Entity\Casts\Contracts\CastableInterface;
+
+class ArrayCast implements CastableInterface
+{
+    public function get(mixed $value): mixed
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (is_string($value) && $value !== '') {
+            $decoded = json_decode($value, true);
+            return json_last_error() === JSON_ERROR_NONE ? $decoded : [];
+        }
+
+        return [];
+    }
+
+    public function set(mixed $value): mixed
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+
+        return json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/Handlers/ArrayCast.php
+++ b/src/Phaseolies/Database/Entity/Casts/Handlers/ArrayCast.php
@@ -6,6 +6,12 @@ use Phaseolies\Database\Entity\Casts\Contracts\CastableInterface;
 
 class ArrayCast implements CastableInterface
 {
+    /**
+     * Get the value as an array.
+     *
+     * @param mixed $value
+     * @return array
+     */
     public function get(mixed $value): mixed
     {
         if (is_array($value)) {
@@ -20,6 +26,12 @@ class ArrayCast implements CastableInterface
         return [];
     }
 
+    /**
+     * Set the value as a JSON string
+     *
+     * @param mixed $value
+     * @return mixed
+     */
     public function set(mixed $value): mixed
     {
         if (is_string($value)) {

--- a/src/Phaseolies/Database/Entity/Casts/Handlers/BooleanCast.php
+++ b/src/Phaseolies/Database/Entity/Casts/Handlers/BooleanCast.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts\Handlers;
+
+use Phaseolies\Database\Entity\Casts\Contracts\CastableInterface;
+
+class BooleanCast implements CastableInterface
+{
+    public function get(mixed $value): mixed
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? (bool) $value;
+    }
+
+    public function set(mixed $value): mixed
+    {
+        return (int) (bool) $value;
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/Handlers/BooleanCast.php
+++ b/src/Phaseolies/Database/Entity/Casts/Handlers/BooleanCast.php
@@ -6,6 +6,12 @@ use Phaseolies\Database\Entity\Casts\Contracts\CastableInterface;
 
 class BooleanCast implements CastableInterface
 {
+    /**
+     * Get the value as a boolean.
+     *
+     * @param mixed $value
+     * @return bool
+     */
     public function get(mixed $value): mixed
     {
         if (is_bool($value)) {
@@ -15,6 +21,12 @@ class BooleanCast implements CastableInterface
         return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? (bool) $value;
     }
 
+    /**
+     * Set the value as a boolean integer (0 or 1)
+     *
+     * @param mixed $value
+     * @return mixed
+     */
     public function set(mixed $value): mixed
     {
         return (int) (bool) $value;

--- a/src/Phaseolies/Database/Entity/Casts/Handlers/CollectionCast.php
+++ b/src/Phaseolies/Database/Entity/Casts/Handlers/CollectionCast.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts\Handlers;
+
+use Phaseolies\Database\Entity\Casts\Contracts\CastableInterface;
+use Phaseolies\Support\Collection;
+
+class CollectionCast implements CastableInterface
+{
+    public function get(mixed $value): mixed
+    {
+        if ($value instanceof Collection) {
+            return $value;
+        }
+
+        if (is_array($value)) {
+            return new Collection('array', $value);
+        }
+
+        if (is_string($value) && $value !== '') {
+            $decoded = json_decode($value, true);
+            $items = json_last_error() === JSON_ERROR_NONE ? $decoded : [];
+            return new Collection('array', $items);
+        }
+
+        return new Collection('array', []);
+    }
+
+    public function set(mixed $value): mixed
+    {
+        if ($value instanceof Collection) {
+            return json_encode($value->all(), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+
+        if (is_array($value)) {
+            return json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+
+        if (is_string($value)) {
+            return $value;
+        }
+
+        return json_encode($value);
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/Handlers/CollectionCast.php
+++ b/src/Phaseolies/Database/Entity/Casts/Handlers/CollectionCast.php
@@ -7,6 +7,12 @@ use Phaseolies\Support\Collection;
 
 class CollectionCast implements CastableInterface
 {
+    /**
+     * Get the value as a Collection
+     *
+     * @param mixed $value
+     * @return Collection
+     */
     public function get(mixed $value): mixed
     {
         if ($value instanceof Collection) {
@@ -26,6 +32,12 @@ class CollectionCast implements CastableInterface
         return new Collection('array', []);
     }
 
+    /**
+     * Set the value as a JSON string
+     *
+     * @param mixed $value
+     * @return mixed
+     */
     public function set(mixed $value): mixed
     {
         if ($value instanceof Collection) {

--- a/src/Phaseolies/Database/Entity/Casts/Handlers/DateCast.php
+++ b/src/Phaseolies/Database/Entity/Casts/Handlers/DateCast.php
@@ -8,6 +8,12 @@ use Phaseolies\Database\Entity\Casts\Contracts\CastableInterface;
 
 class DateCast implements CastableInterface
 {
+    /**
+     * Get the value as a Carbon instance at the start of the day
+     *
+     * @param mixed $value
+     * @return Carbon|null
+     */
     public function get(mixed $value): mixed
     {
         if ($value === null || $value === '') {
@@ -25,6 +31,12 @@ class DateCast implements CastableInterface
         return Carbon::parse($value)->startOfDay();
     }
 
+    /**
+     * Set the value as a date string (Y-m-d)
+     *
+     * @param mixed $value
+     * @return mixed
+     */
     public function set(mixed $value): mixed
     {
         if ($value === null || $value === '') {

--- a/src/Phaseolies/Database/Entity/Casts/Handlers/DateCast.php
+++ b/src/Phaseolies/Database/Entity/Casts/Handlers/DateCast.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts\Handlers;
+
+use Carbon\Carbon;
+use DateTimeInterface;
+use Phaseolies\Database\Entity\Casts\Contracts\CastableInterface;
+
+class DateCast implements CastableInterface
+{
+    public function get(mixed $value): mixed
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if ($value instanceof Carbon) {
+            return $value->startOfDay();
+        }
+
+        if ($value instanceof DateTimeInterface) {
+            return Carbon::instance($value)->startOfDay();
+        }
+
+        return Carbon::parse($value)->startOfDay();
+    }
+
+    public function set(mixed $value): mixed
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if ($value instanceof DateTimeInterface) {
+            return $value->format('Y-m-d');
+        }
+
+        return $value;
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/Handlers/DateTimeCast.php
+++ b/src/Phaseolies/Database/Entity/Casts/Handlers/DateTimeCast.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts\Handlers;
+
+use Carbon\Carbon;
+use DateTimeInterface;
+use Phaseolies\Database\Entity\Casts\Contracts\CastableInterface;
+
+class DateTimeCast implements CastableInterface
+{
+    /**
+     * @param string $format
+     */
+    public function __construct(
+        protected string $format = 'Y-m-d H:i:s'
+    ) {}
+
+    public function get(mixed $value): mixed
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if ($value instanceof Carbon) {
+            return $value;
+        }
+
+        if ($value instanceof DateTimeInterface) {
+            return Carbon::instance($value);
+        }
+
+        return Carbon::parse($value);
+    }
+
+    public function set(mixed $value): mixed
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if ($value instanceof DateTimeInterface) {
+            return $value->format($this->format);
+        }
+
+        return $value;
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/Handlers/DateTimeCast.php
+++ b/src/Phaseolies/Database/Entity/Casts/Handlers/DateTimeCast.php
@@ -15,6 +15,12 @@ class DateTimeCast implements CastableInterface
         protected string $format = 'Y-m-d H:i:s'
     ) {}
 
+    /**
+     * Get the value as a Carbon instance.
+     *
+     * @param mixed $value
+     * @return Carbon|null
+     */
     public function get(mixed $value): mixed
     {
         if ($value === null || $value === '') {
@@ -32,6 +38,12 @@ class DateTimeCast implements CastableInterface
         return Carbon::parse($value);
     }
 
+    /**
+     * Set the value as a formatted date string
+     *
+     * @param mixed $value
+     * @return mixed
+     */
     public function set(mixed $value): mixed
     {
         if ($value === null || $value === '') {

--- a/src/Phaseolies/Database/Entity/Casts/Handlers/DecimalCast.php
+++ b/src/Phaseolies/Database/Entity/Casts/Handlers/DecimalCast.php
@@ -13,6 +13,12 @@ class DecimalCast implements CastableInterface
         protected int $precision = 2
     ) {}
 
+    /**
+     * Get the value as a decimal.
+     *
+     * @param mixed $value
+     * @return float|null
+     */
     public function get(mixed $value): mixed
     {
         if ($value === null || $value === '') {
@@ -22,6 +28,12 @@ class DecimalCast implements CastableInterface
         return round((float) $value, $this->precision);
     }
 
+    /**
+     * Set the value as a decimal.
+     *
+     * @param mixed $value
+     * @return float|null
+     */
     public function set(mixed $value): mixed
     {
         if ($value === null || $value === '') {

--- a/src/Phaseolies/Database/Entity/Casts/Handlers/DecimalCast.php
+++ b/src/Phaseolies/Database/Entity/Casts/Handlers/DecimalCast.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts\Handlers;
+
+use Phaseolies\Database\Entity\Casts\Contracts\CastableInterface;
+
+class DecimalCast implements CastableInterface
+{
+    /**
+     * @param int $precision
+     */
+    public function __construct(
+        protected int $precision = 2
+    ) {}
+
+    public function get(mixed $value): mixed
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return round((float) $value, $this->precision);
+    }
+
+    public function set(mixed $value): mixed
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return round((float) $value, $this->precision);
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/Handlers/EnumCast.php
+++ b/src/Phaseolies/Database/Entity/Casts/Handlers/EnumCast.php
@@ -13,6 +13,13 @@ class EnumCast implements CastableInterface
         protected string $enumClass
     ) {}
 
+    /**
+     * Get the enum case from the given value.
+     *
+     * @param mixed $value
+     * @return mixed
+     * @throws \ValueError
+     */
     public function get(mixed $value): mixed
     {
         if ($value === null || $value === '') {
@@ -40,6 +47,12 @@ class EnumCast implements CastableInterface
         );
     }
 
+    /**
+     * Convert the enum case to a storable value.
+     *
+     * @param mixed $value
+     * @return mixed
+     */
     public function set(mixed $value): mixed
     {
         if ($value === null) {

--- a/src/Phaseolies/Database/Entity/Casts/Handlers/EnumCast.php
+++ b/src/Phaseolies/Database/Entity/Casts/Handlers/EnumCast.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts\Handlers;
+
+use Phaseolies\Database\Entity\Casts\Contracts\CastableInterface;
+
+class EnumCast implements CastableInterface
+{
+    /**
+     * @param string $enumClass
+     */
+    public function __construct(
+        protected string $enumClass
+    ) {}
+
+    public function get(mixed $value): mixed
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if ($value instanceof $this->enumClass) {
+            return $value;
+        }
+
+        // Backed enum — from(value)
+        if (is_subclass_of($this->enumClass, \BackedEnum::class)) {
+            return ($this->enumClass)::from($value);
+        }
+
+        // Pure enum — match by name
+        foreach (($this->enumClass)::cases() as $case) {
+            if ($case->name === $value) {
+                return $case;
+            }
+        }
+
+        throw new \ValueError(
+            "Value [{$value}] is not a valid case for enum [{$this->enumClass}]"
+        );
+    }
+
+    public function set(mixed $value): mixed
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if ($value instanceof \BackedEnum) {
+            return $value->value;
+        }
+
+        if ($value instanceof \UnitEnum) {
+            return $value->name;
+        }
+
+        return $value;
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/Handlers/FloatCast.php
+++ b/src/Phaseolies/Database/Entity/Casts/Handlers/FloatCast.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts\Handlers;
+
+use Phaseolies\Database\Entity\Casts\Contracts\CastableInterface;
+
+class FloatCast implements CastableInterface
+{
+    public function get(mixed $value): mixed
+    {
+        return (float) $value;
+    }
+
+    public function set(mixed $value): mixed
+    {
+        return (float) $value;
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/Handlers/FloatCast.php
+++ b/src/Phaseolies/Database/Entity/Casts/Handlers/FloatCast.php
@@ -6,11 +6,23 @@ use Phaseolies\Database\Entity\Casts\Contracts\CastableInterface;
 
 class FloatCast implements CastableInterface
 {
+    /**
+     * Cast the given value to a float.
+     *
+     * @param mixed $value
+     * @return float
+     */
     public function get(mixed $value): mixed
     {
         return (float) $value;
     }
 
+    /**
+     * Cast the given value to a float before saving.
+     *
+     * @param mixed $value
+     * @return float
+     */
     public function set(mixed $value): mixed
     {
         return (float) $value;

--- a/src/Phaseolies/Database/Entity/Casts/Handlers/IntegerCast.php
+++ b/src/Phaseolies/Database/Entity/Casts/Handlers/IntegerCast.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts\Handlers;
+
+use Phaseolies\Database\Entity\Casts\Contracts\CastableInterface;
+
+class IntegerCast implements CastableInterface
+{
+    public function get(mixed $value): mixed
+    {
+        return (int) $value;
+    }
+
+    public function set(mixed $value): mixed
+    {
+        return (int) $value;
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/Handlers/IntegerCast.php
+++ b/src/Phaseolies/Database/Entity/Casts/Handlers/IntegerCast.php
@@ -6,11 +6,23 @@ use Phaseolies\Database\Entity\Casts\Contracts\CastableInterface;
 
 class IntegerCast implements CastableInterface
 {
+    /**
+     * Cast the given value to an integer.
+     *
+     * @param mixed $value
+     * @return int
+     */
     public function get(mixed $value): mixed
     {
         return (int) $value;
     }
 
+    /**
+     * Cast the given value to an integer before saving to the database.
+     *
+     * @param mixed $value
+     * @return int
+     */
     public function set(mixed $value): mixed
     {
         return (int) $value;

--- a/src/Phaseolies/Database/Entity/Casts/Handlers/ObjectCast.php
+++ b/src/Phaseolies/Database/Entity/Casts/Handlers/ObjectCast.php
@@ -6,6 +6,12 @@ use Phaseolies\Database\Entity\Casts\Contracts\CastableInterface;
 
 class ObjectCast implements CastableInterface
 {
+    /**
+     * Get the value of the cast.
+     *
+     * @param mixed $value
+     * @return mixed
+     */
     public function get(mixed $value): mixed
     {
         if (is_object($value)) {
@@ -20,6 +26,12 @@ class ObjectCast implements CastableInterface
         return (object) [];
     }
 
+    /**
+     * Set the value of the cast.
+     *
+     * @param mixed $value
+     * @return mixed
+     */
     public function set(mixed $value): mixed
     {
         if (is_string($value)) {

--- a/src/Phaseolies/Database/Entity/Casts/Handlers/ObjectCast.php
+++ b/src/Phaseolies/Database/Entity/Casts/Handlers/ObjectCast.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts\Handlers;
+
+use Phaseolies\Database\Entity\Casts\Contracts\CastableInterface;
+
+class ObjectCast implements CastableInterface
+{
+    public function get(mixed $value): mixed
+    {
+        if (is_object($value)) {
+            return $value;
+        }
+
+        if (is_string($value) && $value !== '') {
+            $decoded = json_decode($value);
+            return $decoded ?? (object) [];
+        }
+
+        return (object) [];
+    }
+
+    public function set(mixed $value): mixed
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+
+        return json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/Handlers/StringCast.php
+++ b/src/Phaseolies/Database/Entity/Casts/Handlers/StringCast.php
@@ -6,11 +6,23 @@ use Phaseolies\Database\Entity\Casts\Contracts\CastableInterface;
 
 class StringCast implements CastableInterface
 {
+    /**
+     * Cast the given value to a string.
+     *
+     * @param mixed $value
+     * @return string
+     */
     public function get(mixed $value): mixed
     {
         return (string) $value;
     }
 
+    /**
+     * Cast the given value to a string before saving to the database.
+     *
+     * @param mixed $value
+     * @return string
+     */
     public function set(mixed $value): mixed
     {
         return (string) $value;

--- a/src/Phaseolies/Database/Entity/Casts/Handlers/StringCast.php
+++ b/src/Phaseolies/Database/Entity/Casts/Handlers/StringCast.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts\Handlers;
+
+use Phaseolies\Database\Entity\Casts\Contracts\CastableInterface;
+
+class StringCast implements CastableInterface
+{
+    public function get(mixed $value): mixed
+    {
+        return (string) $value;
+    }
+
+    public function set(mixed $value): mixed
+    {
+        return (string) $value;
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/Handlers/TimestampCast.php
+++ b/src/Phaseolies/Database/Entity/Casts/Handlers/TimestampCast.php
@@ -8,6 +8,12 @@ use Phaseolies\Database\Entity\Casts\Contracts\CastableInterface;
 
 class TimestampCast implements CastableInterface
 {
+    /**
+     * Get the value from the database and convert it to a Carbon instance.
+     *
+     * @param mixed $value
+     * @return Carbon|null
+     */
     public function get(mixed $value): mixed
     {
         if ($value === null || $value === '') {
@@ -29,6 +35,12 @@ class TimestampCast implements CastableInterface
         return Carbon::parse($value);
     }
 
+    /**
+     * Set the value for the database and convert it to a timestamp.
+     *
+     * @param mixed $value
+     * @return mixed
+     */
     public function set(mixed $value): mixed
     {
         if ($value === null || $value === '') {

--- a/src/Phaseolies/Database/Entity/Casts/Handlers/TimestampCast.php
+++ b/src/Phaseolies/Database/Entity/Casts/Handlers/TimestampCast.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts\Handlers;
+
+use Carbon\Carbon;
+use DateTimeInterface;
+use Phaseolies\Database\Entity\Casts\Contracts\CastableInterface;
+
+class TimestampCast implements CastableInterface
+{
+    public function get(mixed $value): mixed
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_numeric($value)) {
+            return Carbon::createFromTimestamp((int) $value);
+        }
+
+        if ($value instanceof Carbon) {
+            return $value;
+        }
+
+        if ($value instanceof DateTimeInterface) {
+            return Carbon::instance($value);
+        }
+
+        return Carbon::parse($value);
+    }
+
+    public function set(mixed $value): mixed
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if ($value instanceof DateTimeInterface) {
+            return $value->getTimestamp();
+        }
+
+        return $value;
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/InteractsWithCasting.php
+++ b/src/Phaseolies/Database/Entity/Casts/InteractsWithCasting.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts;
+
+use Phaseolies\Database\Entity\Casts\Attributes\Transform;
+
+trait InteractsWithCasting
+{
+    /**
+     * Per-class cache of #[Cast] attribute metadata scanned via reflection.
+     *
+     * @var array<string, array<string, string>>
+     */
+    private static array $castAttributeCache = [];
+
+    /**
+     * Ensure cast metadata is scanned for the current class.
+     *
+     * @return void
+     */
+    private function ensureCastsCached(): void
+    {
+        $class = static::class;
+
+        if (!array_key_exists($class, self::$castAttributeCache)) {
+            self::$castAttributeCache[$class] = $this->scanCastAttributes($class);
+        }
+    }
+
+    /**
+     * Scan a class for properties decorated with #[Cast].
+     *
+     * @param string $class
+     * @return array<string, string>
+     */
+    private function scanCastAttributes(string $class): array
+    {
+        $found      = [];
+        $reflection = new \ReflectionClass($class);
+
+        foreach ($reflection->getProperties() as $property) {
+            $castAttributes = $property->getAttributes(Transform::class, \ReflectionAttribute::IS_INSTANCEOF);
+
+            if (empty($castAttributes)) {
+                continue;
+            }
+
+            $cast                        = $castAttributes[0]->newInstance();
+            $found[$property->getName()] = $cast->type;
+        }
+
+        return $found;
+    }
+
+    /**
+     * Apply the get cast — converts a raw DB value to its PHP representation.
+     *
+     * @param string $key
+     * @param mixed  $value
+     * @return mixed
+     */
+    protected function castForGet(string $key, mixed $value): mixed
+    {
+        if ($value === null || !$this->hasCast($key)) {
+            return $value;
+        }
+
+        return CastManager::get(self::$castAttributeCache[static::class][$key], $value);
+    }
+
+    /**
+     * Apply the set cast — converts a PHP value to a DB-compatible format
+     *
+     * @param string $key
+     * @param mixed  $value
+     * @return mixed
+     */
+    protected function castForSet(string $key, mixed $value): mixed
+    {
+        if ($value === null || !$this->hasCast($key)) {
+            return $value;
+        }
+
+        $cast = self::$castAttributeCache[static::class][$key];
+
+        if (!CastManager::requiresSetCast($cast)) {
+            return $value;
+        }
+
+        return CastManager::set($cast, $value);
+    }
+
+    /**
+     * Determine if an attribute has a #[Cast] definition.
+     *
+     * @param string $key
+     * @return bool
+     */
+    public function hasCast(string $key): bool
+    {
+        $this->ensureCastsCached();
+
+        return isset(self::$castAttributeCache[static::class][$key]);
+    }
+
+    /**
+     * Get the cast type for a given attribute.
+     *
+     * @param string $key
+     * @return string|null
+     */
+    public function getCastType(string $key): ?string
+    {
+        $this->ensureCastsCached();
+
+        return self::$castAttributeCache[static::class][$key] ?? null;
+    }
+
+    /**
+     * Get all cast definitions.
+     *
+     * @return array<string, string>
+     */
+    public function getCasts(): array
+    {
+        $this->ensureCastsCached();
+
+        return self::$castAttributeCache[static::class] ?? [];
+    }
+
+    /**
+     * Get all model attributes with casts applied
+     *
+     * @return array
+     */
+    public function getCastAttributes(): array
+    {
+        $this->ensureCastsCached();
+
+        $result = [];
+
+        foreach ($this->attributes as $key => $value) {
+            $result[$key] = $this->hasCast($key)
+                ? $this->castForGet($key, $value)
+                : $value;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Reset the #[Cast] attribute scan cache.
+     *
+     * @param string|null $class
+     * @return void
+     */
+    public static function resetCastCache(?string $class = null): void
+    {
+        if ($class !== null) {
+            unset(self::$castAttributeCache[$class]);
+        } else {
+            self::$castAttributeCache = [];
+        }
+    }
+}

--- a/src/Phaseolies/Database/Entity/Casts/Type.php
+++ b/src/Phaseolies/Database/Entity/Casts/Type.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Phaseolies\Database\Entity\Casts;
+
+enum Type: string
+{
+    case Integer    = 'integer';
+    case Float      = 'float';
+    case Boolean    = 'boolean';
+    case String     = 'string';
+    case Array      = 'array';
+    case Object     = 'object';
+    case Collection = 'collection';
+    case DateTime   = 'datetime';
+    case Date       = 'date';
+    case Timestamp  = 'timestamp';
+    case Json       = 'json';
+}

--- a/src/Phaseolies/Database/Entity/Model.php
+++ b/src/Phaseolies/Database/Entity/Model.php
@@ -6,6 +6,7 @@ use Stringable;
 use Phaseolies\Support\Collection;
 use Phaseolies\Database\Entity\Query\InteractsWithModelQueryProcessing;
 use Phaseolies\Database\Entity\Hooks\HookHandler;
+use Phaseolies\Database\Entity\Casts\InteractsWithCasting;
 use Phaseolies\Database\Temporal\InteractsWithTemporal;
 use Phaseolies\Database\Database;
 use Phaseolies\Database\Contracts\Support\Jsonable;
@@ -18,6 +19,7 @@ abstract class Model implements ArrayAccess, JsonSerializable, Stringable, Jsona
 {
     use InteractsWithModelQueryProcessing;
     use InteractsWithTemporal;
+    use InteractsWithCasting;
 
     /**
      * The name of the database table associated with the model.
@@ -485,6 +487,7 @@ abstract class Model implements ArrayAccess, JsonSerializable, Stringable, Jsona
     public function setAttribute($key, $value): void
     {
         $value = $this->sanitize($value);
+        $value = $this->castForSet($key, $value);
 
         // Always track original value, when first setting
         if (!array_key_exists($key, $this->originalAttributes)) {
@@ -552,7 +555,7 @@ abstract class Model implements ArrayAccess, JsonSerializable, Stringable, Jsona
 
         foreach ($this->attributes as $key => $value) {
             if (!in_array($key, $this->unexposable)) {
-                $visibleAttributes[$key] = $value;
+                $visibleAttributes[$key] = $this->castForGet($key, $value);
             }
         }
 
@@ -860,7 +863,7 @@ abstract class Model implements ArrayAccess, JsonSerializable, Stringable, Jsona
     {
         try {
             if (array_key_exists($name, $this->attributes)) {
-                return $this->attributes[$name];
+                return $this->castForGet($name, $this->attributes[$name]);
             }
 
             if (array_key_exists($name, $this->relations)) {

--- a/tests/Model/CastSystemTest.php
+++ b/tests/Model/CastSystemTest.php
@@ -1,0 +1,826 @@
+<?php
+
+namespace Tests\Unit\Model;
+
+use Carbon\Carbon;
+use PDO;
+use Phaseolies\Database\Database;
+use Phaseolies\Database\Entity\Casts\Attributes\ToArray;
+use Phaseolies\Database\Entity\Casts\Attributes\ToBoolean;
+use Phaseolies\Database\Entity\Casts\Attributes\ToCollection;
+use Phaseolies\Database\Entity\Casts\Attributes\ToDate;
+use Phaseolies\Database\Entity\Casts\Attributes\ToDateTime;
+use Phaseolies\Database\Entity\Casts\Attributes\ToFloat;
+use Phaseolies\Database\Entity\Casts\Attributes\ToInteger;
+use Phaseolies\Database\Entity\Casts\Attributes\ToJson;
+use Phaseolies\Database\Entity\Casts\Attributes\ToObject;
+use Phaseolies\Database\Entity\Casts\Attributes\ToString;
+use Phaseolies\Database\Entity\Casts\Attributes\ToTimestamp;
+use Phaseolies\Database\Entity\Casts\Attributes\Transform;
+use Phaseolies\Database\Entity\Casts\CastManager;
+use Phaseolies\Database\Entity\Casts\Contracts\CastableInterface;
+use Phaseolies\Database\Entity\Casts\Type;
+use Phaseolies\Database\Entity\Model;
+use Phaseolies\DI\Container;
+use Phaseolies\Http\Request;
+use Phaseolies\Support\Collection;
+use Phaseolies\Support\UrlGenerator;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\MockContainer;
+
+enum CastTestStatus: string
+{
+    case Active   = 'active';
+    case Inactive = 'inactive';
+}
+
+enum CastTestPriority: int
+{
+    case Low    = 1;
+    case Medium = 2;
+    case High   = 3;
+}
+
+enum CastTestColor
+{
+    case Red;
+    case Green;
+    case Blue;
+}
+
+class UpperCaseCast implements CastableInterface
+{
+    public function get(mixed $value): mixed
+    {
+        return is_string($value) ? strtoupper($value) : $value;
+    }
+
+    public function set(mixed $value): mixed
+    {
+        return is_string($value) ? strtolower($value) : $value;
+    }
+}
+
+class MockPrimitiveCastModel extends Model
+{
+    protected $table      = 'cast_records';
+    protected $connection = 'default';
+    protected $timeStamps = false;
+
+    #[ToString]
+    protected string $label;
+
+    #[ToInteger]
+    protected string $score;
+
+    #[ToFloat]
+    protected string $weight;
+
+    #[ToBoolean]
+    protected string $is_active;
+}
+
+class MockDateCastModel extends Model
+{
+    protected $table      = 'cast_records';
+    protected $connection = 'default';
+    protected $timeStamps = false;
+
+    #[ToDateTime]
+    protected string $published_at;
+
+    #[ToDate]
+    protected string $birthday;
+
+    #[ToTimestamp]
+    protected string $created_ts;
+}
+
+class MockStructuralCastModel extends Model
+{
+    protected $table      = 'cast_records';
+    protected $connection = 'default';
+    protected $timeStamps = false;
+
+    #[ToArray]
+    protected string $options;
+
+    #[ToJson]
+    protected string $tags;
+
+    #[ToObject]
+    protected string $config;
+
+    #[ToCollection]
+    protected string $items;
+}
+
+class MockDecimalCastModel extends Model
+{
+    protected $table      = 'cast_records';
+    protected $connection = 'default';
+    protected $timeStamps = false;
+
+    #[Transform('decimal:2')]
+    protected string $price;
+
+    #[Transform('decimal:4')]
+    protected string $tax_rate;
+}
+
+class MockEnumCastModel extends Model
+{
+    protected $table      = 'cast_records';
+    protected $connection = 'default';
+    protected $timeStamps = false;
+
+    #[Transform(CastTestStatus::class)]
+    protected string $status;
+
+    #[Transform(CastTestPriority::class)]
+    protected string $priority;
+
+    #[Transform(CastTestColor::class)]
+    protected string $color;
+}
+
+class MockCustomCastModel extends Model
+{
+    protected $table      = 'cast_records';
+    protected $connection = 'default';
+    protected $timeStamps = false;
+
+    #[Transform(UpperCaseCast::class)]
+    protected string $name;
+}
+
+class MockCustomDateFormatModel extends Model
+{
+    protected $table      = 'cast_records';
+    protected $connection = 'default';
+    protected $timeStamps = false;
+
+    #[Transform('datetime:d/m/Y')]
+    protected string $invoiced_at;
+}
+
+class MockTransformEnumModel extends Model
+{
+    protected $table      = 'cast_records';
+    protected $connection = 'default';
+    protected $timeStamps = false;
+
+    #[Transform(Type::String)]
+    protected string $label;
+
+    #[Transform(Type::Integer)]
+    protected string $score;
+}
+
+class MockNoCastsModel extends Model
+{
+    protected $table      = 'cast_records';
+    protected $connection = 'default';
+    protected $timeStamps = false;
+}
+
+class CastSystemTest extends TestCase
+{
+    private $pdo;
+
+    protected function setUp(): void
+    {
+        Container::setInstance(new MockContainer());
+        $container = new Container();
+        $container->bind('request', fn() => new Request());
+        $container->bind('url', fn() => UrlGenerator::class);
+        $container->bind('db', fn() => new Database('default'));
+
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $this->createTestTable();
+        $this->setupDatabaseConnections();
+
+        CastManager::flush();
+        MockPrimitiveCastModel::resetCastCache();
+        MockDateCastModel::resetCastCache();
+        MockStructuralCastModel::resetCastCache();
+        MockDecimalCastModel::resetCastCache();
+        MockEnumCastModel::resetCastCache();
+        MockCustomCastModel::resetCastCache();
+        MockCustomDateFormatModel::resetCastCache();
+        MockTransformEnumModel::resetCastCache();
+        MockNoCastsModel::resetCastCache();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->pdo = null;
+        $this->tearDownDatabaseConnections();
+        CastManager::flush();
+    }
+
+    private function createTestTable(): void
+    {
+        $this->pdo->exec("
+            CREATE TABLE cast_records (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                label        TEXT,
+                score        TEXT,
+                weight       TEXT,
+                is_active    TEXT,
+                published_at TEXT,
+                birthday     TEXT,
+                created_ts   TEXT,
+                options      TEXT,
+                tags         TEXT,
+                config       TEXT,
+                items        TEXT,
+                price        TEXT,
+                tax_rate     TEXT,
+                status       TEXT,
+                priority     TEXT,
+                color        TEXT,
+                name         TEXT,
+                invoiced_at  TEXT
+            )
+        ");
+    }
+
+    private function setupDatabaseConnections(): void
+    {
+        $this->setStaticProperty(Database::class, 'connections', [
+            'default' => $this->pdo,
+            'sqlite'  => $this->pdo,
+        ]);
+        $this->setStaticProperty(Database::class, 'transactions', []);
+    }
+
+    private function tearDownDatabaseConnections(): void
+    {
+        $this->setStaticProperty(Database::class, 'connections', []);
+        $this->setStaticProperty(Database::class, 'transactions', []);
+    }
+
+    private function setStaticProperty(string $class, string $property, mixed $value): void
+    {
+        $ref = new \ReflectionClass($class);
+        $prop = $ref->getProperty($property);
+        $prop->setAccessible(true);
+        $prop->setValue(null, $value);
+        $prop->setAccessible(false);
+    }
+
+    private function insertRecord(array $data): int
+    {
+        $cols = implode(', ', array_keys($data));
+        $placeholders = implode(', ', array_fill(0, count($data), '?'));
+        $stmt = $this->pdo->prepare("INSERT INTO cast_records ({$cols}) VALUES ({$placeholders})");
+        $stmt->execute(array_values($data));
+        return (int) $this->pdo->lastInsertId();
+    }
+
+    public function testHasCastReturnsTrueForDeclaredProperties(): void
+    {
+        $model = new MockPrimitiveCastModel();
+
+        $this->assertTrue($model->hasCast('label'));
+        $this->assertTrue($model->hasCast('score'));
+        $this->assertTrue($model->hasCast('weight'));
+        $this->assertTrue($model->hasCast('is_active'));
+    }
+
+    public function testHasCastReturnsFalseForUndeclaredProperties(): void
+    {
+        $model = new MockPrimitiveCastModel();
+
+        $this->assertFalse($model->hasCast('nonexistent'));
+        $this->assertFalse($model->hasCast('id'));
+    }
+
+    public function testGetCastTypeReturnsCorrectType(): void
+    {
+        $model = new MockPrimitiveCastModel();
+
+        $this->assertSame('string',  $model->getCastType('label'));
+        $this->assertSame('integer', $model->getCastType('score'));
+        $this->assertSame('float',   $model->getCastType('weight'));
+        $this->assertSame('boolean', $model->getCastType('is_active'));
+    }
+
+    public function testGetCastTypeReturnsNullForUnknownKey(): void
+    {
+        $model = new MockPrimitiveCastModel();
+
+        $this->assertNull($model->getCastType('nonexistent'));
+    }
+
+    public function testGetCastsReturnsAllDefinitions(): void
+    {
+        $model = new MockPrimitiveCastModel();
+        $casts = $model->getCasts();
+
+        $this->assertIsArray($casts);
+        $this->assertArrayHasKey('label',     $casts);
+        $this->assertArrayHasKey('score',     $casts);
+        $this->assertArrayHasKey('weight',    $casts);
+        $this->assertArrayHasKey('is_active', $casts);
+        $this->assertCount(4, $casts);
+    }
+
+    public function testModelWithNoCastsReturnsEmptyArray(): void
+    {
+        $model = new MockNoCastsModel();
+
+        $this->assertSame([], $model->getCasts());
+        $this->assertFalse($model->hasCast('label'));
+    }
+
+    public function testCacheIsNotPopulatedUntilFirstAccess(): void
+    {
+        MockPrimitiveCastModel::resetCastCache();
+
+        $ref   = new \ReflectionClass(Model::class);
+        $cache = $ref->getProperty('castAttributeCache');
+        $cache->setAccessible(true);
+
+        $before = $cache->getValue(null);
+        $this->assertArrayNotHasKey(MockPrimitiveCastModel::class, $before);
+
+        $model = new MockPrimitiveCastModel();
+        $model->hasCast('label'); // triggers lazy load
+
+        $after = $cache->getValue(null);
+        $this->assertArrayHasKey(MockPrimitiveCastModel::class, $after);
+
+        $cache->setAccessible(false);
+    }
+
+    public function testCacheIsSharedAcrossInstancesOfSameClass(): void
+    {
+        $a = new MockPrimitiveCastModel();
+        $b = new MockPrimitiveCastModel();
+
+        $a->hasCast('label'); // prime cache via instance a
+
+        $ref   = new \ReflectionClass(Model::class);
+        $cache = $ref->getProperty('castAttributeCache');
+        $cache->setAccessible(true);
+        $data = $cache->getValue(null);
+        $cache->setAccessible(false);
+
+        // Both instances share the same static cache entry
+        $this->assertArrayHasKey(MockPrimitiveCastModel::class, $data);
+        $this->assertTrue($b->hasCast('label'));
+    }
+
+    public function testResetCastCacheFlushesSpecificClass(): void
+    {
+        $model = new MockPrimitiveCastModel();
+        $model->hasCast('label');
+
+        MockPrimitiveCastModel::resetCastCache(MockPrimitiveCastModel::class);
+
+        $ref   = new \ReflectionClass(Model::class);
+        $cache = $ref->getProperty('castAttributeCache');
+        $cache->setAccessible(true);
+        $data = $cache->getValue(null);
+        $cache->setAccessible(false);
+
+        $this->assertArrayNotHasKey(MockPrimitiveCastModel::class, $data);
+    }
+
+    public function testResetCastCacheFlushesAll(): void
+    {
+        (new MockPrimitiveCastModel())->hasCast('label');
+        (new MockDateCastModel())->hasCast('published_at');
+
+        MockPrimitiveCastModel::resetCastCache();
+
+        $ref   = new \ReflectionClass(Model::class);
+        $cache = $ref->getProperty('castAttributeCache');
+        $cache->setAccessible(true);
+        $data = $cache->getValue(null);
+        $cache->setAccessible(false);
+
+        $this->assertEmpty($data);
+    }
+
+    public function testStringCast(): void
+    {
+        $model = new MockPrimitiveCastModel(['label' => 123]);
+
+        $this->assertSame('123', $model->label);
+        $this->assertIsString($model->label);
+    }
+
+    public function testIntegerCast(): void
+    {
+        $model = new MockPrimitiveCastModel(['score' => '42']);
+
+        $this->assertSame(42, $model->score);
+        $this->assertIsInt($model->score);
+    }
+
+    public function testFloatCast(): void
+    {
+        $model = new MockPrimitiveCastModel(['weight' => '3.14']);
+
+        $this->assertSame(3.14, $model->weight);
+        $this->assertIsFloat($model->weight);
+    }
+
+    public function testBooleanCastTrueValues(): void
+    {
+        foreach (['1', 'true', 'yes', 'on'] as $truthy) {
+            $model = new MockPrimitiveCastModel(['is_active' => $truthy]);
+            $this->assertTrue($model->is_active, "Expected true for value: {$truthy}");
+        }
+    }
+
+    public function testBooleanCastFalseValues(): void
+    {
+        foreach (['0', 'false', 'no', 'off', ''] as $falsy) {
+            $model = new MockPrimitiveCastModel(['is_active' => $falsy]);
+            $this->assertFalse($model->is_active, "Expected false for value: {$falsy}");
+        }
+    }
+
+    public function testTransformWithTypeEnumString(): void
+    {
+        $model = new MockTransformEnumModel(['label' => 99]);
+
+        $this->assertSame('99', $model->label);
+        $this->assertIsString($model->label);
+    }
+
+    public function testTransformWithTypeEnumInteger(): void
+    {
+        $model = new MockTransformEnumModel(['score' => '7']);
+
+        $this->assertSame(7, $model->score);
+        $this->assertIsInt($model->score);
+    }
+
+    public function testDateTimeCastReturnsCarbon(): void
+    {
+        $model = new MockDateCastModel(['published_at' => '2024-06-15 12:00:00']);
+
+        $this->assertInstanceOf(Carbon::class, $model->published_at);
+        $this->assertSame('2024-06-15', $model->published_at->format('Y-m-d'));
+    }
+
+    public function testDateCastReturnsCarbon(): void
+    {
+        $model = new MockDateCastModel(['birthday' => '1990-03-25']);
+
+        $this->assertInstanceOf(Carbon::class, $model->birthday);
+        $this->assertSame('1990-03-25', $model->birthday->format('Y-m-d'));
+    }
+
+    public function testTimestampCastGetReturnsCarbon(): void
+    {
+        // TimestampCast::get parses any stored value into a Carbon instance
+        $model = new MockDateCastModel(['created_ts' => '2024-01-01 00:00:00']);
+
+        $this->assertInstanceOf(Carbon::class, $model->created_ts);
+        $this->assertSame('2024-01-01', $model->created_ts->format('Y-m-d'));
+    }
+
+    public function testTimestampCastSetConvertsDateTimeToUnixInt(): void
+    {
+        // TimestampCast::set serialises a DateTimeInterface to a Unix timestamp integer
+        $model = new MockDateCastModel();
+        $model->fill(['created_ts' => Carbon::parse('2024-01-01 00:00:00')]);
+
+        $stored = $model->getAttributes()['created_ts'];
+        $this->assertIsInt($stored);
+        $this->assertSame(Carbon::parse('2024-01-01 00:00:00')->getTimestamp(), $stored);
+    }
+
+    public function testCustomDateTimeFormatCast(): void
+    {
+        $model = new MockCustomDateFormatModel(['invoiced_at' => '2024-06-15 09:30:00']);
+
+        $this->assertInstanceOf(Carbon::class, $model->invoiced_at);
+        $this->assertSame('2024-06-15', $model->invoiced_at->format('Y-m-d'));
+    }
+
+    public function testDateTimeCastNullPassthrough(): void
+    {
+        $model = new MockDateCastModel(['published_at' => null]);
+
+        $this->assertNull($model->published_at);
+    }
+
+    public function testArrayCast(): void
+    {
+        $model = new MockStructuralCastModel(['options' => '{"color":"red","size":"M"}']);
+
+        $this->assertIsArray($model->options);
+        $this->assertSame('red', $model->options['color']);
+        $this->assertSame('M',   $model->options['size']);
+    }
+
+    public function testJsonCast(): void
+    {
+        $model = new MockStructuralCastModel(['tags' => '["php","doppar"]']);
+
+        $this->assertIsArray($model->tags);
+        $this->assertContains('php',    $model->tags);
+        $this->assertContains('doppar', $model->tags);
+    }
+
+    public function testObjectCast(): void
+    {
+        $model = new MockStructuralCastModel(['config' => '{"debug":true,"version":"1.0"}']);
+
+        $this->assertIsObject($model->config);
+        $this->assertTrue($model->config->debug);
+        $this->assertSame('1.0', $model->config->version);
+    }
+
+    public function testCollectionCast(): void
+    {
+        $model = new MockStructuralCastModel(['items' => '["a","b","c"]']);
+
+        $this->assertInstanceOf(Collection::class, $model->items);
+        $this->assertCount(3, $model->items);
+    }
+
+    public function testDecimalCastTwoPlaces(): void
+    {
+        $model = new MockDecimalCastModel(['price' => '19.9999']);
+
+        $this->assertSame(20.0, $model->price);
+    }
+
+    public function testDecimalCastFourPlaces(): void
+    {
+        $model = new MockDecimalCastModel(['tax_rate' => '0.12345']);
+
+        $this->assertSame(0.1235, $model->tax_rate);
+    }
+
+    public function testDecimalCastSetRoundTrip(): void
+    {
+        $model = new MockDecimalCastModel();
+        $model->fill(['price' => '9.9999']);
+
+        $this->assertSame(10.0, $model->price);
+    }
+
+    public function testBackedStringEnumCast(): void
+    {
+        $model = new MockEnumCastModel(['status' => 'active']);
+
+        $this->assertInstanceOf(CastTestStatus::class, $model->status);
+        $this->assertSame(CastTestStatus::Active, $model->status);
+    }
+
+    public function testBackedIntEnumCast(): void
+    {
+        $model = new MockEnumCastModel(['priority' => '2']);
+
+        $this->assertInstanceOf(CastTestPriority::class, $model->priority);
+        $this->assertSame(CastTestPriority::Medium, $model->priority);
+    }
+
+    public function testPureUnitEnumCast(): void
+    {
+        $model = new MockEnumCastModel(['color' => 'Green']);
+
+        $this->assertInstanceOf(CastTestColor::class, $model->color);
+        $this->assertSame(CastTestColor::Green, $model->color);
+    }
+
+    public function testEnumSetCastSerializesBackedEnum(): void
+    {
+        $model = new MockEnumCastModel();
+        $model->fill(['status' => CastTestStatus::Inactive]);
+
+        $this->assertSame('inactive', $model->getAttributes()['status']);
+    }
+
+    public function testEnumSetCastSerializesUnitEnum(): void
+    {
+        $model = new MockEnumCastModel();
+        $model->fill(['color' => CastTestColor::Blue]);
+
+        $this->assertSame('Blue', $model->getAttributes()['color']);
+    }
+
+    public function testInvalidEnumValueThrows(): void
+    {
+        // __get swallows all Throwables, so test the handler directly
+        $this->expectException(\ValueError::class);
+
+        CastManager::resolve(CastTestColor::class)->get('Purple');
+    }
+    public function testCustomCastGetUppercases(): void
+    {
+        $model = new MockCustomCastModel(['name' => 'doppar']);
+
+        $this->assertSame('DOPPAR', $model->name);
+    }
+
+    public function testCustomCastSetLowercases(): void
+    {
+        $model = new MockCustomCastModel();
+        $model->fill(['name' => 'DOPPAR']);
+
+        $this->assertSame('doppar', $model->getAttributes()['name']);
+    }
+
+    public function testNullValuePassesThroughAllCasts(): void
+    {
+        $model = new MockPrimitiveCastModel([
+            'label'     => null,
+            'score'     => null,
+            'weight'    => null,
+            'is_active' => null,
+        ]);
+
+        $this->assertNull($model->label);
+        $this->assertNull($model->score);
+        $this->assertNull($model->weight);
+        $this->assertNull($model->is_active);
+    }
+
+    public function testGetCastAttributesAppliesCastsToAll(): void
+    {
+        $model = new MockPrimitiveCastModel([
+            'label'     => 42,
+            'score'     => '10',
+            'weight'    => '1.5',
+            'is_active' => '1',
+        ]);
+
+        $result = $model->getCastAttributes();
+
+        $this->assertSame('42',  $result['label']);
+        $this->assertSame(10,    $result['score']);
+        $this->assertSame(1.5,   $result['weight']);
+        $this->assertTrue($result['is_active']);
+    }
+
+    public function testCastManagerResolvesKnownPrimitives(): void
+    {
+        foreach (['string', 'integer', 'float', 'boolean', 'array', 'json', 'object', 'collection', 'datetime', 'date', 'timestamp'] as $type) {
+            $handler = CastManager::resolve($type);
+            $this->assertInstanceOf(CastableInterface::class, $handler);
+        }
+    }
+
+    public function testCastManagerResolvesDecimalWithPrecision(): void
+    {
+        $handler = CastManager::resolve('decimal:3');
+        $this->assertSame(1.235, $handler->get('1.2345'));
+    }
+
+    public function testCastManagerResolvesDatetimeWithFormat(): void
+    {
+        $handler = CastManager::resolve('datetime:Y/m/d');
+        $result  = $handler->get('2024-06-15 00:00:00');
+        $this->assertInstanceOf(Carbon::class, $result);
+    }
+
+    public function testCastManagerResolvesBackedEnum(): void
+    {
+        $handler = CastManager::resolve(CastTestStatus::class);
+        $result  = $handler->get('inactive');
+        $this->assertSame(CastTestStatus::Inactive, $result);
+    }
+
+    public function testCastManagerResolvesCustomCastClass(): void
+    {
+        $handler = CastManager::resolve(UpperCaseCast::class);
+        $this->assertSame('HELLO', $handler->get('hello'));
+    }
+
+    public function testCastManagerThrowsOnUnsupportedType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        CastManager::resolve('totally_unknown_cast_xyz');
+    }
+
+    public function testCastManagerFlushClearsResolvedCache(): void
+    {
+        CastManager::resolve('string'); // populate cache
+        CastManager::flush();
+
+        $ref      = new \ReflectionClass(CastManager::class);
+        $resolved = $ref->getProperty('resolved');
+        $resolved->setAccessible(true);
+        $value = $resolved->getValue(null);
+        $resolved->setAccessible(false);
+
+        $this->assertEmpty($value);
+    }
+
+    public function testRequiresSetCastForComplexTypes(): void
+    {
+        foreach (['array', 'json', 'object', 'collection', 'datetime', 'date', 'timestamp', 'decimal:2', 'datetime:d/m/Y'] as $type) {
+            $this->assertTrue(CastManager::requiresSetCast($type), "Expected true for: {$type}");
+        }
+    }
+
+    public function testRequiresSetCastFalseForPrimitives(): void
+    {
+        foreach (['string', 'integer', 'float', 'boolean'] as $type) {
+            $this->assertFalse(CastManager::requiresSetCast($type), "Expected false for: {$type}");
+        }
+    }
+
+    public function testRequiresSetCastTrueForEnum(): void
+    {
+        $this->assertTrue(CastManager::requiresSetCast(CastTestStatus::class));
+    }
+
+    public function testRequiresSetCastTrueForCustomCastClass(): void
+    {
+        $this->assertTrue(CastManager::requiresSetCast(UpperCaseCast::class));
+    }
+
+    public function testStringCastRoundTripFromDatabase(): void
+    {
+        $id = $this->insertRecord(['label' => 'hello']);
+
+        $model = MockPrimitiveCastModel::find($id);
+
+        $this->assertSame('hello', $model->label);
+        $this->assertIsString($model->label);
+    }
+
+    public function testIntegerCastRoundTripFromDatabase(): void
+    {
+        $id = $this->insertRecord(['score' => '99']);
+
+        $model = MockPrimitiveCastModel::find($id);
+
+        $this->assertSame(99, $model->score);
+        $this->assertIsInt($model->score);
+    }
+
+    public function testBooleanCastRoundTripFromDatabase(): void
+    {
+        $id = $this->insertRecord(['is_active' => '1']);
+
+        $model = MockPrimitiveCastModel::find($id);
+
+        $this->assertTrue($model->is_active);
+    }
+
+    public function testDateTimeCastRoundTripFromDatabase(): void
+    {
+        $id = $this->insertRecord(['published_at' => '2024-03-10 08:30:00']);
+
+        $model = MockDateCastModel::find($id);
+
+        $this->assertInstanceOf(Carbon::class, $model->published_at);
+        $this->assertSame('2024-03-10', $model->published_at->format('Y-m-d'));
+        $this->assertSame('08:30:00',   $model->published_at->format('H:i:s'));
+    }
+
+    public function testArrayCastRoundTripFromDatabase(): void
+    {
+        $id = $this->insertRecord(['options' => '{"size":"L","color":"blue"}']);
+
+        $model = MockStructuralCastModel::find($id);
+
+        $this->assertIsArray($model->options);
+        $this->assertSame('L',    $model->options['size']);
+        $this->assertSame('blue', $model->options['color']);
+    }
+
+    public function testDecimalCastRoundTripFromDatabase(): void
+    {
+        $id = $this->insertRecord(['price' => '49.9999']);
+
+        $model = MockDecimalCastModel::find($id);
+
+        $this->assertSame(50.0, $model->price);
+    }
+
+    public function testEnumCastRoundTripFromDatabase(): void
+    {
+        $id = $this->insertRecord(['status' => 'inactive']);
+
+        $model = MockEnumCastModel::find($id);
+
+        $this->assertInstanceOf(CastTestStatus::class, $model->status);
+        $this->assertSame(CastTestStatus::Inactive, $model->status);
+    }
+
+    public function testCollectionCastRoundTripFromDatabase(): void
+    {
+        $id = $this->insertRecord(['items' => '["x","y","z"]']);
+
+        $model = MockStructuralCastModel::find($id);
+
+        $this->assertInstanceOf(Collection::class, $model->items);
+        $this->assertCount(3, $model->items);
+    }
+}


### PR DESCRIPTION
This PR introduces a fully attribute-driven casting system for entities, replacing the legacy $casts array with a more modern, type-safe, and extensible approach.

```php
use Phaseolies\Database\Entity\Casts\Attributes\ToDateTime;
use Phaseolies\Database\Entity\Casts\Attributes\ToString;

#[ToDateTime]
protected string $joining_date;

#[ToString]
protected string $salary;
```


All available shorthand attributes:

```php
#[ToString]      protected string  $name;
#[ToInteger]     protected int     $views;
#[ToFloat]       protected float   $weight;
#[ToBoolean]     protected bool    $is_active;
#[ToDate]        protected string  $birthday;
#[ToDateTime]    protected string  $published_at;
#[ToTimestamp]   protected int     $created_at;
#[ToArray]       protected string  $options;
#[ToJson]        protected string  $tags;
#[ToObject]      protected string  $config;
#[ToCollection]  protected string  $images;
```
Added support for custom and enum casting via the base `#[Transform]` attribute:
```php
#[Transform('decimal:2')] protected string $price; 

#[Transform(OrderStatus::class)] protected string $status;
```