### PR TITLE
adding proper error message if user use reserved keywords of model:

### DIFF
--- a/src/Phaseolies/Database/Entity/Casts/InteractsWithCasting.php
+++ b/src/Phaseolies/Database/Entity/Casts/InteractsWithCasting.php
@@ -7,6 +7,23 @@ use Phaseolies\Database\Entity\Casts\Attributes\Transform;
 trait InteractsWithCasting
 {
     /**
+     * Internal model state properties that must never be used as cast targets.
+     *
+     * @var array<int, string>
+     */
+    private const RESERVED_CAST_PROPERTIES = [
+        'attributes',
+        'originalAttributes',
+        'relations',
+        'lastRelationType',
+        'lastRelatedModel',
+        'lastForeignKey',
+        'lastLocalKey',
+        'lastRelatedKey',
+        'lastPivotTable',
+    ];
+
+    /**
      * Per-class cache of #[Cast] attribute metadata scanned via reflection.
      *
      * @var array<string, array<string, string>>
@@ -43,6 +60,14 @@ trait InteractsWithCasting
 
             if (empty($castAttributes)) {
                 continue;
+            }
+
+            if (in_array($property->getName(), self::RESERVED_CAST_PROPERTIES, true)) {
+                throw new \LogicException(sprintf(
+                    'Invalid cast declaration on %s::$%s. This is a reserved internal model property and cannot be used with cast attributes. Use a real model field name or the $casts array for your column instead.',
+                    $class,
+                    $property->getName()
+                ));
             }
 
             $cast                        = $castAttributes[0]->newInstance();


### PR DESCRIPTION
If users use reserved keywords from doppar Entity model, they will see a proper error message when they will run `db:seed` command and use attribute cast properties.

Like assume you are using this in your Product model
```php
#[ToArray]
protected $attributes;
```

```php
 php pool db:seed


In Command.php line 150:
                                                                                                   
  Invalid cast declaration on App\Models\Product::$attributes. This is a reserved internal model   
  property and cannot be used with cast attributes. Use a real model field name or the $casts arr  
  ay for your column instead.                                                                      
                                                                                                   

db:seed [<seed>]
```