### PR TITLE
fix: resolve background command argument parsing, config cache race condition, pid capture, and add per-job log control

### DIFF
--- a/src/Phaseolies/Config/Config.php
+++ b/src/Phaseolies/Config/Config.php
@@ -178,7 +178,7 @@ final class Config
             'data' => self::$config,
         ];
 
-        $tempFile = self::$cacheFile . '.tmp';
+        $tempFile = self::$cacheFile . '.tmp.' . getmypid();
         file_put_contents($tempFile, '<?php return ' . var_export($cacheContent, true) . ';', LOCK_EX);
         rename($tempFile, self::$cacheFile);
 

--- a/src/Phaseolies/Console/Commands/Cron/CronRunCommand.php
+++ b/src/Phaseolies/Console/Commands/Cron/CronRunCommand.php
@@ -380,11 +380,13 @@ class CronRunCommand extends Command
             mkdir($lockDir, 0755, true);
         }
 
+        $commandParts = implode(' ', array_map('escapeshellarg', preg_split('/\s+/', trim($command->getCommand()))));
+
         $commandString = sprintf(
             '(%s %s %s >> %s 2>&1 ; %s %s cron:finish %s %d $? >> %s 2>&1) & echo $!',
             escapeshellarg($phpBinary),
             escapeshellarg($poolScript),
-            escapeshellarg($command->getCommand()),
+            $commandParts,
             escapeshellarg($logFile),
             escapeshellarg($phpBinary),
             escapeshellarg($poolScript),
@@ -455,7 +457,7 @@ class CronRunCommand extends Command
             $command->lock();
         }
 
-        $process = new Process(['php', 'pool', $command->getCommand()], base_path(), $env);
+        $process = new Process(array_merge(['php', 'pool'], preg_split('/\s+/', trim($command->getCommand()))), base_path(), $env);
         $process->setTimeout(null);
         $process->run();
 

--- a/src/Phaseolies/Console/Commands/Cron/CronRunCommand.php
+++ b/src/Phaseolies/Console/Commands/Cron/CronRunCommand.php
@@ -368,11 +368,15 @@ class CronRunCommand extends Command
             $command->lock();
         }
 
