### PR TITLE
Improve thin-coverage test areas

### DIFF
--- a/tests/Auth/ActorManagerTest.php
+++ b/tests/Auth/ActorManagerTest.php
@@ -119,5 +119,18 @@ namespace Tests\Unit\Auth {
 
             $this->assertNotSame($web, $admin);
         }
+
+        public function testActorDefaultsToConfiguredDefaultWhenNameIsNull()
+        {
+            $default = $this->manager->actor();
+
+            $this->assertInstanceOf(Authenticate::class, $default);
+            $this->assertSame('web', $default->name());
+        }
+
+        public function testMagicCallProxiesToDefaultActor()
+        {
+            $this->assertSame('web', $this->manager->name());
+        }
     }
 }

--- a/tests/Auth/PasswordHashingTest.php
+++ b/tests/Auth/PasswordHashingTest.php
@@ -3,7 +3,7 @@
 namespace Phaseolies\Auth\Security {
     function config(string $key, mixed $default = null): mixed
     {
-        $map = [
+        $map = $GLOBALS['doppar_hashing_test_config'] ?? [
             'hashing.driver'        => 'bcrypt',
             'hashing.bcrypt.rounds' => 10,
         ];
@@ -23,7 +23,16 @@ namespace Tests\Unit\Auth {
 
         protected function setUp(): void
         {
+            $GLOBALS['doppar_hashing_test_config'] = [
+                'hashing.driver' => 'bcrypt',
+                'hashing.bcrypt.rounds' => 10,
+            ];
             $this->hashing = new PasswordHashing();
+        }
+
+        protected function tearDown(): void
+        {
+            unset($GLOBALS['doppar_hashing_test_config']);
         }
 
         public function testMakeReturnsBcryptHash()
@@ -97,6 +106,43 @@ namespace Tests\Unit\Auth {
             $hash = $this->hashing->make('password');
 
             $this->assertGreaterThan(50, strlen($hash));
+        }
+
+        public function testMakeThrowsForInvalidBcryptRounds()
+        {
+            $GLOBALS['doppar_hashing_test_config'] = [
+                'hashing.driver' => 'bcrypt',
+                'hashing.bcrypt.rounds' => 3,
+            ];
+
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('Bcrypt rounds must be between 4 and 31.');
+
+            $this->hashing->make('password');
+        }
+
+        public function testMakeThrowsForUnsupportedDriver()
+        {
+            $GLOBALS['doppar_hashing_test_config'] = [
+                'hashing.driver' => 'sha1',
+            ];
+
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('Unsupported hashing driver: sha1');
+
+            $this->hashing->make('password');
+        }
+
+        public function testNeedsRehashThrowsForUnsupportedDriver()
+        {
+            $GLOBALS['doppar_hashing_test_config'] = [
+                'hashing.driver' => 'sha1',
+            ];
+
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('Unsupported hashing driver: sha1');
+
+            $this->hashing->needsRehash(password_hash('password', PASSWORD_BCRYPT, ['cost' => 10]));
         }
     }
 }

--- a/tests/Logger/LogServiceTest.php
+++ b/tests/Logger/LogServiceTest.php
@@ -14,7 +14,13 @@ class LogServiceTest extends TestCase
 
     protected function setUp(): void
     {
+        putenv('LOG_CHANNEL');
         $this->logService = new LogService();
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('LOG_CHANNEL');
     }
 
     public function testGetLoggerReturnsMonologInstance()
@@ -85,5 +91,28 @@ class LogServiceTest extends TestCase
         $logger2 = $this->logService->getLogger('ch');
 
         $this->assertNotSame($logger1, $logger2);
+    }
+
+    public function testGetLoggerUsesEnvChannelWhenChannelNotProvided()
+    {
+        putenv('LOG_CHANNEL=stderr');
+
+        $logger = $this->logService->getLogger();
+
+        $this->assertSame('stderr', $logger->getName());
+    }
+
+    public function testHandlersCanBeAddedAgainAfterReset()
+    {
+        $handler = $this->createMock(LogHandlerInterface::class);
+        $handler->expects($this->once())
+            ->method('configureHandler')
+            ->with($this->isInstanceOf(Logger::class), 'reset-channel');
+
+        $this->logService->addHandler($handler);
+        $this->logService->reset();
+        $this->logService->addHandler($handler);
+
+        $this->logService->getLogger('reset-channel');
     }
 }

