### PR TITLE
Improve cron:list output with schedule timing and runtime constraints

### DIFF
--- a/src/Phaseolies/Console/Commands/Cron/CronListCommand.php
+++ b/src/Phaseolies/Console/Commands/Cron/CronListCommand.php
@@ -3,7 +3,9 @@
 namespace Phaseolies\Console\Commands\Cron;
 
 use App\Schedule\Schedule;
+use Cron\CronExpression;
 use Phaseolies\Console\Schedule\Command;
+use Phaseolies\Console\Schedule\ScheduledCommand;
 use Symfony\Component\Console\Helper\Table;
 
 class CronListCommand extends Command
@@ -43,16 +45,15 @@ class CronListCommand extends Command
             $table = new Table($this->output);
             $table->setHeaders([
                 'Command',
-                'Runs In',
-                'Without Overlapping'
+                'Schedule',
+                'Next Run',
+                'Timezone',
+                'Mode',
+                'Constraints',
             ]);
 
             foreach ($commands as $command) {
-                $table->addRow([
-                    $command->getCommand(),
-                    $command->shouldRunInBackground() ? 'Background' : 'Foreground',
-                    $command->withoutOverlapping ? 'Yes' : 'No'
-                ]);
+                $table->addRow($this->commandRow($command));
             }
 
             $table->render();
@@ -60,5 +61,192 @@ class CronListCommand extends Command
             $this->displaySuccess('Listed ' . count($commands) . ' scheduled commands');
             return Command::SUCCESS;
         });
+    }
+
+    /**
+     * Build a display row for the schedule table.
+     *
+     * @param ScheduledCommand $command
+     * @return array
+     */
+    private function commandRow(ScheduledCommand $command): array
+    {
+        return [
+            $command->getCommand(),
+            $this->formatSchedule($command),
+            $this->formatNextRun($command),
+            $this->resolveTimezone($command),
+            $command->shouldRunInBackground() ? 'Background' : 'Foreground',
+            $this->formatConstraints($command),
+        ];
+    }
+
+    /**
+     * Format the schedule column for a command.
+     *
+     * @param ScheduledCommand $command
+     * @return string
+     */
+    private function formatSchedule(ScheduledCommand $command): string
+    {
+        if ($command->isSecondSchedule()) {
+            $specificSeconds = $command->getSpecificSeconds();
+            if (!empty($specificSeconds)) {
+                sort($specificSeconds);
+
+                return 'At seconds ' . implode(', ', $specificSeconds) . ' each minute';
+            }
+
+            $interval = $command->getSecondInterval();
+
+            return sprintf('Every %d second%s', $interval, $interval === 1 ? '' : 's');
+        }
+
+        return $command->getExpression();
+    }
+
+    /**
+     * Format the next run value for a command.
+     *
+     * @param ScheduledCommand $command
+     * @return string
+     */
+    private function formatNextRun(ScheduledCommand $command): string
+    {
+        if ($command->isSecondSchedule()) {
+            if (!empty($command->getSpecificSeconds())) {
+                return $this->formatSpecificSecondNextRun($command);
+            }
+
+            return 'Daemon-managed';
+        }
+
+        try {
+            $nextRun = (new CronExpression($command->getExpression()))
+                ->getNextRunDate('now', 0, false, $this->resolveTimezone($command));
+
+            return $nextRun->format('Y-m-d H:i:s');
+        } catch (\Throwable $e) {
+            return 'Unavailable';
+        }
+    }
+
+    /**
+     * Resolve the effective timezone for the command.
+     *
+     * @param ScheduledCommand $command
+     * @return string
+     */
+    private function resolveTimezone(ScheduledCommand $command): string
+    {
+        if ($command->getTimezone() !== null) {
+            return $command->getTimezone();
+        }
+
+        if (function_exists('config')) {
+            return (string) config('app.timezone', 'UTC');
+        }
+
+        return 'UTC';
+    }
+
+    /**
+     * Format command constraints into a compact summary.
+     *
+     * @param ScheduledCommand $command
+     * @return string
+     */
+    private function formatConstraints(ScheduledCommand $command): string
+    {
+        $constraints = [];
+
+        if ($command->withoutOverlapping) {
+            $constraints[] = 'No overlap (' . $command->getMaxLockTime() . 'm)';
+        }
+
+        if ($command->getRateLimit() !== null) {
+            $constraints[] = 'Throttle ' . $command->getRateLimit();
+        }
+
+        if ($command->getMaxRetries() > 0) {
+            $constraints[] = sprintf(
+                'Retry %dx/%ss',
+                $command->getMaxRetries(),
+                $command->getRetryDelay()
+            );
+        }
+
+        if ($command->hasAdditionalConditions()) {
+            $constraints[] = 'Time window';
+        }
+
+        if ($command->hasCustomCondition()) {
+            $constraints[] = 'Custom condition';
+        }
+
+        if (!empty($command->getExcludedDates())) {
+            $constraints[] = 'Exclude ' . $this->summarizeExcludedDates($command->getExcludedDates());
+        }
+
+        return empty($constraints) ? 'None' : implode('; ', $constraints);
+    }
+
+    /**
+     * Summarize excluded dates so the table stays readable.
+     *
+     * @param array $dates
+     * @return string
+     */
+    private function summarizeExcludedDates(array $dates): string
+    {
+        $dates = array_values(array_unique($dates));
+        $visibleDates = array_slice($dates, 0, 2);
+
+        if (count($dates) <= 2) {
+            return implode(', ', $visibleDates);
+        }
+
+        return implode(', ', $visibleDates) . sprintf(' +%d more', count($dates) - 2);
+    }
+
+    /**
+     * Estimate the next run for commands scheduled at specific seconds.
+     *
+     * @param ScheduledCommand $command
+     * @return string
+     */
+    private function formatSpecificSecondNextRun(ScheduledCommand $command): string
+    {
+        $timezone = $this->resolveTimezone($command);
+        $seconds = $command->getSpecificSeconds();
+
+        sort($seconds);
+
+        try {
+            $now = new \DateTimeImmutable('now', new \DateTimeZone($timezone));
+            $currentSecond = (int) $now->format('s');
+
+            foreach ($seconds as $second) {
+                if ($second > $currentSecond) {
+                    return $now->setTime(
+                        (int) $now->format('H'),
+                        (int) $now->format('i'),
+                        $second
+                    )->format('Y-m-d H:i:s');
+                }
+            }
+
+            $nextMinute = $now->modify('+1 minute');
+
+            return $nextMinute
+                ->setTime(
+                    (int) $nextMinute->format('H'),
+                    (int) $nextMinute->format('i'),
+                    $seconds[0]
+                )
+                ->format('Y-m-d H:i:s');
+        } catch (\Throwable $e) {
+            return 'Daemon-managed';
+        }
     }
 }