-        $logDir = storage_path('schedule');
-        if (!file_exists($logDir)) {
-            mkdir($logDir, 0755, true);
+        if ($command->getOutputTo() !== null) {
+            $logFile = $command->getOutputTo();
+        } else {
+            $logDir = storage_path('schedule');
+            if (!file_exists($logDir)) {
+                mkdir($logDir, 0755, true);
+            }
+            $logFile = $logDir . '/cron_' . md5($command->getCommand()) . '.log';
         }
-        $logFile = $logDir . '/cron_' . md5($command->getCommand()) . '.log';
 
         $lockFile = $command->getLockFile() . '.pid';
         $lockDir = dirname($lockFile);

--- a/src/Phaseolies/Console/Schedule/SchedulePool.php
+++ b/src/Phaseolies/Console/Schedule/SchedulePool.php
@@ -10,13 +10,6 @@ class SchedulePool
     /**
      * List of processes currently managed by the schedule pool.
      *
-     * Each element is an associative array containing:
-     * - pid (int) Process ID.
-     * - start_time (int) UNIX timestamp indicating when the process started.
-     *
-     * This property is used to keep track of background processes initiated
-     * through the pool, allowing status checks and management.
-     *
      * @var array<int, array{pid:int, start_time:int}>
      */
     protected static $runningProcesses = [];
@@ -30,8 +23,10 @@ class SchedulePool
      */
     public static function call(string $command, bool $background = false): array
     {
-        $commandArray = ['php', 'pool'];
-        $commandArray = array_merge($commandArray, explode(' ', $command));
+        $commandArray = array_merge(
+            ['php', 'pool'],
+            preg_split('/\s+/', trim($command))
+        );
 
         $process = new Process(
             $commandArray,
@@ -62,11 +57,15 @@ class SchedulePool
 
             return $processInfo;
         } else {
+            $pid = null;
+
             try {
-                $process->run();
+                $process->start();
+                $pid = $process->getPid();
+                $process->wait();
 
                 return [
-                    'pid' => $process->getPid(),
+                    'pid' => $pid,
                     'command' => $command,
                     'status' => $process->isSuccessful() ? 'success' : 'failed',
                     'output' => $process->getOutput(),
@@ -74,7 +73,7 @@ class SchedulePool
                 ];
             } catch (ProcessFailedException $e) {
                 return [
-                    'pid' => $process->getPid(),
+                    'pid' => $pid,
                     'command' => $command,
                     'status' => 'failed',
                     'error' => $e->getMessage()

--- a/src/Phaseolies/Console/Schedule/ScheduledCommand.php
+++ b/src/Phaseolies/Console/Schedule/ScheduledCommand.php
@@ -39,6 +39,13 @@ class ScheduledCommand
     private $runInBackground = false;
 
     /**
+     * Custom output destination for background process stdout/stderr
+     *
+     * @var string|null
+     */
+    private $outputTo = null;
+
+    /**
      * Path to a file used to store the timestamp of the last run.
      *
      * @var string
@@ -891,6 +898,39 @@ class ScheduledCommand
     public function shouldRunInBackground(): bool
     {
         return $this->runInBackground;
+    }
+
+    /**
+     * Redirect background process output to the given file path.
+     *
+     * @param string $location
+     * @return self
+     */
+    public function sendOutputTo(string $location): self
+    {
+        $this->outputTo = $location;
+
+        return $this;
+    }
+
+    /**
+     * Discard all background process output instead of writing a per-job log file.
+     *
+     * @return self
+     */
+    public function withoutLog(): self
+    {
+        return $this->sendOutputTo('/dev/null');
+    }
+
+    /**
+     * Get the configured output destination, or null to use the default per-job log file.
+     *
+     * @return string|null
+     */
+    public function getOutputTo(): ?string
+    {
+        return $this->outputTo;
     }
 
     /**


### PR DESCRIPTION
## Summary

This pull request fixes three framework-level bugs that caused all scheduled commands with arguments or options to silently fail, resolves a concurrent config-cache race condition, fixes a null PID being returned from `Pool::call()`, and adds two new methods to give developers control over where background job output is written.

## Bug Fixes

### 1. Scheduled commands with arguments or options were never recognised

**Files:** `package/doppar/src/Phaseolies/Console/Commands/Cron/CronRunCommand.php`

**Root cause:** `CronRunCommand::runInBackground()` passed the entire command string — including arguments and options — through `escapeshellarg()` as a single shell token. The OS received `'doppar:tag-insert pending --process_per_minute=100'` as one argument, so the `pool` script's `argv[1]` was the whole string. Symfony Console looked for a command literally named `doppar:tag-insert pending --process_per_minute=100`, found nothing, and exited with code `1`. Commands with no arguments (e.g. `doppar:user-insert`) were unaffected because their full string equalled their command name.

The same bug existed in `runInForeground()` where the entire command string was passed as a single element of the `Process` array.

**Fix:** Split the command string on whitespace before escaping, so each token becomes a separate shell argument.

```php
// Before (runInBackground)
escapeshellarg($command->getCommand())

// After
$commandParts = implode(' ', array_map('escapeshellarg', preg_split('/\s+/', trim($command->getCommand()))));
```

```php
// Before (runInForeground)
new Process(['php', 'pool', $command->getCommand()], ...)

// After
new Process(array_merge(['php', 'pool'], preg_split('/\s+/', trim($command->getCommand()))), ...)
```

### 2. Config cache race condition on concurrent background process startup

**File:** `package/doppar/src/Phaseolies/Config/Config.php`

**Root cause:** `Config::cacheConfig()` wrote config data to a fixed temp file path (`config.php.tmp`) then atomically renamed it. When two background processes started at the same tick (e.g. `tag-insert` and `user-insert` both firing at second 0), both wrote to the identical `.tmp` path. Whichever process renamed first left the other with a missing source file, causing:

```
rename(...config.php.tmp, ...config.php): No such file or directory
```

This crashed the second process during bootstrap before `handle()` was ever called, producing exit code `1` and a misleading `cron:finish` error in the log.

**Fix:** Append the current process ID to the temp filename so each concurrent process writes to its own unique path.

```php
// Before
$tempFile = self::$cacheFile . '.tmp';

// After
$tempFile = self::$cacheFile . '.tmp.' . getmypid();
```

---

### 3. `Pool::call()` returned `null` for the process PID

**File:** `package/doppar/src/Phaseolies/Console/Schedule/SchedulePool.php`

**Root cause:** In foreground mode, `Pool::call()` used `$process->run()`, which blocks until the process exits before returning. Symfony's `Process::getPid()` returns `null` once a process has terminated, so the PID captured after `run()` was always `null` — even though the command executed successfully.

**Fix:** Replace `run()` with `start()` + `wait()`. The PID is read immediately after `start()`, while the process is alive, and `wait()` blocks until completion so output and exit code are still available.

```php
// Before
$process->run();
return ['pid' => $process->getPid(), ...];

// After
$process->start();
$pid = $process->getPid();   // captured while process is alive
$process->wait();
return ['pid' => $pid, ...];
```

---

### 4. Inconsistent command argument splitting in `Pool::call()`

**File:** `package/doppar/src/Phaseolies/Console/Schedule/SchedulePool.php`

**Root cause:** `Pool::call()` used `explode(' ', $command)` to split the command string into an array for the `Process` constructor. While this worked for the current commands, it would silently misparse any command whose argument values contained multiple consecutive spaces or leading/trailing whitespace.

**Fix:** Unified with the same `preg_split('/\s+/', trim($command))` pattern used in `CronRunCommand` after fix #1.

```php
// Before
$commandArray = array_merge($commandArray, explode(' ', $command));

// After
$commandArray = array_merge(
    ['php', 'pool'],
    preg_split('/\s+/', trim($command))
);
```

---

## New Feature

### `sendOutputTo()` and `withoutLog()` on scheduled commands

**Files:**
- `package/doppar/src/Phaseolies/Console/Schedule/ScheduledCommand.php`
- `package/doppar/src/Phaseolies/Console/Commands/Cron/CronRunCommand.php`

**Context:** When `inBackground()` is used, Doppar writes each background job's stdout and stderr to a dedicated file at `storage/schedule/cron_{md5}.log`. For high-frequency second-based commands this creates a large number of log files that fill the `storage/schedule/` directory.

**Two new methods added to `ScheduledCommand`:**

`sendOutputTo(string $location)` — redirects background process output to any file path instead of the default per-job log file:
```php
$schedule->command('report:generate monthly')
    ->dailyAt('06:00')
    ->inBackground()
    ->sendOutputTo(storage_path('logs/reports.log'));
```

`withoutLog()` — discards all background process output entirely. No log file is created for that job. Shorthand for `sendOutputTo('/dev/null')`:
```php
$schedule->command('cache:warm')
    ->everyMinute()
    ->inBackground()
    ->withoutLog();
```

When neither method is called, the existing default behaviour (per-job log file) is preserved unchanged