### PR TITLE
Always scaffold frontend welcome pages through layouts/app.odo.php

### DIFF
--- a/src/Phaseolies/Console/Commands/FrontendInstallCommand.php
+++ b/src/Phaseolies/Console/Commands/FrontendInstallCommand.php
@@ -14,16 +14,6 @@ class FrontendInstallCommand extends Command
     /**
      * @var string
      */
-    protected const VITE_MARKER_START = '<!-- DOPPAR_FRONTEND_VITE_START -->';
-
-    /**
-     * @var string
-     */
-    protected const VITE_MARKER_END = '<!-- DOPPAR_FRONTEND_VITE_END -->';
-
-    /**
-     * @var string
-     */
     protected $name = 'frontend:install {--force : Overwrite existing frontend files} {--install : Install dependencies after scaffolding}';
 
     /**
@@ -65,23 +55,6 @@ class FrontendInstallCommand extends Command
                 in_array($framework, ['react', 'vue', 'svelte'], true)
             );
 
-            $patchLayout = false;
-            $layoutPath = null;
-
-            if (!$this->usesClientFramework($framework)) {
-                $patchLayout = $this->confirm(
-                    'Do you want Doppar to patch your main Odo layout with #vite(...) automatically?',
-                    true
-                );
-
-                $layoutPath = $patchLayout
-                    ? $this->ask(
-                        'Which layout file should be updated?',
-                        base_path('resources/views/layouts/app.odo.php')
-                    )
-                    : null;
-            }
-
             $installDependencies = (bool) ($this->option('install') ?: $this->confirm(
                 'Do you want to install frontend dependencies now?',
                 false
@@ -95,8 +68,6 @@ class FrontendInstallCommand extends Command
                 'cssStack' => $cssStack,
                 'framework' => $framework,
                 'typescript' => $typescript,
-                'patchLayout' => $patchLayout,
-                'layoutPath' => $layoutPath,
                 'installDependencies' => $installDependencies,
                 'packageManager' => $packageManager,
                 'force' => (bool) $this->option('force'),
@@ -107,10 +78,6 @@ class FrontendInstallCommand extends Command
             $this->ensureClientDirectories();
             $this->prepareDependencyArtifacts($state, $packageManager, $installDependencies);
             $this->writeFrontendFiles($options, $state);
-
-            if ($patchLayout && $layoutPath) {
-                $this->patchLayout($layoutPath, $this->entryFilePath($framework, $typescript), $framework, $state);
-            }
 
             if ($installDependencies) {
                 $this->rememberFrontendDirectoryLifecycle($state, base_path('node_modules'));
@@ -183,12 +150,9 @@ class FrontendInstallCommand extends Command
             client_path('css/app.css') => $this->clientCss($cssStack),
             client_path('js/' . $this->bootstrapFilename($typescript)) => $this->bootstrapFile($cssStack, $typescript),
             client_path('js/' . $this->entryFilename($framework, $typescript)) => $this->entryFile($framework, $cssStack, $typescript),
+            base_path('resources/views/layouts/app.odo.php') => $this->appLayoutView($framework, $typescript),
             base_path('resources/views/welcome.odo.php') => $this->welcomeView($framework, $typescript),
         ];
-
-        if ($this->usesClientFramework($framework)) {
-            $files[base_path('resources/views/layouts/app.odo.php')] = $this->appLayoutView($framework, $typescript);
-        }
 
         if ($cssStack === 'tailwind') {
             $files[base_path('postcss.config.js')] = $this->postcssConfig();
@@ -252,52 +216,6 @@ class FrontendInstallCommand extends Command
 
         file_put_contents($path, $contents);
         $this->line("  <fg=green>Wrote</> <fg=white>{$path}</>");
-    }
-
-    /**
-     * Patch the selected layout to include #vite and a framework mount point.
-     *
-     * @param string $layoutPath
-     * @param string $entryPath
-     * @param string $framework
-     * @return void
-     */
-    protected function patchLayout(string $layoutPath, string $entryPath, string $framework, array &$state): void
-    {
-        if (!file_exists($layoutPath)) {
-            $this->displayWarning("Layout not found: {$layoutPath}. Skipping automatic patch.");
-            return;
-        }
-
-        $this->rememberFrontendFileMutation($state, $layoutPath);
-        $contents = (string) file_get_contents($layoutPath);
-        $viteDirective = self::VITE_MARKER_START . "\n    #vite('{$entryPath}')\n    " . self::VITE_MARKER_END;
-        $mountPoint = '<div id="app"></div>';
-
-        if (str_contains($contents, self::VITE_MARKER_START) && str_contains($contents, self::VITE_MARKER_END)) {
-            $contents = preg_replace(
-                '/' . preg_quote(self::VITE_MARKER_START, '/') . '.*?' . preg_quote(self::VITE_MARKER_END, '/') . '/s',
-                $viteDirective,
-                $contents
-            ) ?? $contents;
-        } else {
-            if (str_contains($contents, '</head>')) {
-                $contents = str_replace('</head>', "    {$viteDirective}\n</head>", $contents);
-            } else {
-                $contents .= "\n{$viteDirective}\n";
-            }
-        }
-
-        if ($framework !== 'vanilla' && !str_contains($contents, $mountPoint)) {
-            if (str_contains($contents, '</body>')) {
-                $contents = str_replace('</body>', "    {$mountPoint}\n</body>", $contents);
-            } else {
-                $contents .= "\n{$mountPoint}\n";
-            }
-        }
-
-        file_put_contents($layoutPath, $contents);
-        $this->line("  <fg=green>Patched</> <fg=white>{$layoutPath}</>");
     }
 
     /**

--- a/src/Phaseolies/Console/Commands/stubs/frontend/views/layouts/app.stub
+++ b/src/Phaseolies/Console/Commands/stubs/frontend/views/layouts/app.stub
@@ -3,8 +3,8 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>#yield('title')</title>
         <meta name="csrf-token" content="[[ csrf_token() ]]" />
-        <title>Doppar</title>
         <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
         <script>
             window.__DOPPAR_FRONTEND__ = {
@@ -17,6 +17,6 @@
         #vite('{{ entry }}')
     </head>
     <body>
-        <div id="app"></div>
+        #yield('content')
     </body>
 </html>

--- a/src/Phaseolies/Console/Commands/stubs/frontend/views/welcome/client.stub
+++ b/src/Phaseolies/Console/Commands/stubs/frontend/views/welcome/client.stub
@@ -1,1 +1,7 @@
 #extends('layouts.app')
+#section('title')
+    Doppar
+#endsection
+#section('content')
+<div id="app"></div>
+#endsection

--- a/src/Phaseolies/Console/Commands/stubs/frontend/views/welcome/plain.stub
+++ b/src/Phaseolies/Console/Commands/stubs/frontend/views/welcome/plain.stub
@@ -1,48 +1,41 @@
-<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta charset="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>Doppar</title>
-        <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
-        <style>
-            .cta-box,.version{margin-bottom:40px}:root{--primary:#10b981;--background:#f9fafb;--card-bg:#ffffff;--text-color:#111827;--border:#d1d5db}*{box-sizing:border-box}body{margin:0;padding:40px 20px;font-family:Poppins,sans-serif;background:var(--background);color:var(--text-color);text-align:center}.cta-box h2,h1,header img{margin-bottom:10px}header img{width:48px;height:auto}h1{font-size:2rem;font-weight:700}.version{font-size:14px;color:#6b7280}.cta-box{border:2px solid var(--primary);border-radius:12px;padding:20px;display:inline-block;max-width:600px;width:100%;background:#ecfdf5}.cta-box h2{font-size:1.2rem}.cta-box code{background:#e5e7eb;padding:2px 6px;border-radius:4px;font-family:monospace}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:20px;max-width:800px;margin:0 auto 40px}.card{background:var(--card-bg);padding:20px;border:1px solid var(--border);border-radius:12px;text-align:left;transition:box-shadow .2s}.card:hover{box-shadow:0 4px 12px rgba(0,0,0,.05)}.card h3{font-size:1rem;margin-bottom:8px}.card p{font-size:14px;color:#4b5563}.footer{font-size:13px;color:#9ca3af;margin-top:50px}.btn-group{margin-top:20px}.btn{display:inline-block;margin:0 10px;padding:10px 18px;background-color:#fff;color:#00f;text-decoration:none;border-radius:6px;font-weight:500;transition:background .2s}.btn:hover{background-color:#c4c9c8;border:1px solid #ddd}
-        </style>
-    </head>
-    <body>
-        <header>
-            <img src="[[ enqueue('logo.png') ]]" alt="Logo" />
-            <h2>Welcome to Doppar</h2>
-        </header>
-        <section class="cta-box">
-            <h3>[[ trans('messages.welcome', ['version' => 'v' . Application::VERSION]) ]]</h3>
-            <p>Craft Fast-Loading PHP Application</p>
-        </section>
-        <section class="grid">
-            <a href="https://doppar.com/versions/3.x/starter-kits" class="card">
-                <h3>Starter kits</h3>
-                <p>To give you a head start building your new Doppar application, we are happy to offer application
-                    starter kits.</p>
-            </a>
-            <a href="https://doppar.com/versions/3.x/architecture-concept" class="card">
-                <h3>System Architecture</h3>
-                <p>Doppar follows the Model-View-Controller (MVC) architectural pattern, a widely accepted standard in web application development.</p>
-            </a>
-            <a href="https://doppar.com/versions/3.x/routing" class="card">
-                <h3>Routing</h3>
-                <p>With support for route prefix grouping, named routes, throttle route, middleware assignment, and RESTful resource routing, Doppar gives developers full control over how requests are handled.</p>
-            </a>
-            <a href="https://doppar.com/versions/3.x/authentication" class="card">
-                <h3>Authentication</h3>
-                <p>Doppar simplifies this process by providing built-in tools and scaffolding to help you implement user authentication quickly and securely.</p>
-            </a>
-        </section>
-        <div class="btn-group">
-            <a href="https://github.com/doppar" class="btn">GitHub</a>
-            <a href="https://doppar.com" class="btn">Website</a>
-        </div>
-        <div class="footer">
-            PHP [[ phpversion() ]]
-        </div>
-    </body>
-</html>
+#extends('layouts.app')
+#section('title')
+    Doppar
+#endsection
+#section('content')
+<main class="doppar-welcome-shell">
+    <header class="doppar-welcome-header">
+        <img class="doppar-welcome-logo" src="[[ enqueue('logo.png') ]]" alt="Logo" />
+        <h2 class="doppar-welcome-title">Welcome to Doppar</h2>
+    </header>
+    <section class="doppar-cta-box">
+        <h3>[[ trans('messages.welcome', ['version' => 'v' . Application::VERSION]) ]]</h3>
+        <p>Craft Fast-Loading PHP Application</p>
+    </section>
+    <section class="doppar-grid">
+        <a href="https://doppar.com/versions/3.x/starter-kits" class="doppar-card">
+            <h3>Starter kits</h3>
+            <p>To give you a head start building your new Doppar application, we are happy to offer application starter kits.</p>
+        </a>
+        <a href="https://doppar.com/versions/3.x/architecture-concept" class="doppar-card">
+            <h3>System Architecture</h3>
+            <p>Doppar follows the Model-View-Controller (MVC) architectural pattern, a widely accepted standard in web application development.</p>
+        </a>
+        <a href="https://doppar.com/versions/3.x/routing" class="doppar-card">
+            <h3>Routing</h3>
+            <p>With support for route prefix grouping, named routes, throttle route, middleware assignment, and RESTful resource routing, Doppar gives developers full control over how requests are handled.</p>
+        </a>
+        <a href="https://doppar.com/versions/3.x/authentication" class="doppar-card">
+            <h3>Authentication</h3>
+            <p>Doppar simplifies this process by providing built-in tools and scaffolding to help you implement user authentication quickly and securely.</p>
+        </a>
+    </section>
+    <div class="doppar-btn-group">
+        <a href="https://github.com/doppar" class="doppar-btn">GitHub</a>
+        <a href="https://doppar.com" class="doppar-btn">Website</a>
+    </div>
+    <div class="doppar-footer">
+        PHP [[ phpversion() ]]
+    </div>
+</main>
+#endsection

--- a/tests/Console/FrontendInstallCommandTest.php
+++ b/tests/Console/FrontendInstallCommandTest.php
@@ -19,15 +19,17 @@ class FrontendInstallCommandTest extends TestCase
         $this->assertSame('resources/client/js/main.tsx', $pathMethod->invoke($command, 'react', true));
     }
 
-    public function testVanillaWelcomeUsesPlainOdoWelcomeStub(): void
+    public function testVanillaWelcomeUsesSharedAppLayout(): void
     {
         $command = new FrontendInstallCommand();
         $method = new \ReflectionMethod($command, 'welcomeView');
 
         $welcome = $method->invoke($command, 'vanilla', false);
 
-        $this->assertStringContainsString('<h2>Welcome to Doppar</h2>', $welcome);
-        $this->assertStringNotContainsString("#extends('layouts.app')", $welcome);
+        $this->assertStringContainsString("#extends('layouts.app')", $welcome);
+        $this->assertStringContainsString('#section(\'content\')', $welcome);
+        $this->assertStringContainsString('<h2 class="doppar-welcome-title">Welcome to Doppar</h2>', $welcome);
+        $this->assertStringNotContainsString('<!DOCTYPE html>', $welcome);
     }
 
     public function testInstallerWelcomeBannerIncludesDopparBranding(): void
@@ -43,7 +45,7 @@ class FrontendInstallCommandTest extends TestCase
         $this->assertStringContainsString('We will now walk through your frontend stack setup step by step.', $banner);
     }
 
-    public function testClientFrameworkWelcomeUsesGeneratedAppLayoutShell(): void
+    public function testClientFrameworkWelcomeUsesSharedLayoutShell(): void
     {
         $command = new FrontendInstallCommand();
         $welcomeMethod = new \ReflectionMethod($command, 'welcomeView');
@@ -53,10 +55,25 @@ class FrontendInstallCommandTest extends TestCase
         $layout = $layoutMethod->invoke($command, 'vue', true);
 
         $this->assertStringContainsString("#extends('layouts.app')", $welcome);
+        $this->assertStringContainsString('#section(\'content\')', $welcome);
+        $this->assertStringContainsString('<div id="app"></div>', $welcome);
         $this->assertStringContainsString("#vite('resources/client/js/main.ts')", $layout);
         $this->assertStringContainsString('<meta name="csrf-token" content="[[ csrf_token() ]]" />', $layout);
         $this->assertStringContainsString('window.__DOPPAR_FRONTEND__', $layout);
         $this->assertStringContainsString('csrfToken: "[[ csrf_token() ]]"', $layout);
+        $this->assertStringContainsString("#yield('content')", $layout);
+        $this->assertStringNotContainsString('<div id="app"></div>', $layout);
+    }
+
+    public function testVanillaAppLayoutUsesAppEntrypoint(): void
+    {
+        $command = new FrontendInstallCommand();
+        $method = new \ReflectionMethod($command, 'appLayoutView');
+
+        $layout = $method->invoke($command, 'vanilla', true);
+
+        $this->assertStringContainsString("#vite('resources/client/js/app.ts')", $layout);
+        $this->assertStringContainsString("#yield('content')", $layout);
     }
 
     public function testViteConfigTargetsMainReactEntrypoint(): void


### PR DESCRIPTION
## Summary
- always scaffold `resources/views/layouts/app.odo.php` during `frontend:install`
- make `resources/views/welcome.odo.php` extend the shared app layout for every frontend choice, including vanilla
- keep `#vite(...)` in the shared layout using the entry file from the selected stack
- render vanilla welcome content through the layout `content` section, while React/Vue/Svelte mount `#app` from the welcome view

## Testing
- `vendor/bin/phpunit tests/Console/FrontendInstallCommandTest.php`