--- a/tests/Session/CookieSessionHandlerTest.php
+++ b/tests/Session/CookieSessionHandlerTest.php
@@ -2,9 +2,15 @@
 
 namespace Tests\Unit\Session;
 
+require_once __DIR__ . '/../Support/MockContainer.php';
+
+use Phaseolies\Config\Config;
+use Phaseolies\DI\Container;
 use Phaseolies\Session\Handlers\CookieSessionHandler;
 use PHPUnit\Framework\TestCase;
 use Exception;
+use RuntimeException;
+use Tests\Support\MockContainer;
 
 class CookieSessionHandlerTest extends TestCase
 {
@@ -20,6 +26,22 @@ class CookieSessionHandlerTest extends TestCase
     private function makeHandler(array $overrides = []): CookieSessionHandler
     {
         return new CookieSessionHandler(array_merge($this->config, $overrides));
+    }
+
+    protected function setUp(): void
+    {
+        Container::setInstance(new MockContainer());
+        $this->seedConfig([
+            'app' => ['key' => str_repeat('a', 32)],
+            'session' => ['cookie' => $this->config['cookie']],
+        ]);
+        session_name($this->config['cookie']);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_COOKIE[$this->config['cookie']]);
+        Container::forgetInstance();
     }
 
     public function testOpenReturnsTrue()
@@ -119,5 +141,63 @@ class CookieSessionHandlerTest extends TestCase
         $result = $handler->destroy('session_id_456');
 
         $this->assertIsBool($result);
+    }
+
+    public function testPrivateEncryptAndDecryptRoundTrip()
+    {
+        $handler = $this->makeHandler();
+        $encrypt = new \ReflectionMethod($handler, 'encrypt');
+        $decrypt = new \ReflectionMethod($handler, 'decrypt');
+
+        $encrypted = $encrypt->invoke($handler, 'session_payload');
+        $decrypted = $decrypt->invoke($handler, $encrypted);
+
+        $this->assertIsString($encrypted);
+        $this->assertNotSame('session_payload', $encrypted);
+        $this->assertSame('session_payload', $decrypted);
+    }
+
+    public function testValidatePreservesValidEncryptedCookie()
+    {
+        $handler = $this->makeHandler();
+        $encrypt = new \ReflectionMethod($handler, 'encrypt');
+
+        $_COOKIE[$this->config['cookie']] = $encrypt->invoke($handler, 'valid_payload');
+
+        $handler->validate();
+
+        $this->assertArrayHasKey($this->config['cookie'], $_COOKIE);
+    }
+
+    public function testDecryptThrowsWhenAppKeyIsMissing()
+    {
+        $this->seedConfig([
+            'app' => ['key' => null],
+            'session' => ['cookie' => $this->config['cookie']],
+        ]);
+        $handler = $this->makeHandler();
+        $decrypt = new \ReflectionMethod($handler, 'decrypt');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Encryption key not configured');
+
+        $decrypt->invoke($handler, base64_encode('anything'));
+    }
+
+    private function seedConfig(array $config): void
+    {
+        $this->setConfigStatic('cacheFile', sys_get_temp_dir() . '/doppar_test_config.php');
+        $this->setConfigStatic('config', $config);
+        $this->setConfigStatic('loadedFromCache', true);
+        $this->setConfigStatic('configModified', false);
+        $this->setConfigStatic('fileHashes', []);
+        $this->setConfigStatic('configFiles', []);
+    }
+
+    private function setConfigStatic(string $propertyName, mixed $value): void
+    {
+        $reflection = new \ReflectionClass(Config::class);
+        $property = $reflection->getProperty($propertyName);
+        $property->setValue(null, $value);
     }
 }

--- a/tests/Storage/FileSystemTest.php
+++ b/tests/Storage/FileSystemTest.php
@@ -152,4 +152,68 @@ class FileSystemTest extends TestCase
 
         $this->assertEquals('original_name.txt', $result);
     }