--- a/src/Phaseolies/Console/Schedule/ScheduledCommand.php
+++ b/src/Phaseolies/Console/Schedule/ScheduledCommand.php
@@ -837,6 +837,26 @@ class ScheduledCommand
     }
 
     /**
+     * Get the raw cron expression for the command.
+     *
+     * @return string
+     */
+    public function getExpression(): string
+    {
+        return $this->expression;
+    }
+
+    /**
+     * Get the maximum overlap lock time in minutes.
+     *
+     * @return int
+     */
+    public function getMaxLockTime(): int
+    {
+        return $this->maxLockTime;
+    }
+
+    /**
      * Prevent overlapping executions of the command.
      *
      * @param int $minutes The maximum lock time in minutes. Default: 1440 (24 hours)
@@ -907,6 +927,46 @@ class ScheduledCommand
         $this->rateLimit = $limit;
 
         return $this;
+    }
+
+    /**
+     * Get excluded dates for the command.
+     *
+     * @return array
+     */
+    public function getExcludedDates(): array
+    {
+        return $this->excludedDates;
+    }
+
+    /**
+     * Get the configured throttle expression.
+     *
+     * @return string|null
+     */
+    public function getRateLimit(): ?string
+    {
+        return $this->rateLimit;
+    }
+
+    /**
+     * Determine if the command has additional time-based conditions.
+     *
+     * @return bool
+     */
+    public function hasAdditionalConditions(): bool
+    {
+        return !empty($this->additionalConditions);
+    }
+
+    /**
+     * Determine if the command has a custom when() condition.
+     *
+     * @return bool
+     */
+    public function hasCustomCondition(): bool
+    {
+        return $this->condition !== null;
     }
 
     /**
@@ -1139,6 +1199,26 @@ class ScheduledCommand
         $this->retryDelay = $delaySeconds;
 
         return $this;
+    }
+
+    /**
+     * Get the maximum number of retry attempts.
+     *
+     * @return int
+     */
+    public function getMaxRetries(): int
+    {
+        return $this->maxRetries;
+    }
+
+    /**
+     * Get the retry delay in seconds.
+     *
+     * @return int
+     */
+    public function getRetryDelay(): int
+    {
+        return $this->retryDelay;
     }
 
     /**

--- a/tests/Console/CronListCommandTest.php
+++ b/tests/Console/CronListCommandTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Unit\Console;
+
+use Phaseolies\Console\Commands\Cron\CronListCommand;
+use Phaseolies\Console\Schedule\ScheduledCommand;
+use PHPUnit\Framework\TestCase;
+
+class CronListCommandTest extends TestCase
+{
+    public function testCommandRowIncludesCronExpressionNextRunAndTimezone(): void
+    {
+        $listCommand = new CronListCommand();
+        $scheduledCommand = (new ScheduledCommand('reports:daily'))
+            ->cron('*/15 * * * *')
+            ->timezone('UTC');
+
+        $row = $this->commandRow($listCommand, $scheduledCommand);
+
+        $this->assertSame('reports:daily', $row[0]);
+        $this->assertSame('*/15 * * * *', $row[1]);
+        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $row[2]);
+        $this->assertSame('UTC', $row[3]);
+        $this->assertSame('Foreground', $row[4]);
+        $this->assertSame('None', $row[5]);
+    }
+
+    public function testCommandRowIncludesRuntimeConstraintsForSecondSchedules(): void
+    {
+        $listCommand = new CronListCommand();
+        $scheduledCommand = (new ScheduledCommand('queue:prune'))
+            ->everyFiveSeconds()
+            ->inBackground()
+            ->noOverlap(30)
+            ->throttle('5/1h')
+            ->retry(3, 120)
+            ->exclude('2026-12-25', '2026-12-31', '2027-01-01')
+            ->between('09:00', '17:00')
+            ->when(fn() => true)
+            ->timezone('UTC');
+
+        $row = $this->commandRow($listCommand, $scheduledCommand);
+
+        $this->assertSame('Every 5 seconds', $row[1]);
+        $this->assertSame('Daemon-managed', $row[2]);
+        $this->assertSame('UTC', $row[3]);
+        $this->assertSame('Background', $row[4]);
+        $this->assertStringContainsString('No overlap (30m)', $row[5]);
+        $this->assertStringContainsString('Throttle 5/1h', $row[5]);
+        $this->assertStringContainsString('Retry 3x/120s', $row[5]);
+        $this->assertStringContainsString('Time window', $row[5]);
+        $this->assertStringContainsString('Custom condition', $row[5]);
+        $this->assertStringContainsString('Exclude 2026-12-25, 2026-12-31 +1 more', $row[5]);
+    }
+
+    public function testCommandRowEstimatesNextRunForSpecificSecondSchedules(): void
+    {
+        $listCommand = new CronListCommand();
+        $scheduledCommand = (new ScheduledCommand('sync:heartbeat'))
+            ->atSeconds([40, 10])
+            ->timezone('UTC');
+
+        $row = $this->commandRow($listCommand, $scheduledCommand);
+
+        $this->assertSame('At seconds 10, 40 each minute', $row[1]);
+        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $row[2]);
+    }
+
+    private function commandRow(CronListCommand $listCommand, ScheduledCommand $scheduledCommand): array
+    {
+        $method = new \ReflectionMethod($listCommand, 'commandRow');
+
+        return $method->invoke($listCommand, $scheduledCommand);
+    }
+}


### PR DESCRIPTION
This updates `cron:list` to show more useful scheduler details at a glance. The command now includes the schedule expression or second-based cadence, next run time, timezone, execution mode, and runtime constraints such as overlap protection, throttle rules, retries, excluded dates, and custom conditions.

It also adds small read-only accessors on `ScheduledCommand` so the list command can surface this metadata cleanly, plus PHPUnit coverage for the new row formatting behavior.

Previously, this command showed very limited information.

### Output
<img width="718" height="220" alt="image" src="https://github.com/user-attachments/assets/8cb3b99c-d653-46e7-9556-8c4d6220242a" />
