### PR TITLE
 Add explicit request termination lifecycle and terminable dispatch result

### DIFF
--- a/src/Phaseolies/Application.php
+++ b/src/Phaseolies/Application.php
@@ -4,6 +4,7 @@ namespace Phaseolies;
 
 use Phaseolies\Support\Router;
 use Phaseolies\Providers\ServiceProvider;
+use Phaseolies\Http\DispatchResult;
 use Phaseolies\Http\Response;
 use Phaseolies\Http\Request;
 use Phaseolies\Http\Exceptions\HttpException;
@@ -157,6 +158,13 @@ class Application extends Container
      * @var array<string>
      */
     protected $relaxablePaths = [];
+
+    /**
+     * Callbacks that should run after the request lifecycle has finished.
+     *
+     * @var array<int, array{callback: callable, parameters: array<int, \ReflectionParameter>}>
+     */
+    protected array $terminatingCallbacks = [];
 
     /**
      * Application constructor.
@@ -836,22 +844,183 @@ class Application extends Container
     }
 
     /**
+     * Register a callback to run after the response has been sent.
+     *
+     * Supported callback parameter names are: $request, $response, $exception.
+     *
+     * @param callable $callback
+     * @return self
+     */
+    public function terminating(callable $callback): self
+    {
+        $this->terminatingCallbacks[] = [
+            'callback' => $callback,
+            'parameters' => $this->reflectCallable($callback)->getParameters(),
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Run all registered terminating callbacks for the completed request.
+     *
+     * @param Request $request
+     * @param Response|null $response
+     * @param \Throwable|null $exception
+     * @return void
+     */
+    public function terminate(Request $request, ?Response $response = null, ?\Throwable $exception = null): void
+    {
+        if (empty($this->terminatingCallbacks)) {
+            return;
+        }
+
+        foreach ($this->terminatingCallbacks as $callback) {
+            $this->callTerminatingCallback($callback, $request, $response, $exception);
+        }
+    }
+
+    /**
+     * Invoke a terminating callback with the current lifecycle context.
+     *
+     * @param array{callback: callable, parameters: array<int, \ReflectionParameter>} $callback
+     * @param Request $request
+     * @param Response|null $response
+     * @param \Throwable|null $exception
+     * @return void
+     */
+    protected function callTerminatingCallback(array $callback, Request $request, ?Response $response = null, ?\Throwable $exception = null): void
+    {
+        $namedContext = [
+            'request' => $request,
+            'response' => $response,
+            'exception' => $exception,
+        ];
+
+        $arguments = [];
+
+        foreach ($callback['parameters'] as $parameter) {
+            $resolved = false;
+            $type = $parameter->getType();
+
+            if ($type instanceof \ReflectionNamedType && !$type->isBuiltin()) {
+                $typeName = $type->getName();
+
+                if ($request instanceof $typeName) {
+                    $arguments[] = $request;
+                    $resolved = true;
+                } elseif ($response instanceof $typeName) {
+                    $arguments[] = $response;
+                    $resolved = true;
+                } elseif ($exception instanceof $typeName) {
+                    $arguments[] = $exception;
+                    $resolved = true;
+                } elseif ($this->typeAllowsNull($type)) {
+                    $arguments[] = null;
+                    $resolved = true;
+                }
+            } elseif ($type instanceof \ReflectionUnionType && $this->typeAllowsNull($type)) {
+                $arguments[] = null;
+                $resolved = true;
+            }
+
+            if (!$resolved && array_key_exists($parameter->getName(), $namedContext)) {
+                $arguments[] = $namedContext[$parameter->getName()];
+                $resolved = true;
+            }
+
+            if (!$resolved && $parameter->isDefaultValueAvailable()) {
+                $arguments[] = $parameter->getDefaultValue();
+                $resolved = true;
+            }
+
+            if (!$resolved) {
+                throw new \RuntimeException(
+                    "Unresolvable terminating callback parameter '\${$parameter->getName()}'."
+                );
+            }
+        }
+
+        call_user_func_array($callback['callback'], $arguments);
+    }
+
+    /**
+     * Create a reflection instance for a generic PHP callable.
+     *
+     * @param callable $callback
+     * @return \ReflectionFunctionAbstract
+     */
+    protected function reflectCallable(callable $callback): \ReflectionFunctionAbstract
+    {
+        if (is_array($callback)) {
+            return new \ReflectionMethod($callback[0], $callback[1]);
+        }
+
+        if (is_object($callback) && method_exists($callback, '__invoke')) {
+            return new \ReflectionMethod($callback, '__invoke');
+        }
+
+        return new \ReflectionFunction($callback);
+    }
+
+    /**
+     * Determine whether a reflected parameter type explicitly allows null.
+     *
+     * @param \ReflectionType $type
+     * @return bool
+     */
+    protected function typeAllowsNull(\ReflectionType $type): bool
+    {
+        if ($type instanceof \ReflectionNamedType) {
+            return $type->allowsNull();
+        }
+
+        if ($type instanceof \ReflectionUnionType) {
+            foreach ($type->getTypes() as $innerType) {
+                if ($innerType instanceof \ReflectionNamedType && $innerType->getName() === 'null') {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Resolve the incoming request into a response instance.
+     *
+     * @param Request $request
+     * @return Response
+     */
+    public function handle(Request $request): Response
+    {
+        $response = $this->router->resolve($this, $request);
+
+        if (!$response instanceof Response) {
+            $response = $response->setBody((string) $response);
+        }
+
+        return $response;
+    }
+
+    /**
      * Dispatches the application request.
      *
      * @param Request $request
-     * @return void
+     * @return DispatchResult
      */
-    public function dispatch($request): void
+    public function dispatch($request): DispatchResult
     {
         try {
-            $response = $this->router->resolve($this, $request);
-            if (!$response instanceof Response) {
-                $response = $response->setBody((string) $response);
-            }
+            $response = $this->handle($request);
 
             $response->prepare($request)->send();
+
+            return new DispatchResult($this, $request, $response);
         } catch (HttpException $e) {
             Response::dispatchHttpException($e);
+
+            return new DispatchResult($this, $request, null, $e);
         }
     }
 }

--- a/src/Phaseolies/Http/DispatchResult.php
+++ b/src/Phaseolies/Http/DispatchResult.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Phaseolies\Http;
+
+use Phaseolies\Application;
+
+class DispatchResult
+{
+    /**
+     * Indicates whether termination has already been performed.
+     *
+     * @var bool
+     */
+    protected bool $terminated = false;
+
+    /**
+     * @param Application $app
+     * @param Request $request
+     * @param Response|null $response
+     * @param \Throwable|null $exception
+     */
+    public function __construct(
+        protected Application $app,
+        protected Request $request,
+        protected ?Response $response = null,
+        protected ?\Throwable $exception = null
+    ) {}
+
+    /**
+     * Run the application termination lifecycle once.
+     *
+     * @return $this
+     */
+    public function terminate(): static
+    {
+        if ($this->terminated) {
+            return $this;
+        }
+
+        $this->terminated = true;
+        $this->app->terminate($this->request, $this->response, $this->exception);
+
+        return $this;
+    }
+
+    /**
+     * Get the resolved response instance, if one exists.
+     *
+     * @return Response|null
+     */
+    public function response(): ?Response
+    {
+        return $this->response;
+    }
+
+    /**
+     * Get the captured exception for the request, if one exists.
+     *
+     * @return \Throwable|null
+     */
+    public function exception(): ?\Throwable
+    {
+        return $this->exception;
+    }
+
+    /**
+     * Ensure termination still runs when the dispatch result is ignored.
+     */
+    public function __destruct()
+    {
+        $this->terminate();
+    }
+}

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -6,7 +6,10 @@ use ReflectionClass;
 use Tests\Support\Kernel;
 use Phaseolies\Application;
 use Phaseolies\DI\Container;
+use Phaseolies\Http\DispatchResult;
 use Phaseolies\Http\Request;
+use Phaseolies\Http\Response;
+use Phaseolies\Http\Exceptions\HttpException;
 use Phaseolies\Config\Config;
 use Phaseolies\Support\Router;
 use Phaseolies\Console\Console;
@@ -289,5 +292,156 @@ final class ApplicationTest extends TestCase
         $result = $this->app->withConfiguration();
 
         $this->assertSame($this->app, $result);
+    }
+
+    public function testHandleReturnsResolvedResponse(): void
+    {
+        $request = new Request();
+        $response = new Response('handled');
+
+        $router = $this->createMock(Router::class);
+        $router->expects($this->once())
+            ->method('resolve')
+            ->with($this->app, $request)
+            ->willReturn($response);
+
+        $this->app->router = $router;
+
+        $handled = $this->app->handle($request);
+
+        $this->assertSame($response, $handled);
+    }
+
+    public function testDispatchReturnsTerminableResult(): void
+    {
+        $request = new Request();
+
+        $response = $this->getMockBuilder(Response::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['prepare', 'send'])
+            ->getMock();
+
+        $response->expects($this->once())
+            ->method('prepare')
+            ->with($request)
+            ->willReturnSelf();
+
+        $response->expects($this->once())
+            ->method('send')
+            ->with()
+            ->willReturnSelf();
+
+        $router = $this->createMock(Router::class);
+        $router->expects($this->once())
+            ->method('resolve')
+            ->with($this->app, $request)
+            ->willReturn($response);
+
+        $this->app->router = $router;
+
+        $captured = [];
+
+        $this->app->terminating(
+            function (
+                Request $requestArg,
+                ?Response $responseArg,
+                ?\Throwable $exception
+            ) use (&$captured): void {
+                $captured = [$requestArg, $responseArg, $exception];
+            }
+        );
+
+        $result = $this->app->dispatch($request);
+
+        $this->assertInstanceOf(DispatchResult::class, $result);
+
+        $result->terminate();
+
+        $this->assertSame($response, $result->response());
+        $this->assertNull($result->exception());
+        $this->assertSame($request, $captured[0]);
+        $this->assertSame($response, $captured[1]);
+        $this->assertNull($captured[2]);
+    }
+
+    public function testDispatchStillTerminatesWhenResultIsIgnored(): void
+    {
+        $request = new Request();
+
+        $response = $this->getMockBuilder(Response::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['prepare', 'send'])
+            ->getMock();
+
+        $response->expects($this->once())
+            ->method('prepare')
+            ->with($request)
+            ->willReturnSelf();
+
+        $response->expects($this->once())
+            ->method('send')
+            ->with()
+            ->willReturnSelf();
+
+        $router = $this->createMock(Router::class);
+        $router->expects($this->once())
+            ->method('resolve')
+            ->with($this->app, $request)
+            ->willReturn($response);
+
+        $this->app->router = $router;
+
+        $captured = [];
+
+        $this->app->terminating(function (
+            Request $requestArg,
+            ?Response $responseArg,
+            ?\Throwable $exception
+        ) use (&$captured): void {
+            $captured = [$requestArg, $responseArg, $exception];
+        });
+
+        $this->app->dispatch($request);
+
+        $this->assertSame($request, $captured[0]);
+        $this->assertSame($response, $captured[1]);
+        $this->assertNull($captured[2]);
+    }
+
+    public function testDispatchResultDoesNotTerminateTwiceAfterExplicitTermination(): void
+    {
+        $request = new Request();
+        $response = new Response('ok');
+        $calls = 0;
+
+        $this->app->terminating(function () use (&$calls): void {
+            $calls++;
+        });
+
+        $result = new DispatchResult($this->app, $request, $response);
+
+        $result->terminate();
+        unset($result);
+
+        $this->assertSame(1, $calls);
+    }
+
+    public function testTerminateProvidesLifecycleContextToNamedParameters(): void
+    {
+        $request = new Request();
+        $response = new Response('ok');
+        $exception = new HttpException(500, 'Lifecycle failed');
+
+        $captured = [];
+
+        $this->app->terminating(function ($request, $response, $exception) use (&$captured): void {
+            $captured = compact('request', 'response', 'exception');
+        });
+
+        $this->app->terminate($request, $response, $exception);
+
+        $this->assertSame($request, $captured['request']);
+        $this->assertSame($response, $captured['response']);
+        $this->assertSame($exception, $captured['exception']);
     }
 }


### PR DESCRIPTION
This change introduces a dedicated post-response termination lifecycle for Doppar’s HTTP flow and makes it available through an explicit terminable dispatch result.

Previously, the request lifecycle ended when the response was prepared and sent, but there was no clean framework-level hook for running post-response logic such as logging, cleanup, metrics, audit handling, or deferred request-side work. This update adds that capability in a structured way while keeping the request/response flow backward compatible.

Now, from the skeleton app, `public/index.php` will end like this way.
```php
$response = $app->dispatch(Request::capture());
$response->terminate();
```

And `bootstrap/app.php` get a new method `terminating()`
```php
return $app
    ->withBasePath(basePath: $basePath)
    ->setRelaxablePaths(relaxablePaths: [
        // The paths listed below will bypass CSRF token verification.
        // This is useful for APIs, webhooks, or routes where CSRF protection is not required.
        // '/webhook/payment' – bypasses only the '/webhook/payment' URI.
        // '/webhook/*' – bypasses all URIs that start with '/webhook'.
        // '/tags/*',
    ])
    ->terminating(function (Request $request, ?Response $response, ?\Throwable $exception = null) {
        // Runs after the response is sent, during application termination.
    })
    ->configure(app: $app)
    ->build();
 ```   