+
+    public function testGetFileNameUsesConfiguredBaseNameAndDetectedExtension()
+    {
+        $pngPath = $this->tmpDir . '/avatar.png';
+        file_put_contents($pngPath, 'png data');
+
+        $file = new \Phaseolies\Support\File([
+            'name' => 'avatar.png',
+            'type' => 'image/png',
+            'tmp_name' => $pngPath,
+            'error' => UPLOAD_ERR_OK,
+            'size' => filesize($pngPath),
+        ]);
+
+        $customFs = new FileSystem($this->tmpDir, 'profile_image');
+
+        $this->assertSame('profile_image.png', $customFs->getFileName($file));
+    }
+
+    public function testPutReturnsFalseWhenSourceStreamCannotBeOpened()
+    {
+        $file = new \Phaseolies\Support\File([
+            'name' => 'missing.txt',
+            'type' => 'text/plain',
+            'tmp_name' => $this->tmpDir . '/does-not-exist.txt',
+            'error' => UPLOAD_ERR_OK,
+            'size' => 0,
+        ]);
+
+        $warning = null;
+        set_error_handler(static function (int $severity, string $message) use (&$warning): bool {
+            $warning = $message;
+            return true;
+        }, E_WARNING);
+
+        try {
+            $this->assertFalse($this->fs->put('uploads', $file));
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertNotNull($warning);
+        $this->assertStringContainsString('Failed to open stream', $warning);
+    }
+
+    public function testPutWritesUsingConfiguredCustomFileName()
+    {
+        $source = $this->tmpDir . '/photo-source.jpg';
+        file_put_contents($source, 'jpeg data');
+
+        $file = new \Phaseolies\Support\File([
+            'name' => 'photo.jpg',
+            'type' => 'image/jpeg',
+            'tmp_name' => $source,
+            'error' => UPLOAD_ERR_OK,
+            'size' => filesize($source),
+        ]);
+
+        $customFs = new FileSystem($this->tmpDir, 'avatar');
+        $customFs->makeDirectory($this->tmpDir . '/uploads', 0755, true);
+
+        $this->assertTrue($customFs->put('uploads', $file));
+        $this->assertFileExists($this->tmpDir . '/uploads/avatar.jpeg');
+    }
 }

--- a/tests/Storage/LocalFileSystemTest.php
+++ b/tests/Storage/LocalFileSystemTest.php
@@ -152,4 +152,47 @@ class LocalFileSystemTest extends TestCase
         $this->assertStringContainsString('line one', $result);
         $this->assertStringContainsString('line three', $result);
     }
+
+    public function testStoreReturnsFalseWhenSourceUploadPathDoesNotExist()
+    {
+        $file = new File([
+            'name' => 'ghost.txt',
+            'type' => 'text/plain',
+            'tmp_name' => $this->tmpDir . '/ghost.txt',
+            'error' => UPLOAD_ERR_OK,
+            'size' => 0,
+        ]);
+
+        $warning = null;
+        set_error_handler(static function (int $severity, string $message) use (&$warning): bool {
+            $warning = $message;
+            return true;
+        }, E_WARNING);
+
+        try {
+            $this->assertFalse($this->fs->store('uploads', $file));
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertNotNull($warning);
+        $this->assertStringContainsString('Failed to open stream', $warning);
+    }
+
+    public function testDeleteReturnsTrueForEmptyArray()
+    {
+        $this->assertTrue($this->fs->delete([]));
+    }
+
+    public function testContentExceptionContainsResolvedFullPath()
+    {
+        $missing = 'nested/missing.txt';
+
+        try {
+            $this->fs->content($missing);
+            $this->fail('Expected FileNotFoundException was not thrown.');
+        } catch (FileNotFoundException $e) {
+            $this->assertStringContainsString($this->tmpDir . '/' . $missing, $e->getMessage());
+        }
+    }
 }


### PR DESCRIPTION
Expands targeted tests for auth, logger, session, and storage edge cases, including default actor resolution, unsupported hashing drivers, env-based log channels, cookie encryption/decryption, and filesystem failure paths.