### PR TITLE
Fix temporal migrations for models on non-default database connections

### DIFF
--- a/src/Phaseolies/Console/Commands/Migrations/MigrateTemporalCommand.php
+++ b/src/Phaseolies/Console/Commands/Migrations/MigrateTemporalCommand.php
@@ -35,19 +35,13 @@ class MigrateTemporalCommand extends Command
     public function handle(): int
     {
         return $this->executeWithTiming(function () {
-            $connection = $this->option('connection') ?: config('database.default');
+            $connection = $this->option('connection') ?: null;
             $dryRun     = (bool) $this->option('show');
             $modelsPath = $this->option('path') ?: base_path('app/Models');
 
-            try {
-                $pdo    = Database::getPdoInstance($connection ?: null);
-                $driver = strtolower($pdo->getAttribute(PDO::ATTR_DRIVER_NAME));
-            } catch (\Throwable $e) {
-                $this->displayError('Failed to connect to database: ' . $e->getMessage());
-                return Command::FAILURE;
-            }
+            $connectionLabel = $connection ?: 'per-model';
 
-            $this->line("<fg=yellow>🕐 Temporal Migration — connection: {$connection}</>");
+            $this->line("<fg=yellow>🕐 Temporal Migration — connection: {$connectionLabel}</>");
             $this->newLine();
 
             $classes = $this->discoverTemporalModels($modelsPath);
@@ -65,8 +59,20 @@ class MigrateTemporalCommand extends Command
                 $model        = new $class();
                 $baseTable    = $model->getTable();
                 $historyTable = TemporalManager::historyTable($baseTable, $class);
+                $modelConnection = $this->resolveConnectionForModel($model, $connection);
+
+                try {
+                    $pdo    = Database::getPdoInstance($modelConnection);
+                    $driver = strtolower($pdo->getAttribute(PDO::ATTR_DRIVER_NAME));
+                } catch (\Throwable $e) {
+                    $this->displayError(
+                        "Failed to connect to database [{$modelConnection}] for {$class}: " . $e->getMessage()
+                    );
+                    return Command::FAILURE;
+                }
 
                 $this->line("  <fg=cyan>Model</>        : <fg=white>{$class}</>");
+                $this->line("  <fg=cyan>Connection</>   : <fg=white>{$modelConnection}</>");
                 $this->line("  <fg=cyan>Base table</>   : <fg=white>{$baseTable}</>");
                 $this->line("  <fg=cyan>History table</> : <fg=white>{$historyTable}</>");
 
@@ -114,6 +120,21 @@ class MigrateTemporalCommand extends Command
 
             return Command::SUCCESS;
         });
+    }
+
+    /**
+     * Resolve the database connection for a temporal model, honoring a command
+     * override first and then the model's own configured connection.
+     *
+     * @param Model $model
+     * @param string|null $overrideConnection
+     * @return string
+     */
+    private function resolveConnectionForModel(Model $model, ?string $overrideConnection = null): string
+    {
+        return $overrideConnection
+            ?: $model->getConnectionName()
+            ?: config('database.default');
     }
 
     /**

--- a/tests/Console/MigrateTemporalCommandTest.php
+++ b/tests/Console/MigrateTemporalCommandTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Phaseolies\Console\Commands\Migrations {
+    function config($key = null, $default = null)
+    {
+        return $key === 'database.default' ? 'default_connection' : $default;
+    }
+}
+
+namespace Tests\Unit\Console {
+
+require_once __DIR__ . '/../Support/Model/MockTemporalRecord.php';
+
+use PHPUnit\Framework\TestCase;
+use Phaseolies\Console\Commands\Migrations\MigrateTemporalCommand;
+use Tests\Support\Model\MockTemporalRecord;
+
+class MigrateTemporalCommandTest extends TestCase
+{
+    public function testResolveConnectionForModelPrefersModelConnectionWhenNoOverride(): void
+    {
+        $command = new MigrateTemporalCommand();
+        $method = new \ReflectionMethod($command, 'resolveConnectionForModel');
+
+        $connection = $method->invoke($command, new MockTemporalRecord(), null);
+
+        $this->assertSame('default', $connection);
+    }
+
+    public function testResolveConnectionForModelPrefersCommandOverride(): void
+    {
+        $command = new MigrateTemporalCommand();
+        $method = new \ReflectionMethod($command, 'resolveConnectionForModel');
+
+        $connection = $method->invoke($command, new MockTemporalRecord(), 'mysql_second');
+
+        $this->assertSame('mysql_second', $connection);
+    }
+
+    public function testResolveConnectionForModelFallsBackToDefaultConfig(): void
+    {
+        $command = new MigrateTemporalCommand();
+        $method = new \ReflectionMethod($command, 'resolveConnectionForModel');
+
+        $model = new class extends \Phaseolies\Database\Entity\Model {
+            protected $table = 'plain_temporal_records';
+            protected $connection = null;
+        };
+
+        $connection = $method->invoke($command, $model, null);
+
+        $this->assertSame('default_connection', $connection);
+    }
+}
+}


### PR DESCRIPTION
Updates `migrate:temporal` to resolve the target database per temporal model instead of reusing one global connection for the whole command. Preserves `--connection` as an explicit override, while default behavior now honors each model’s configured `$connection`. 

Adds regression coverage for model-based connection resolution so temporal history tables are created on the correct database.