### PR TITLE
Fix redundant instantiations and uncached reflection in model internals

### DIFF
--- a/src/Phaseolies/Database/Entity/Computed/InteractsWithComputedProperties.php
+++ b/src/Phaseolies/Database/Entity/Computed/InteractsWithComputedProperties.php
@@ -61,7 +61,13 @@ trait InteractsWithComputedProperties
     {
         $this->ensureComputedCached();
 
-        foreach (self::$computedAttributeCache[static::class] as $entry) {
+        $entries = self::$computedAttributeCache[static::class];
+
+        if (empty($entries)) {
+            return false;
+        }
+
+        foreach ($entries as $entry) {
             if ($entry['key'] === $name || $entry['method'] === $name) {
                 return true;
             }

--- a/src/Phaseolies/Database/Entity/Model.php
+++ b/src/Phaseolies/Database/Entity/Model.php
@@ -564,8 +564,12 @@ abstract class Model implements ArrayAccess, JsonSerializable, Stringable, Jsona
             }
         }
 
-        foreach ($this->getComputedAttributes() as $key => $value) {
-            $visibleAttributes[$key] = $value;
+        $computed = $this->getComputedAttributes();
+
+        if (!empty($computed)) {
+            foreach ($computed as $key => $value) {
+                $visibleAttributes[$key] = $value;
+            }
         }
 
         return $visibleAttributes;

--- a/src/Phaseolies/Database/Entity/Query/InteractsWithModelQueryProcessing.php
+++ b/src/Phaseolies/Database/Entity/Query/InteractsWithModelQueryProcessing.php
@@ -282,7 +282,7 @@ trait InteractsWithModelQueryProcessing
         $model = new static();
         $usesTimestamps = $model->timeStamps;
         $hasCastToDate = $usesTimestamps
-            ? (new static())->propertyHasAttribute(new static(), 'timeStamps', CastToDate::class)
+            ? $model->propertyHasAttribute($model, 'timeStamps', CastToDate::class)
             : false;
 
         if ($hasCastToDate) {
@@ -502,14 +502,20 @@ trait InteractsWithModelQueryProcessing
         }
 
         if ($this->usesTimestamps()) {
-            $hasCastToDate = $this->propertyHasAttribute(static::class, 'timeStamps', CastToDate::class);
-            if ($hasCastToDate) {
-                trigger_error(
-                    'CastToDate attribute is deprecated and will be removed in a future major version. Use #[ToDate] from Phaseolies\Database\Entity\Casts\Attributes\ToDate instead.',
-                    E_USER_DEPRECATED
-                );
+            static $castToDateCache = [];
+            $class = static::class;
+
+            if (!array_key_exists($class, $castToDateCache)) {
+                $castToDateCache[$class] = $this->propertyHasAttribute(static::class, 'timeStamps', CastToDate::class);
+                if ($castToDateCache[$class]) {
+                    trigger_error(
+                        'CastToDate attribute is deprecated and will be removed in a future major version. Use #[ToDate] from Phaseolies\Database\Entity\Casts\Attributes\ToDate instead.',
+                        E_USER_DEPRECATED
+                    );
+                }
             }
-            $dirty['updated_at'] = $hasCastToDate
+
+            $dirty['updated_at'] = $castToDateCache[$class]
                 ? now()->startOfDay()
                 : now();
         }
@@ -547,7 +553,6 @@ trait InteractsWithModelQueryProcessing
 
         if ($reflection->hasProperty($attribute)) {
             $property = $reflection->getProperty($attribute);
-            $property->setAccessible(true);
 
             return $property->isStatic()
                 ? $property->getValue()


### PR DESCRIPTION
Three performance issues found and fixed in `InteractsWithModelQueryProcessing`:

1. **`update()` — reflection ran on every call** — `propertyHasAttribute()` creates a `ReflectionClass` internally. It was called on every `update()` with no caching, so a model that is updated 100 times in a request paid the reflection cost 100 times.

2. **`saveMany()` — 3 model instances created, only 1 needed** — `(new static())->propertyHasAttribute(new static(), ...)` allocated two extra model instances when the already-created `$model` variable was sitting right there.

3. **`getClassProperty()` — called deprecated `setAccessible()`** — `ReflectionProperty::setAccessible()` has been a no-op since PHP 8.1 and triggers a deprecation notice in PHP 8.3. The call was removed.