### PR TITLE
fix: relation loading forces related models onto the parent/builder connection

### DIFF
--- a/src/Phaseolies/Database/Entity/Model.php
+++ b/src/Phaseolies/Database/Entity/Model.php
@@ -826,7 +826,7 @@ abstract class Model implements Jsonable, \ArrayAccess, \JsonSerializable, \Stri
 
         $relatedInstance = app($related);
 
-        return $relatedInstance->query($this->connection)->where($foreignKey, '=', $this->$localKey);
+        return $relatedInstance->query()->where($foreignKey, '=', $this->$localKey);
     }
 
     /**
@@ -846,7 +846,7 @@ abstract class Model implements Jsonable, \ArrayAccess, \JsonSerializable, \Stri
 
         $relatedInstance = app($related);
 
-        return $relatedInstance->query($this->connection)->where($foreignKey, '=', $this->$localKey);
+        return $relatedInstance->query()->where($foreignKey, '=', $this->$localKey);
     }
 
     /**
@@ -866,7 +866,7 @@ abstract class Model implements Jsonable, \ArrayAccess, \JsonSerializable, \Stri
 
         $relatedInstance = app($related);
 
-        return $relatedInstance->query($this->connection)->where($foreignKey, '=', $this->$localKey);
+        return $relatedInstance->query()->where($foreignKey, '=', $this->$localKey);
     }
 
     /**
@@ -887,7 +887,7 @@ abstract class Model implements Jsonable, \ArrayAccess, \JsonSerializable, \Stri
         $this->lastPivotTable = $pivotTable;
 
         $relatedModel = app($related);
-        $query = $relatedModel->query($this->connection);
+        $query = $relatedModel->query();
 
         $query->setRelationInfo([
             'type' => 'bindToMany',
@@ -1025,7 +1025,7 @@ abstract class Model implements Jsonable, \ArrayAccess, \JsonSerializable, \Stri
                                 return "{$pivotTable}.{$column} as pivot_{$column}";
                             }, $pivotColumns);
 
-                            $query = $relatedModel->query($this->connection)
+                            $query = $relatedModel->query()
                                 ->select(array_merge(
                                     ["{$relatedModel->getTable()}.*"],
                                     $pivotSelects

--- a/tests/Support/Model/MockAnalyticsConnectionAudit.php
+++ b/tests/Support/Model/MockAnalyticsConnectionAudit.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Support\Model;
+
+use Phaseolies\Database\Entity\Model;
+
+class MockAnalyticsConnectionAudit extends Model
+{
+    protected $table = 'connection_audits';
+    protected $primaryKey = 'id';
+    protected $connection = 'analytics';
+    protected $timeStamps = false;
+    protected $creatable = ['record_id', 'message'];
+}

--- a/tests/Support/Model/MockFlexibleConnectionTag.php
+++ b/tests/Support/Model/MockFlexibleConnectionTag.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Support\Model;
+
+use Phaseolies\Database\Entity\Model;
+
+class MockFlexibleConnectionTag extends Model
+{
+    protected $table = 'connection_tags';
+    protected $primaryKey = 'id';
+    protected $connection = null;
+    protected $timeStamps = false;
+    protected $creatable = ['record_id', 'name'];
+}


### PR DESCRIPTION
Assume we have User and Permission, Model.

This PR resolves an issue where the user relationship on the Permission model was not loading correctly when the Permission model used a custom database connection (e.g., 'test') while the User model remained on the default connection.

This fix ensures that the user relationship correctly resolves and loads data even when the Permission model uses a different connection than the User model.

## Example
```php
$permission = Permission::find(1);
$permission->user;
```
