### PR TITLE
Fix multi-connection ORM state handling and prevent non-column attribute leaks

### DIFF
--- a/src/Phaseolies/Auth/Security/Authenticate.php
+++ b/src/Phaseolies/Auth/Security/Authenticate.php
@@ -160,7 +160,7 @@ class Authenticate
         $authKeyValue = $credentials[$customAuthKey] ?? '';
         $password     = $credentials['password'] ?? '';
 
-        $user = $authModel::query()->where($customAuthKey, $authKeyValue)->first();
+        $user = $authModel::where($customAuthKey, $authKeyValue)->first();
 
         if (!$user || !Hash::check($password, $user->password)) {
             return false;

--- a/src/Phaseolies/Database/Database.php
+++ b/src/Phaseolies/Database/Database.php
@@ -609,7 +609,7 @@ class Database
     {
         $connection = $connection ?: config('database.default');
 
-        static::disconnect($connection);
+        $this->disconnect($connection);
 
         return static::getPdoInstance($connection);
     }
@@ -664,7 +664,7 @@ class Database
     public function cleanupAllConnections(): void
     {
         foreach (array_keys(static::$connections) as $connection) {
-            static::disconnect($connection);
+            $this->disconnect($connection);
         }
 
         // Clear all arrays

--- a/src/Phaseolies/Database/Entity/Builder.php
+++ b/src/Phaseolies/Database/Entity/Builder.php
@@ -138,17 +138,26 @@ class Builder
     protected bool $suppressEagerLoad = false;
 
     /**
+     * The resolved connection name for this builder.
+     *
+     * @var string|null
+     */
+    protected ?string $connectionName = null;
+
+    /**
      * @param PDO $pdo
      * @param string $table
      * @param string $modelClass
      * @param int $rowPerPage
+     * @param string|null $connectionName
      */
-    public function __construct(PDO $pdo, string $table, string $modelClass, int $rowPerPage)
+    public function __construct(PDO $pdo, string $table, string $modelClass, int $rowPerPage, ?string $connectionName = null)
     {
         $this->pdo = $pdo;
         $this->table = $table;
         $this->modelClass = $modelClass;
         $this->rowPerPage = $rowPerPage;
+        $this->connectionName = $connectionName;
     }
 
     /**
@@ -161,6 +170,11 @@ class Builder
     {
         $modelClass = $this->modelClass;
         $model = new $modelClass();
+
+        if ($this->connectionName !== null) {
+            $model->setConnectionName($this->connectionName);
+        }
+
         $model->fill($attributes);
         $model->save();
 
@@ -275,7 +289,7 @@ class Builder
      */
     public function whereNested(callable $callback, string $boolean = 'AND'): self
     {
-        $nestedQuery = new static($this->pdo, $this->table, $this->modelClass, $this->rowPerPage);
+        $nestedQuery = new static($this->pdo, $this->table, $this->modelClass, $this->rowPerPage, $this->connectionName);
 
         $callback($nestedQuery);
 
@@ -607,7 +621,7 @@ class Builder
      */
     private function addCallbackConditions(string $subquery, mixed $relatedModel, callable $callback, string $relatedTable): string
     {
-        $subQueryBuilder = $relatedModel::query();
+        $subQueryBuilder = $relatedModel::query($this->connectionName);
         $callback($subQueryBuilder);
 
         $quote = fn($identifier) => $this->quoteIdentifier($identifier);
@@ -903,6 +917,10 @@ class Builder
 
             while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
                 $model = app($this->modelClass, [$row]);
+
+                if ($this->connectionName !== null) {
+                    $model->setConnectionName($this->connectionName);
+                }
 
                 if ($needsEncryption && $this->takeWithoutEncryption) {
                     foreach ($encryptedAttributes as $attribute) {
@@ -1472,7 +1490,7 @@ class Builder
 
         // For linkOne/bindTo relations, the foreignKey is on the related table
         // For linkMany relations, the foreignKey is also on the related table
-        $query = $relatedModelInstance->query()->whereIn($foreignKey, $keys);
+        $query = $relatedModelInstance->query($this->connectionName)->whereIn($foreignKey, $keys);
 
         // Apply constraint (which may include column selection)
         if (is_callable($constraint)) {
@@ -1538,7 +1556,7 @@ class Builder
         $selectedColumns = null;
 
         if (is_callable($constraint)) {
-            $inspectQuery = $relatedModelInstance->query();
+            $inspectQuery = $relatedModelInstance->query($this->connectionName);
             $constraint($inspectQuery);
 
             if ($inspectQuery->fields !== ['*']) {
@@ -1552,7 +1570,7 @@ class Builder
             }
         }
 
-        $query = $relatedModelInstance->query();
+        $query = $relatedModelInstance->query($this->connectionName);
 
         if ($hasCustomSelect) {
             $query->select(array_merge($selectedColumns, $pivotSelects));
@@ -1673,7 +1691,7 @@ class Builder
 
         // Handle one-to-many or one-to-one count
         $relatedModelInstance = app($relatedModel);
-        $query = $relatedModelInstance->query()
+        $query = $relatedModelInstance->query($this->connectionName)
             ->select([$foreignKey, 'COUNT(*) as aggregate'])
             ->whereIn($foreignKey, $localKeys)
             ->groupBy($foreignKey);
@@ -1725,7 +1743,7 @@ class Builder
         $relatedModelInstance = new $relatedModel();
         $relatedTable = $relatedModelInstance->getTable();
 
-        $query = $relatedModelInstance->query()
+        $query = $relatedModelInstance->query($this->connectionName)
             ->select(["{$pivotTable}.{$foreignKey}", 'COUNT(*) as aggregate'])
             ->join(
                 $pivotTable,
@@ -1841,7 +1859,7 @@ class Builder
     protected function loadOneToOne(array $models, string $relation, string $relatedModel, string $foreignKey, string $localKey): void
     {
         $localKeys = array_map(fn($model) => $model->$localKey, $models);
-        $relatedModels = $relatedModel::query()
+        $relatedModels = $relatedModel::query($this->connectionName)
             ->whereIn($foreignKey, $localKeys)
             ->get()
             ->keyBy($foreignKey);
@@ -1867,7 +1885,7 @@ class Builder
     protected function loadOneToMany(array $models, string $relation, string $relatedModel, string $foreignKey, string $localKey): void
     {
         $localKeys = array_map(fn($model) => $model->$localKey, $models);
-        $relatedModels = $relatedModel::query()
+        $relatedModels = $relatedModel::query($this->connectionName)
             ->whereIn($foreignKey, $localKeys)
             ->get()
             ->getItemsGroupedBy($foreignKey);
@@ -1951,6 +1969,10 @@ class Builder
             }
 
             $model = new $this->modelClass($result);
+
+            if ($this->connectionName !== null) {
+                $model->setConnectionName($this->connectionName);
+            }
 
             if ($this->needsEncryption() && $this->takeWithoutEncryption) {
                 $encryptedAttributes = $this->getEncryptedAttributes();
@@ -2511,7 +2533,15 @@ class Builder
             $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
             // Convert results to model instances
-            $models = array_map(fn($item) => new $this->modelClass($item), $results);
+            $models = array_map(function ($item) {
+                $model = new $this->modelClass($item);
+
+                if ($this->connectionName !== null) {
+                    $model->setConnectionName($this->connectionName);
+                }
+
+                return $model;
+            }, $results);
 
             $collection = new Collection($this->modelClass, $models);
 

--- a/src/Phaseolies/Database/Entity/Model.php
+++ b/src/Phaseolies/Database/Entity/Model.php
@@ -432,6 +432,27 @@ abstract class Model implements Jsonable, \ArrayAccess, \JsonSerializable, \Stri
     }
 
     /**
+     * Get the connection name for the model.
+     *
+     * @return string|null
+     */
+    public function getConnectionName(): ?string
+    {
+        return $this->connection;
+    }
+
+    /**
+     * Set the connection name for the model.
+     *
+     * @param string|null $connection
+     * @return void
+     */
+    public function setConnectionName(?string $connection): void
+    {
+        $this->connection = $connection;
+    }
+
+    /**
      * Begin querying the model on a given connection.
      *
      * @param string|null $connection
@@ -457,7 +478,8 @@ abstract class Model implements Jsonable, \ArrayAccess, \JsonSerializable, \Stri
             pdo: $this->getConnection(),
             table: $this->getTable(),
             modelClass: static::class,
-            rowPerPage: $this->pageSize
+            rowPerPage: $this->pageSize,
+            connectionName: $this->connection
         );
     }
 
@@ -659,7 +681,7 @@ abstract class Model implements Jsonable, \ArrayAccess, \JsonSerializable, \Stri
                 return false;
             }
 
-            $result = static::query()
+            $result = $this->newQuery()
                 ->where($this->primaryKey, $this->attributes[$this->primaryKey])
                 ->delete();
 
@@ -710,7 +732,7 @@ abstract class Model implements Jsonable, \ArrayAccess, \JsonSerializable, \Stri
 
         $relatedInstance = app($related);
 
-        return $relatedInstance->query()->where($foreignKey, '=', $this->$localKey);
+        return $relatedInstance->query($this->connection)->where($foreignKey, '=', $this->$localKey);
     }
 
     /**
@@ -730,7 +752,7 @@ abstract class Model implements Jsonable, \ArrayAccess, \JsonSerializable, \Stri
 
         $relatedInstance = app($related);
 
-        return $relatedInstance->query()->where($foreignKey, '=', $this->$localKey);
+        return $relatedInstance->query($this->connection)->where($foreignKey, '=', $this->$localKey);
     }
 
     /**
@@ -750,7 +772,7 @@ abstract class Model implements Jsonable, \ArrayAccess, \JsonSerializable, \Stri
 
         $relatedInstance = app($related);
 
-        return $relatedInstance->query()->where($foreignKey, '=', $this->$localKey);
+        return $relatedInstance->query($this->connection)->where($foreignKey, '=', $this->$localKey);
     }
 
     /**
@@ -771,7 +793,7 @@ abstract class Model implements Jsonable, \ArrayAccess, \JsonSerializable, \Stri
         $this->lastPivotTable = $pivotTable;
 
         $relatedModel = app($related);
-        $query = $relatedModel->query();
+        $query = $relatedModel->query($this->connection);
 
         $query->setRelationInfo([
             'type' => 'bindToMany',
@@ -909,7 +931,7 @@ abstract class Model implements Jsonable, \ArrayAccess, \JsonSerializable, \Stri
                                 return "{$pivotTable}.{$column} as pivot_{$column}";
                             }, $pivotColumns);
 
-                            $query = $relatedModel->query()
+                            $query = $relatedModel->query($this->connection)
                                 ->select(array_merge(
                                     ["{$relatedModel->getTable()}.*"],
                                     $pivotSelects
@@ -1058,7 +1080,7 @@ abstract class Model implements Jsonable, \ArrayAccess, \JsonSerializable, \Stri
      */
     public function increment(string $column, int $amount = 1, array $extra = []): int
     {
-        $result = $this->query()
+        $result = $this->newQuery()
             ->where($this->getKeyName(), '=', $this->getKey())
             ->increment($column, $amount, $extra);
 
@@ -1083,7 +1105,7 @@ abstract class Model implements Jsonable, \ArrayAccess, \JsonSerializable, \Stri
      */
     public function decrement(string $column, int $amount = 1, array $extra = []): int
     {
-        $result = $this->query()
+        $result = $this->newQuery()
             ->where($this->getKeyName(), '=', $this->getKey())
             ->decrement($column, $amount, $extra);
 

--- a/src/Phaseolies/Database/Entity/Model.php
+++ b/src/Phaseolies/Database/Entity/Model.php
@@ -144,6 +144,13 @@ abstract class Model implements Jsonable, \ArrayAccess, \JsonSerializable, \Stri
     private static array $hookAttributeCache = [];
 
     /**
+     * Cache of actual table columns keyed by connection/table.
+     *
+     * @var array<string, array<int, string>>
+     */
+    private static array $tableColumnCache = [];
+
+    /**
      * Model constructor.
      *
      * @param array $attributes Initial attributes to populate the model.
@@ -439,6 +446,93 @@ abstract class Model implements Jsonable, \ArrayAccess, \JsonSerializable, \Stri
     public function getConnectionName(): ?string
     {
         return $this->connection;
+    }
+
+    /**
+     * Remove dirty attributes that are not backed by actual table columns
+     *
+     * @param array<string, mixed> $dirty
+     * @return void
+     */
+    public function pruneNonColumnDirtyAttributes(array $dirty): void
+    {
+        if (empty($dirty)) {
+            return;
+        }
+
+        $columns = $this->getTableColumnsForPersistence();
+        if (empty($columns)) {
+            return;
+        }
+
+        foreach (array_keys($dirty) as $key) {
+            if (!in_array($key, $columns, true)) {
+                unset($this->attributes[$key], $this->originalAttributes[$key]);
+            }
+        }
+    }
+
+    /**
+     * Remove attributes that are not backed by actual table columns.
+     *
+     * @param array<string, mixed>|null $attributes
+     * @return void
+     */
+    public function pruneNonColumnAttributes(?array $attributes = null): void
+    {
+        $attributes ??= $this->attributes;
+
+        if (empty($attributes)) {
+            return;
+        }
+
+        $columns = $this->getTableColumnsForPersistence();
+        if (empty($columns)) {
+            return;
+        }
+
+        foreach (array_keys($attributes) as $key) {
+            if (!in_array($key, $columns, true)) {
+                unset($this->attributes[$key], $this->originalAttributes[$key]);
+            }
+        }
+    }
+
+    /**
+     * Get the persisted table columns for this model.
+     *
+     * @return array<int, string>
+     */
+    protected function getTableColumnsForPersistence(): array
+    {
+        $pdo = $this->getConnection();
+        $cacheKey = spl_object_id($pdo) . '|' . $this->getTable();
+
+        if (!array_key_exists($cacheKey, self::$tableColumnCache)) {
+            try {
+                self::$tableColumnCache[$cacheKey] = (new Database($this->connection))
+                    ->getTableColumns($this->getTable());
+            } catch (\Throwable) {
+                self::$tableColumnCache[$cacheKey] = [];
+            }
+        }
+
+        return self::$tableColumnCache[$cacheKey];
+    }
+
+    /**
+     * Reset cached table-column metadata.
+     *
+     * @param string|null $cacheKey
+     * @return void
+     */
+    public static function resetTableColumnCache(?string $cacheKey = null): void
+    {
+        if ($cacheKey !== null) {
+            unset(self::$tableColumnCache[$cacheKey]);
+        } else {
+            self::$tableColumnCache = [];
+        }
     }
 
     /**

--- a/src/Phaseolies/Database/Entity/Query/InteractsWithModelQueryProcessing.php
+++ b/src/Phaseolies/Database/Entity/Query/InteractsWithModelQueryProcessing.php
@@ -184,6 +184,8 @@ trait InteractsWithModelQueryProcessing
                 }
 
                 $dirtyAttributes = $this->getDirtyAttributes();
+                $this->pruneNonColumnDirtyAttributes($dirtyAttributes);
+                $dirtyAttributes = $this->getDirtyAttributes();
                 if (!empty($this->creatable)) {
                     $dirtyAttributes = array_intersect_key($dirtyAttributes, array_flip($this->creatable));
                 }
@@ -201,6 +203,7 @@ trait InteractsWithModelQueryProcessing
                     ->update($dirtyAttributes);
 
                 if (self::$isHookShouldBeCalled && $response) {
+                    $this->pruneNonColumnDirtyAttributes($this->getDirtyAttributes());
                     $this->fireAfterHooks('updated');
                     $this->firePropertyWatches($dirtyAttributes);
                     $this->originalAttributes = $this->attributes;
@@ -213,6 +216,7 @@ trait InteractsWithModelQueryProcessing
                 return false;
             }
 
+            $this->pruneNonColumnAttributes();
             $attributes = $this->getCreatableAttributes();
 
             if ($this->timeStamps) {
@@ -493,6 +497,8 @@ trait InteractsWithModelQueryProcessing
         }
 
         $dirty = $this->getDirtyAttributes();
+        $this->pruneNonColumnDirtyAttributes($dirty);
+        $dirty = $this->getDirtyAttributes();
 
         if (empty($dirty)) {
             return true;
@@ -527,6 +533,7 @@ trait InteractsWithModelQueryProcessing
                 ->update($dirty);
 
             if ($result) {
+                $this->pruneNonColumnDirtyAttributes($this->getDirtyAttributes());
                 if (self::$isHookShouldBeCalled) {
                     $this->fireAfterHooks('updated');
                     $this->firePropertyWatches($dirty);

--- a/src/Phaseolies/Database/Entity/Query/InteractsWithModelQueryProcessing.php
+++ b/src/Phaseolies/Database/Entity/Query/InteractsWithModelQueryProcessing.php
@@ -31,7 +31,8 @@ trait InteractsWithModelQueryProcessing
             Database::getPdoInstance($connection),
             $model->getTable(),
             static::class,
-            $model->pageSize
+            $model->pageSize,
+            $connection
         );
     }
 
@@ -195,7 +196,7 @@ trait InteractsWithModelQueryProcessing
                     $dirtyAttributes['updated_at'] = $dateTime;
                 }
 
-                $response = $this->query()
+                $response = $this->newQuery()
                     ->where($this->primaryKey, $this->attributes[$this->primaryKey])
                     ->update($dirtyAttributes);
 
@@ -219,7 +220,7 @@ trait InteractsWithModelQueryProcessing
                 $attributes['updated_at'] = $dateTime;
             }
 
-            $id = $this->query()->insert($attributes);
+            $id = $this->newQuery()->insert($attributes);
 
             if ($id && self::$isHookShouldBeCalled) {
                 $this->fireAfterHooks('created');
@@ -521,7 +522,7 @@ trait InteractsWithModelQueryProcessing
         }
 
         try {
-            $result = static::query()
+            $result = $this->newQuery()
                 ->where($this->primaryKey, $this->attributes[$this->primaryKey])
                 ->update($dirty);
 

--- a/src/Phaseolies/Database/Entity/Query/InteractsWithNestedRelations.php
+++ b/src/Phaseolies/Database/Entity/Query/InteractsWithNestedRelations.php
@@ -117,7 +117,7 @@ trait InteractsWithNestedRelations
 
         // Apply callback conditions on the final table
         if ($callback && $previousTable) {
-            $subQueryBuilder = $currentModel->query();
+            $subQueryBuilder = $currentModel->query($this->connectionName);
             $callback($subQueryBuilder);
 
             foreach ($subQueryBuilder->conditions as $condition) {

--- a/tests/Builder/DatabaseConnectionPoolTest.php
+++ b/tests/Builder/DatabaseConnectionPoolTest.php
@@ -1,0 +1,256 @@
+<?php
+
+namespace Tests\Unit\Builder;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Phaseolies\Config\Config;
+use Phaseolies\Database\Database;
+
+class DatabaseConnectionPoolTest extends TestCase
+{
+    private Database $database;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $originalConfigState = [];
+
+    private string $primaryPath;
+    private string $analyticsPath;
+
+    protected function setUp(): void
+    {
+        $this->originalConfigState = $this->captureStaticProperties(Config::class, [
+            'config',
+            'cacheFile',
+            'loadedFromCache',
+            'configModified',
+            'fileHashes',
+            'configFiles',
+        ]);
+
+        $this->resetDatabaseStatics();
+        $this->primeDatabaseConfig();
+
+        $this->database = new Database('primary');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetDatabaseStatics();
+        $this->restoreStaticProperties(Config::class, $this->originalConfigState);
+        $this->cleanupTempFile($this->primaryPath ?? null);
+        $this->cleanupTempFile($this->analyticsPath ?? null);
+    }
+
+    public function testGetPdoInstanceCachesConnectionsPerName(): void
+    {
+        $primary = Database::getPdoInstance('primary');
+        $primaryAgain = Database::getPdoInstance('primary');
+        $analytics = Database::getPdoInstance('analytics');
+
+        $this->assertSame($primary, $primaryAgain);
+        $this->assertNotSame($primary, $analytics);
+        $this->assertSame('sqlite', $primary->getAttribute(PDO::ATTR_DRIVER_NAME));
+        $this->assertTrue($this->database->isConnected('primary'));
+        $this->assertTrue($this->database->isConnected('analytics'));
+    }
+
+    public function testTransactionLevelsAreTrackedPerConnection(): void
+    {
+        $primary = new Database('primary');
+        $analytics = new Database('analytics');
+
+        $primary->beginTransaction();
+        $this->assertSame(1, Database::transactionLevel('primary'));
+        $this->assertSame(0, Database::transactionLevel('analytics'));
+
+        $analytics->beginTransaction();
+        $this->assertSame(1, Database::transactionLevel('primary'));
+        $this->assertSame(1, Database::transactionLevel('analytics'));
+
+        $primary->beginTransaction();
+        $this->assertSame(2, Database::transactionLevel('primary'));
+        $this->assertSame(1, Database::transactionLevel('analytics'));
+
+        $primary->rollBack();
+        $this->assertSame(1, Database::transactionLevel('primary'));
+
+        $analytics->rollBack();
+        $this->assertSame(0, Database::transactionLevel('analytics'));
+
+        $primary->rollBack();
+        $this->assertSame(0, Database::transactionLevel('primary'));
+    }
+
+    public function testDisconnectRemovesOnlyRequestedConnection(): void
+    {
+        Database::getPdoInstance('primary');
+        Database::getPdoInstance('analytics');
+
+        $analytics = new Database('analytics');
+        $analytics->beginTransaction();
+
+        $this->assertTrue($this->database->disconnect('analytics'));
+        $this->assertTrue($this->database->isConnected('primary'));
+        $this->assertFalse($this->database->isConnected('analytics'));
+        $this->assertSame(0, Database::transactionLevel('analytics'));
+
+        $connections = $this->getStaticProperty(Database::class, 'connections');
+        $drivers = $this->getStaticProperty(Database::class, 'drivers');
+
+        $this->assertArrayHasKey('primary', $connections);
+        $this->assertArrayNotHasKey('analytics', $connections);
+        $this->assertArrayHasKey('primary', $drivers);
+        $this->assertArrayNotHasKey('analytics', $drivers);
+    }
+
+    public function testReconnectReturnsFreshConnectionAndReplacesPooledInstance(): void
+    {
+        $original = Database::getPdoInstance('primary');
+
+        $reconnected = $this->database->reconnect('primary');
+        $pooled = Database::getPdoInstance('primary');
+
+        $this->assertInstanceOf(PDO::class, $reconnected);
+        $this->assertNotSame($original, $reconnected);
+        $this->assertSame($reconnected, $pooled);
+        $this->assertTrue($this->database->isConnected('primary'));
+    }
+
+    public function testGetFreshConnectionBypassesThePool(): void
+    {
+        $pooled = Database::getPdoInstance('primary');
+        $fresh = $this->database->getFreshConnection('primary');
+        $pooledAgain = Database::getPdoInstance('primary');
+
+        $this->assertInstanceOf(PDO::class, $fresh);
+        $this->assertNotSame($pooled, $fresh);
+        $this->assertSame($pooled, $pooledAgain);
+    }
+
+    public function testCleanupAllConnectionsClearsPoolsDriversAndTransactions(): void
+    {
+        Database::getPdoInstance('primary');
+        Database::getPdoInstance('analytics');
+
+        $primary = new Database('primary');
+        $analytics = new Database('analytics');
+
+        $primary->beginTransaction();
+        $analytics->beginTransaction();
+
+        $this->database->cleanupAllConnections();
+
+        $this->assertFalse($this->database->isConnected('primary'));
+        $this->assertFalse($this->database->isConnected('analytics'));
+        $this->assertSame(0, Database::transactionLevel('primary'));
+        $this->assertSame(0, Database::transactionLevel('analytics'));
+        $this->assertSame([], $this->getStaticProperty(Database::class, 'connections'));
+        $this->assertSame([], $this->getStaticProperty(Database::class, 'drivers'));
+        $this->assertSame([], $this->getStaticProperty(Database::class, 'transactions'));
+    }
+
+    public function testGetPdoInstanceThrowsForUnknownConnectionConfiguration(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Database connection [missing] not configured.');
+
+        Database::getPdoInstance('missing');
+    }
+
+    public function testGetPdoInstanceWrapsUnsupportedDriverErrors(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Database connection error [unsupported]: Unsupported database driver: sqlsrv'
+        );
+
+        Database::getPdoInstance('unsupported');
+    }
+
+    private function primeDatabaseConfig(): void
+    {
+        $this->primaryPath = (string) tempnam(sys_get_temp_dir(), 'doppar-primary-');
+        $this->analyticsPath = (string) tempnam(sys_get_temp_dir(), 'doppar-analytics-');
+
+        $this->restoreStaticProperties(Config::class, [
+            'config' => [
+                'database' => [
+                    'default' => 'primary',
+                    'connections' => [
+                        'primary' => [
+                            'driver' => 'sqlite',
+                            'database' => $this->primaryPath,
+                        ],
+                        'analytics' => [
+                            'driver' => 'sqlite',
+                            'database' => $this->analyticsPath,
+                        ],
+                        'unsupported' => [
+                            'driver' => 'sqlsrv',
+                            'database' => 'irrelevant',
+                        ],
+                    ],
+                ],
+            ],
+            'cacheFile' => sys_get_temp_dir() . '/doppar-config-test-cache.php',
+            'loadedFromCache' => true,
+            'configModified' => false,
+            'fileHashes' => [],
+            'configFiles' => [],
+        ]);
+    }
+
+    private function cleanupTempFile(?string $path): void
+    {
+        if ($path !== null && $path !== '' && file_exists($path)) {
+            @unlink($path);
+        }
+    }
+
+    private function resetDatabaseStatics(): void
+    {
+        $this->restoreStaticProperties(Database::class, [
+            'connections' => [],
+            'transactions' => [],
+            'drivers' => [],
+        ]);
+    }
+
+    /**
+     * @param array<int, string> $properties
+     * @return array<string, mixed>
+     */
+    private function captureStaticProperties(string $className, array $properties): array
+    {
+        $reflection = new \ReflectionClass($className);
+        $values = [];
+
+        foreach ($properties as $propertyName) {
+            $values[$propertyName] = $reflection->getProperty($propertyName)->getValue();
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    private function restoreStaticProperties(string $className, array $values): void
+    {
+        $reflection = new \ReflectionClass($className);
+
+        foreach ($values as $propertyName => $value) {
+            $reflection->getProperty($propertyName)->setValue(null, $value);
+        }
+    }
+
+    private function getStaticProperty(string $className, string $propertyName): mixed
+    {
+        $reflection = new \ReflectionClass($className);
+
+        return $reflection->getProperty($propertyName)->getValue();
+    }
+}

--- a/tests/Model/MultiConnectionModelTest.php
+++ b/tests/Model/MultiConnectionModelTest.php
@@ -172,6 +172,33 @@ class MultiConnectionModelTest extends TestCase
         );
     }
 
+    public function testSaveRemovesUnknownAttributesThatDoNotExistInTheTable(): void
+    {
+        $record = MockAnalyticsConnectionRecord::find(1);
+
+        $record->description = 'transient';
+        $this->assertTrue($record->save());
+
+        $this->assertArrayNotHasKey('description', $record->toArray());
+        $this->assertArrayNotHasKey('description', $record->getAttributes());
+        $this->assertSame('Analytics Seed', $this->findRow($this->analyticsPdo, 1)['name']);
+    }
+
+    public function testCreateDropsUnknownAttributesThatDoNotExistInTheTable(): void
+    {
+        $record = new MockAnalyticsConnectionRecord([
+            'name' => 'Unknown Field Test',
+            'status' => 'queued',
+            'amount' => 700,
+            'description' => 'should disappear',
+        ]);
+
+        $this->assertTrue($record->save());
+        $this->assertArrayNotHasKey('description', $record->toArray());
+        $this->assertSame('Unknown Field Test', $this->findRow($this->analyticsPdo, $record->id)['name']);
+        $this->assertSame(3, $this->countRows($this->analyticsPdo));
+    }
+
     private function makeConnection(): PDO
     {
         $pdo = new PDO('sqlite::memory:');

--- a/tests/Model/MultiConnectionModelTest.php
+++ b/tests/Model/MultiConnectionModelTest.php
@@ -1,0 +1,256 @@
+<?php
+
+namespace Tests\Unit\Model;
+
+require_once __DIR__ . '/../Support/Model/MockPrimaryConnectionRecord.php';
+require_once __DIR__ . '/../Support/Model/MockAnalyticsConnectionRecord.php';
+require_once __DIR__ . '/../Support/Model/MockFlexibleConnectionRecord.php';
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Phaseolies\Database\Database;
+use Tests\Support\Model\MockAnalyticsConnectionRecord;
+use Tests\Support\Model\MockFlexibleConnectionRecord;
+use Tests\Support\Model\MockPrimaryConnectionRecord;
+
+class MultiConnectionModelTest extends TestCase
+{
+    private PDO $primaryPdo;
+    private PDO $analyticsPdo;
+
+    protected function setUp(): void
+    {
+        $this->primaryPdo = $this->makeConnection();
+        $this->analyticsPdo = $this->makeConnection();
+
+        $this->createSchema($this->primaryPdo);
+        $this->createSchema($this->analyticsPdo);
+
+        $this->seedPrimaryDatabase();
+        $this->seedAnalyticsDatabase();
+
+        $this->setStaticProperty(Database::class, 'connections', [
+            'primary' => $this->primaryPdo,
+            'analytics' => $this->analyticsPdo,
+        ]);
+        $this->setStaticProperty(Database::class, 'drivers', []);
+        $this->setStaticProperty(Database::class, 'transactions', []);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->setStaticProperty(Database::class, 'connections', []);
+        $this->setStaticProperty(Database::class, 'drivers', []);
+        $this->setStaticProperty(Database::class, 'transactions', []);
+    }
+
+    public function testDedicatedModelsFetchFromTheirAssignedConnections(): void
+    {
+        $primary = MockPrimaryConnectionRecord::find(1);
+        $analytics = MockAnalyticsConnectionRecord::find(1);
+
+        $this->assertSame('Primary Seed', $primary->name);
+        $this->assertSame('Analytics Seed', $analytics->name);
+        $this->assertSame('primary', $primary->getConnectionName());
+        $this->assertSame('analytics', $analytics->getConnectionName());
+    }
+
+    public function testCreatePersistsIntoConfiguredConnectionOnly(): void
+    {
+        $primary = MockPrimaryConnectionRecord::create([
+            'name' => 'Primary Create',
+            'status' => 'draft',
+            'amount' => 175,
+        ]);
+
+        $analytics = MockAnalyticsConnectionRecord::create([
+            'name' => 'Analytics Create',
+            'status' => 'published',
+            'amount' => 480,
+        ]);
+
+        $this->assertNotNull($primary->id);
+        $this->assertNotNull($analytics->id);
+        $this->assertSame(3, $this->countRows($this->primaryPdo));
+        $this->assertSame(3, $this->countRows($this->analyticsPdo));
+        $this->assertSame('Primary Create', $this->findRow($this->primaryPdo, $primary->id)['name']);
+        $this->assertNull($this->findRowByName($this->analyticsPdo, 'Primary Create'));
+        $this->assertSame('Analytics Create', $this->findRow($this->analyticsPdo, $analytics->id)['name']);
+        $this->assertNull($this->findRowByName($this->primaryPdo, 'Analytics Create'));
+    }
+
+    public function testFetchedModelUpdateOnlyTouchesItsOwnConnection(): void
+    {
+        $primary = MockPrimaryConnectionRecord::find(1);
+        $analytics = MockAnalyticsConnectionRecord::find(1);
+
+        $primary->status = 'archived';
+        $analytics->amount = 999;
+
+        $this->assertTrue($primary->save());
+        $this->assertTrue($analytics->save());
+
+        $this->assertSame('archived', $this->findRow($this->primaryPdo, 1)['status']);
+        $this->assertSame('pending', $this->findRow($this->analyticsPdo, 1)['status']);
+        $this->assertSame(999, (int) $this->findRow($this->analyticsPdo, 1)['amount']);
+        $this->assertSame(900, (int) $this->findRow($this->primaryPdo, 1)['amount']);
+    }
+
+    public function testFetchedModelDeleteOnlyRemovesRowFromItsOwnConnection(): void
+    {
+        $primary = MockPrimaryConnectionRecord::find(2);
+        $analytics = MockAnalyticsConnectionRecord::find(2);
+
+        $this->assertTrue($primary->delete());
+        $this->assertTrue($analytics->delete());
+
+        $this->assertNull($this->findRow($this->primaryPdo, 2));
+        $this->assertNull($this->findRow($this->analyticsPdo, 2));
+        $this->assertSame(1, $this->countRows($this->primaryPdo));
+        $this->assertSame(1, $this->countRows($this->analyticsPdo));
+    }
+
+    public function testExplicitQueryConnectionFetchesFromRequestedDatabase(): void
+    {
+        $primary = MockFlexibleConnectionRecord::query('primary')
+            ->where('name', 'Primary Seed')
+            ->first();
+
+        $analytics = MockFlexibleConnectionRecord::query('analytics')
+            ->where('name', 'Analytics Seed')
+            ->first();
+
+        $this->assertSame('primary', $primary->getConnectionName());
+        $this->assertSame('analytics', $analytics->getConnectionName());
+        $this->assertSame(900, (int) $primary->amount);
+        $this->assertSame(450, (int) $analytics->amount);
+    }
+
+    public function testExplicitConnectionBuilderCreateUsesRequestedDatabase(): void
+    {
+        $created = MockFlexibleConnectionRecord::connection('analytics')->create([
+            'name' => 'Builder Insert',
+            'status' => 'queued',
+            'amount' => 320,
+        ]);
+
+        $this->assertSame('analytics', $created->getConnectionName());
+        $this->assertSame(2, $this->countRows($this->primaryPdo));
+        $this->assertSame(3, $this->countRows($this->analyticsPdo));
+        $this->assertNull($this->findRowByName($this->primaryPdo, 'Builder Insert'));
+        $this->assertSame('Builder Insert', $this->findRowByName($this->analyticsPdo, 'Builder Insert')['name']);
+    }
+
+    public function testHydratedModelFromExplicitConnectionCanBeUpdatedAndDeletedSafely(): void
+    {
+        $analytics = MockFlexibleConnectionRecord::query('analytics')
+            ->where('id', 1)
+            ->first();
+
+        $analytics->status = 'processed';
+        $this->assertTrue($analytics->save());
+
+        $this->assertSame('processed', $this->findRow($this->analyticsPdo, 1)['status']);
+        $this->assertSame('active', $this->findRow($this->primaryPdo, 1)['status']);
+
+        $this->assertTrue($analytics->delete());
+        $this->assertNull($this->findRow($this->analyticsPdo, 1));
+        $this->assertNotNull($this->findRow($this->primaryPdo, 1));
+    }
+
+    public function testConnectionScopedCountsStayIsolatedAcrossDatabases(): void
+    {
+        $this->assertSame(2, MockPrimaryConnectionRecord::count());
+        $this->assertSame(2, MockAnalyticsConnectionRecord::count());
+        $this->assertSame(
+            1,
+            MockFlexibleConnectionRecord::query('analytics')->where('status', 'pending')->count()
+        );
+        $this->assertSame(
+            1,
+            MockFlexibleConnectionRecord::query('primary')->where('status', 'active')->count()
+        );
+    }
+
+    private function makeConnection(): PDO
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+
+        return $pdo;
+    }
+
+    private function createSchema(PDO $pdo): void
+    {
+        $pdo->exec(
+            'CREATE TABLE connection_records (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                status TEXT NOT NULL,
+                amount INTEGER NOT NULL
+            )'
+        );
+    }
+
+    private function seedPrimaryDatabase(): void
+    {
+        $statement = $this->primaryPdo->prepare(
+            'INSERT INTO connection_records (name, status, amount) VALUES (?, ?, ?)'
+        );
+
+        $statement->execute(['Primary Seed', 'active', 900]);
+        $statement->execute(['Primary Secondary', 'draft', 125]);
+    }
+
+    private function seedAnalyticsDatabase(): void
+    {
+        $statement = $this->analyticsPdo->prepare(
+            'INSERT INTO connection_records (name, status, amount) VALUES (?, ?, ?)'
+        );
+
+        $statement->execute(['Analytics Seed', 'pending', 450]);
+        $statement->execute(['Analytics Secondary', 'archived', 250]);
+    }
+
+    private function countRows(PDO $pdo): int
+    {
+        return (int) $pdo->query('SELECT COUNT(*) FROM connection_records')->fetchColumn();
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function findRow(PDO $pdo, int $id): ?array
+    {
+        $statement = $pdo->prepare('SELECT * FROM connection_records WHERE id = ?');
+        $statement->execute([$id]);
+
+        $row = $statement->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $row;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function findRowByName(PDO $pdo, string $name): ?array
+    {
+        $statement = $pdo->prepare('SELECT * FROM connection_records WHERE name = ?');
+        $statement->execute([$name]);
+
+        $row = $statement->fetch(PDO::FETCH_ASSOC);
+
+        return $row === false ? null : $row;
+    }
+
+    private function setStaticProperty(string $className, string $propertyName, mixed $value): void
+    {
+        try {
+            $reflection = new \ReflectionClass($className);
+            $reflection->getProperty($propertyName)->setValue(null, $value);
+        } catch (\ReflectionException $e) {
+            $this->fail("Failed to set static property {$propertyName}: " . $e->getMessage());
+        }
+    }
+}

--- a/tests/Support/Model/MockAnalyticsConnectionRecord.php
+++ b/tests/Support/Model/MockAnalyticsConnectionRecord.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Support\Model;
+
+use Phaseolies\Database\Entity\Model;
+
+class MockAnalyticsConnectionRecord extends Model
+{
+    protected $table = 'connection_records';
+    protected $primaryKey = 'id';
+    protected $connection = 'analytics';
+    protected $timeStamps = false;
+    protected $creatable = ['name', 'status', 'amount'];
+}

--- a/tests/Support/Model/MockFlexibleConnectionRecord.php
+++ b/tests/Support/Model/MockFlexibleConnectionRecord.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Support\Model;
+
+use Phaseolies\Database\Entity\Model;
+
+class MockFlexibleConnectionRecord extends Model
+{
+    protected $table = 'connection_records';
+    protected $primaryKey = 'id';
+    protected $connection = null;
+    protected $timeStamps = false;
+    protected $creatable = ['name', 'status', 'amount'];
+}

--- a/tests/Support/Model/MockPrimaryConnectionRecord.php
+++ b/tests/Support/Model/MockPrimaryConnectionRecord.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Support\Model;
+
+use Phaseolies\Database\Entity\Model;
+
+class MockPrimaryConnectionRecord extends Model
+{
+    protected $table = 'connection_records';
+    protected $primaryKey = 'id';
+    protected $connection = 'primary';
+    protected $timeStamps = false;
+    protected $creatable = ['name', 'status', 'amount'];
+}


### PR DESCRIPTION
- Adds focused coverage for connection pooling and multi-database model CRUD, including fetch, create, update, delete, explicit connection queries, and connection-scoped isolation.
- Fixes runtime connection propagation so hydrated and builder-created models keep the connection they were loaded from, avoiding writes drifting back to the default connection.
- Prevents attributes that do not exist as real table columns from surviving save() and appearing in serialized model output.
- Hardens column metadata caching to use the active PDO instance, eliminating cross-test schema leakage and restoring a fully green suite.