### PR TITLE
Fix eager-loaded relations across multiple database connections

### DIFF
--- a/src/Phaseolies/Database/Entity/Builder.php
+++ b/src/Phaseolies/Database/Entity/Builder.php
@@ -1490,7 +1490,7 @@ class Builder
 
         // For linkOne/bindTo relations, the foreignKey is on the related table
         // For linkMany relations, the foreignKey is also on the related table
-        $query = $relatedModelInstance->query($this->connectionName)->whereIn($foreignKey, $keys);
+        $query = $relatedModelInstance->query()->whereIn($foreignKey, $keys);
 
         // Apply constraint (which may include column selection)
         if (is_callable($constraint)) {
@@ -1556,7 +1556,7 @@ class Builder
         $selectedColumns = null;
 
         if (is_callable($constraint)) {
-            $inspectQuery = $relatedModelInstance->query($this->connectionName);
+            $inspectQuery = $relatedModelInstance->query();
             $constraint($inspectQuery);
 
             if ($inspectQuery->fields !== ['*']) {
@@ -1570,7 +1570,7 @@ class Builder
             }
         }
 
-        $query = $relatedModelInstance->query($this->connectionName);
+        $query = $relatedModelInstance->query();
 
         if ($hasCustomSelect) {
             $query->select(array_merge($selectedColumns, $pivotSelects));
@@ -1691,7 +1691,7 @@ class Builder
 
         // Handle one-to-many or one-to-one count
         $relatedModelInstance = app($relatedModel);
-        $query = $relatedModelInstance->query($this->connectionName)
+        $query = $relatedModelInstance->query()
             ->select([$foreignKey, 'COUNT(*) as aggregate'])
             ->whereIn($foreignKey, $localKeys)
             ->groupBy($foreignKey);
@@ -1743,7 +1743,7 @@ class Builder
         $relatedModelInstance = new $relatedModel();
         $relatedTable = $relatedModelInstance->getTable();
 
-        $query = $relatedModelInstance->query($this->connectionName)
+        $query = $relatedModelInstance->query()
             ->select(["{$pivotTable}.{$foreignKey}", 'COUNT(*) as aggregate'])
             ->join(
                 $pivotTable,
@@ -1799,7 +1799,13 @@ class Builder
      */
     public function getModel(): Model
     {
-        return app($this->modelClass);
+        $model = app($this->modelClass);
+
+        if ($this->connectionName !== null) {
+            $model->setConnectionName($this->connectionName);
+        }
+
+        return $model;
     }
 
     /**
@@ -1859,7 +1865,7 @@ class Builder
     protected function loadOneToOne(array $models, string $relation, string $relatedModel, string $foreignKey, string $localKey): void
     {
         $localKeys = array_map(fn($model) => $model->$localKey, $models);
-        $relatedModels = $relatedModel::query($this->connectionName)
+        $relatedModels = $relatedModel::query()
             ->whereIn($foreignKey, $localKeys)
             ->get()
             ->keyBy($foreignKey);
@@ -1885,7 +1891,7 @@ class Builder
     protected function loadOneToMany(array $models, string $relation, string $relatedModel, string $foreignKey, string $localKey): void
     {
         $localKeys = array_map(fn($model) => $model->$localKey, $models);
-        $relatedModels = $relatedModel::query($this->connectionName)
+        $relatedModels = $relatedModel::query()
             ->whereIn($foreignKey, $localKeys)
             ->get()
             ->getItemsGroupedBy($foreignKey);

--- a/tests/Model/MultiConnectionModelTest.php
+++ b/tests/Model/MultiConnectionModelTest.php
@@ -172,6 +172,16 @@ class MultiConnectionModelTest extends TestCase
         );
     }
 
+    public function testEmbedLoadsRelatedModelFromItsOwnConnection(): void
+    {
+        $record = MockAnalyticsConnectionRecord::embed('primaryRecord')->find(1);
+
+        $this->assertSame('Analytics Seed', $record->name);
+        $this->assertNotNull($record->primaryRecord);
+        $this->assertSame('Primary Seed', $record->primaryRecord->name);
+        $this->assertSame('primary', $record->primaryRecord->getConnectionName());
+    }
+
     public function testSaveRemovesUnknownAttributesThatDoNotExistInTheTable(): void
     {
         $record = MockAnalyticsConnectionRecord::find(1);

--- a/tests/Support/Model/MockAnalyticsConnectionRecord.php
+++ b/tests/Support/Model/MockAnalyticsConnectionRecord.php
@@ -11,4 +11,9 @@ class MockAnalyticsConnectionRecord extends Model
     protected $connection = 'analytics';
     protected $timeStamps = false;
     protected $creatable = ['name', 'status', 'amount'];
+
+    public function primaryRecord()
+    {
+        return $this->bindTo(MockPrimaryConnectionRecord::class, 'id', 'id');
+    }
 }


### PR DESCRIPTION
- Stops builder-side eager loading from forcing the parent model connection onto related model queries.
-  Makes embed() follow the same connection behavior as direct relation access, so related models load from their own configured database.
- Adds a regression test covering cross-connection eager loading to prevent bindTo relations from resolving against the wrong database.