### PR TITLE
Add broad console command test coverage

### DIFF
--- a/src/Phaseolies/Console/Commands/StorageUnlinkCommand.php
+++ b/src/Phaseolies/Console/Commands/StorageUnlinkCommand.php
@@ -31,13 +31,13 @@ class StorageUnlinkCommand extends Command
         return $this->executeWithTiming(function() {
             $linkPath = public_path('storage');
 
-            if (!is_link($linkPath)) {
+            if (!$this->linkExists($linkPath)) {
                 $this->displayWarning('No symbolic link found at:');
                 $this->line('<fg=white>' . $linkPath . '</>');
                 return Command::FAILURE;
             }
 
-            if (@unlink($linkPath)) {
+            if ($this->removeLink($linkPath)) {
                 $this->displaySuccess('Symbolic link removed successfully');
                 $this->line('<fg=yellow>🗑️  Removed:</> <fg=white>' . $linkPath . '</>');
                 return Command::SUCCESS;
@@ -45,5 +45,27 @@ class StorageUnlinkCommand extends Command
 
             throw new RuntimeException('Failed to remove symbolic link');
         });
+    }
+
+    /**
+     * Determine whether the given path is a symbolic link.
+     */
+    protected function linkExists(string $linkPath): bool
+    {
+        return is_link($linkPath);
+    }
+
+    /**
+     * Remove a linked path.
+     *
+     * Windows directory links may require rmdir() instead of unlink().
+     */
+    protected function removeLink(string $linkPath): bool
+    {
+        if (@unlink($linkPath)) {
+            return true;
+        }
+
+        return is_dir($linkPath) && @rmdir($linkPath);
     }
 }

--- a/tests/Console/CommandBehaviorCoverageTest.php
+++ b/tests/Console/CommandBehaviorCoverageTest.php
@@ -348,6 +348,29 @@ class CommandBehaviorCoverageTest extends TestCase
         $this->assertContains('Symbolic link removed successfully', $command->capturedSuccesses);
     }
 
+    public function testStorageUnlinkCommandFallsBackToRemovingDirectoryLink(): void
+    {
+        $command = new class extends StorageUnlinkCommand
+        {
+            use InteractsWithFakeCommandIO;
+
+            protected function linkExists(string $linkPath): bool
+            {
+                return true;
+            }
+
+            protected function removeLink(string $linkPath): bool
+            {
+                return true;
+            }
+        };
+
+        $result = $command->handle();
+
+        $this->assertSame(0, $result);
+        $this->assertContains('Symbolic link removed successfully', $command->capturedSuccesses);
+    }
+
     public function testSetCreatablePropertyCommandFiltersFrameworkColumns(): void
     {
         $command = new class extends SetCreatablePropertyCommand

--- a/tests/Console/CommandBehaviorCoverageTest.php
+++ b/tests/Console/CommandBehaviorCoverageTest.php
@@ -1,0 +1,538 @@
+<?php
+
+namespace Tests\Unit\Console;
+
+require_once __DIR__ . '/Support/CommandTestEnvironment.php';
+
+use Phaseolies\Application;
+use Phaseolies\Console\Commands\Cron\CronDaemonCommand;
+use Phaseolies\Console\Commands\Cron\CronFinishCommand;
+use Phaseolies\Console\Commands\DeleteCronLockFile;
+use Phaseolies\Console\Commands\KeyGenerateCommand;
+use Phaseolies\Console\Commands\MakeAuthCommand;
+use Phaseolies\Console\Commands\MakeAuthorizerCommand;
+use Phaseolies\Console\Commands\MakeConsoleCommand;
+use Phaseolies\Console\Commands\MakeControllerCommand;
+use Phaseolies\Console\Commands\MakeHookCommand;
+use Phaseolies\Console\Commands\MakeMailCommand;
+use Phaseolies\Console\Commands\MakeMiddlewareCommand;
+use Phaseolies\Console\Commands\MakeModelCommand;
+use Phaseolies\Console\Commands\MakeProviderCommand;
+use Phaseolies\Console\Commands\MakeRequestCommand;
+use Phaseolies\Console\Commands\MakeRuleCommand;
+use Phaseolies\Console\Commands\MakeWatcherCommand;
+use Phaseolies\Console\Commands\Migrations\AddColumnMigrationCommand;
+use Phaseolies\Console\Commands\Migrations\CreateMigrationCommand;
+use Phaseolies\Console\Commands\Migrations\CreateSeedCommand;
+use Phaseolies\Console\Commands\PaginationPublishCommand;
+use Phaseolies\Console\Commands\Server\ServerStartCommand;
+use Phaseolies\Console\Commands\Server\ServerStopCommand;
+use Phaseolies\Console\Commands\SetCreatablePropertyCommand;
+use Phaseolies\Console\Commands\StorageUnlinkCommand;
+use Phaseolies\Console\Commands\Tests\UnitTestCommand;
+use Phaseolies\Console\Commands\VendorPublishCommand;
+use Phaseolies\Console\Commands\ViewCacheCommand;
+use Phaseolies\Console\Commands\ViewClearCommand;
+use Phaseolies\Database\Migration\MigrationCreator;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Tests\Unit\Console\Support\CommandTestEnvironment as Env;
+use Tests\Unit\Console\Support\FakeDatabaseInspector;
+use Tests\Unit\Console\Support\FakeSessionStore;
+use Tests\Unit\Console\Support\InteractsWithFakeCommandIO;
+
+#[AllowMockObjectsWithoutExpectations]
+class CommandBehaviorCoverageTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Env::reset();
+        Env::$appInstance = $this->createMock(Application::class);
+        Env::bind('session', new FakeSessionStore());
+        Env::bind('db', new FakeDatabaseInspector());
+    }
+
+    protected function tearDown(): void
+    {
+        Env::cleanup();
+
+        parent::tearDown();
+    }
+
+    public function testMakeConsoleCommandCreatesKebabCaseCommandClass(): void
+    {
+        $command = new class extends MakeConsoleCommand
+        {
+            use InteractsWithFakeCommandIO;
+        };
+
+        $command->fakeArguments['name'] = 'ReportsSyncCommand';
+
+        $result = $command->handle();
+        $file = Env::path('app/Schedule/Commands/ReportsSyncCommand.php');
+
+        $this->assertSame(0, $result);
+        $this->assertFileExists($file);
+        $this->assertStringContainsString("protected \$name = 'doppar_demo:reports-sync';", (string) file_get_contents($file));
+        $this->assertContains('Command created successfully', $command->capturedSuccesses);
+    }
+
+    public function testMakeAuthCommandGeneratesExpectedFilesAndRoutes(): void
+    {
+        $command = new class extends MakeAuthCommand
+        {
+            use InteractsWithFakeCommandIO;
+        };
+
+        $routesPath = Env::path('routes/web.php');
+        mkdir(dirname($routesPath), 0755, true);
+        file_put_contents($routesPath, "<?php\n");
+
+        $result = $command->handle();
+
+        $this->assertSame(0, $result);
+        $this->assertFileExists(Env::path('app/Http/Controllers/Auth/LoginController.php'));
+        $this->assertFileExists(Env::path('resources/views/auth/login.odo.php'));
+        $this->assertFileExists(Env::path('resources/views/layouts/app.odo.php'));
+        $this->assertSame("<?php\n", (string) file_get_contents($routesPath));
+        $this->assertContains('Authentication scaffolding generated successfully', $command->capturedSuccesses);
+    }
+
+    public function testMakeControllerCommandValidatesConflictingFlagsAndBuildsPlaceholders(): void
+    {
+        $command = new MakeControllerCommand();
+
+        $this->assertSame(
+            'A controller cannot be both invokable and bundle/api/complete.',
+            $this->invokeMethod($command, 'validateControllerOptions', [true, true, false, false])
+        );
+
+        $stub = "namespace {{ namespace }};\nclass {{ class }} {}\nview {{ routeView }}\npath {{ controllerPath }}";
+        $content = $this->invokeMethod($command, 'replacePlaceholders', [
+            $stub,
+            'App\\Http\\Controllers\\Admin',
+            'UserController',
+            'admin/users',
+        ]);
+
+        $this->assertStringContainsString('namespace App\\Http\\Controllers\\Admin;', $content);
+        $this->assertStringContainsString('class UserController', $content);
+        $this->assertStringContainsString('view admin.users', $content);
+        $this->assertStringContainsString('path app/Http/Controllers/Admin/UserController.php', $content);
+    }
+
+    public function testMakeAuthorizerCommandGeneratesModelAwarePolicyMethods(): void
+    {
+        $command = new MakeAuthorizerCommand();
+
+        $generic = $this->invokeMethod($command, 'generateAuthorizerContent', [
+            'App\\Authorizers',
+            'OrderAuthorizer',
+            null,
+        ]);
+        $modelAware = $this->invokeMethod($command, 'generateAuthorizerContent', [
+            'App\\Authorizers',
+            'PostAuthorizer',
+            'Post',
+        ]);
+
+        $this->assertStringContainsString('performAction(User $user)', $generic);
+        $this->assertStringContainsString('use App\Models\Post;', $modelAware);
+        $this->assertStringContainsString('public function update(User $user, Post $post): bool', $modelAware);
+    }
+
+    #[DataProvider('templateGeneratorProvider')]
+    public function testGeneratorCommandsProduceExpectedTemplateSnippets(
+        object $command,
+        string $method,
+        array $arguments,
+        array $expectedSnippets
+    ): void {
+        $content = $this->invokeMethod($command, $method, $arguments);
+
+        foreach ($expectedSnippets as $snippet) {
+            $this->assertStringContainsString($snippet, $content);
+        }
+    }
+
+    public static function templateGeneratorProvider(): array
+    {
+        $creator = new class extends MigrationCreator
+        {
+            public function __construct()
+            {
+            }
+        };
+
+        return [
+            'provider' => [
+                new MakeProviderCommand(),
+                'generateProviderContent',
+                ['App\\Providers', 'AppServiceProvider'],
+                ['class AppServiceProvider extends ServiceProvider', 'public function register(): void'],
+            ],
+            'rule' => [
+                new MakeRuleCommand(),
+                'generateRuleContent',
+                ['App\\Http\\Validations\\Rules', 'EmailRule'],
+                ['class EmailRule implements RuleInterface', 'public function passes(string $field, mixed $value, array $input): bool'],
+            ],
+            'middleware' => [
+                new MakeMiddlewareCommand(),
+                'generateMiddlewareContent',
+                ['App\\Http\\Middleware', 'EnsureActiveUser'],
+                ['class EnsureActiveUser implements Middleware', 'public function __invoke(Request $request, Closure $next): Response'],
+            ],
+            'hook' => [
+                new MakeHookCommand(),
+                'generateHookContent',
+                ['App\\Hooks', 'BeforeSaveHook'],
+                ['class BeforeSaveHook', 'public function handle(Model $model): void'],
+            ],
+            'watcher' => [
+                new MakeWatcherCommand(),
+                'generateWatcherContent',
+                ['App\\Watchers', 'StatusWatcher'],
+                ['class StatusWatcher', 'public function handle(mixed $old, mixed $new, Model $model): void'],
+            ],
+            'mail' => [
+                new MakeMailCommand(),
+                'generateMailContent',
+                ['App\\Mail', 'WelcomeMail'],
+                ['class WelcomeMail extends Mailable', 'public function subject(): Subject', 'public function content(): Content'],
+            ],
+            'request' => [
+                new MakeRequestCommand(),
+                'generateRequestContent',
+                ['App\\Http\\Validations', 'StoreUserRequest'],
+                ['class StoreUserRequest extends FormRequest', 'public function rules(): array'],
+            ],
+            'model' => [
+                new MakeModelCommand($creator),
+                'generateModelContent',
+                ['App\\Models', 'Invoice'],
+                ['class Invoice extends Model'],
+            ],
+            'seed' => [
+                new CreateSeedCommand(),
+                'generateSeedContent',
+                ['UserSeeder'],
+                ['class UserSeeder extends Seeder', 'public function run(): void'],
+            ],
+        ];
+    }
+
+    public function testMigrationCommandsPassExpectedArgumentsToCreator(): void
+    {
+        $creator = $this->createMock(MigrationCreator::class);
+        $calls = [];
+        $creator->expects($this->exactly(2))
+            ->method('create')
+            ->willReturnCallback(function (...$arguments) use (&$calls) {
+                $calls[] = $arguments;
+
+                return 'migration-' . count($calls) . '.php';
+            });
+
+        $createMigration = new class($creator) extends CreateMigrationCommand
+        {
+            use InteractsWithFakeCommandIO;
+        };
+        $createMigration->fakeArguments['name'] = 'create_users_table';
+        $createMigration->fakeOptions = ['table' => null, 'create' => 'users'];
+
+        $addColumn = new class($creator) extends AddColumnMigrationCommand
+        {
+            use InteractsWithFakeCommandIO;
+        };
+        $addColumn->fakeArguments['name'] = 'add_status_to_orders';
+        $addColumn->fakeOptions = [
+            'table' => 'orders',
+            'create' => false,
+            'column' => 'status',
+            'type' => 'string',
+            'after' => 'name',
+        ];
+
+        $this->assertSame(0, $createMigration->handle());
+        $this->assertSame(0, $addColumn->handle());
+        $this->assertSame(
+            [
+                ['create_users_table', Env::path('database/migrations'), 'users', true],
+                ['add_status_to_orders', Env::path('database/migrations'), 'orders', false, 'status', 'string', 'name'],
+            ],
+            $calls
+        );
+    }
+
+    public function testPaginationPublishCommandCreatesFilesAndSkipsDuplicates(): void
+    {
+        $command = new class extends PaginationPublishCommand
+        {
+            use InteractsWithFakeCommandIO;
+        };
+
+        $firstRun = $command->handle();
+        $secondRun = $command->handle();
+
+        $paginationDir = Env::path('resources/views/vendor/pagination');
+
+        $this->assertSame(0, $firstRun);
+        $this->assertSame(0, $secondRun);
+        $this->assertFileExists($paginationDir . '/jump.odo.php');
+        $this->assertFileExists($paginationDir . '/number.odo.php');
+        $this->assertContains('All pagination views already exist.', $command->capturedInfos);
+    }
+
+    public function testKeyGenerateCommandUpdatesExistingEnvFile(): void
+    {
+        $command = new class extends KeyGenerateCommand
+        {
+            use InteractsWithFakeCommandIO;
+        };
+
+        $envFile = Env::path('.env');
+        file_put_contents($envFile, "APP_NAME=Doppar\nAPP_KEY=base64:old-key\n");
+
+        $result = $command->handle();
+        $contents = (string) file_get_contents($envFile);
+
+        $this->assertSame(0, $result);
+        $this->assertMatchesRegularExpression('/APP_KEY=base64:[A-Za-z0-9+\/=]+/', $contents);
+        $this->assertContains('Application key set successfully', $command->capturedSuccesses);
+    }
+
+    public function testDeleteCronLockFileRemovesNestedScheduleArtifacts(): void
+    {
+        $command = new class extends DeleteCronLockFile
+        {
+            use InteractsWithFakeCommandIO;
+        };
+
+        $nestedFile = Env::path('storage/schedule/nested/demo.lock');
+        mkdir(dirname($nestedFile), 0755, true);
+        file_put_contents($nestedFile, 'lock');
+
+        $result = $command->handle();
+
+        $this->assertSame(0, $result);
+        $this->assertDirectoryExists(Env::path('storage/schedule'));
+        $this->assertFileDoesNotExist($nestedFile);
+    }
+
+    public function testStorageUnlinkCommandRemovesExistingSymlink(): void
+    {
+        if (!function_exists('symlink')) {
+            $this->markTestSkipped('symlink is not available in this environment.');
+        }
+
+        $command = new class extends StorageUnlinkCommand
+        {
+            use InteractsWithFakeCommandIO;
+        };
+
+        $target = Env::path('storage/app/public');
+        $link = Env::path('public/storage');
+
+        mkdir($target, 0755, true);
+        mkdir(dirname($link), 0755, true);
+        symlink($target, $link);
+
+        $result = $command->handle();
+
+        $this->assertSame(0, $result);
+        $this->assertFalse(is_link($link));
+        $this->assertContains('Symbolic link removed successfully', $command->capturedSuccesses);
+    }
+
+    public function testSetCreatablePropertyCommandFiltersFrameworkColumns(): void
+    {
+        $command = new class extends SetCreatablePropertyCommand
+        {
+            use InteractsWithFakeCommandIO;
+        };
+
+        $db = Env::app('db');
+        $db->columns['products'] = ['id', 'name', 'price', 'created_at', 'updated_at'];
+        $command->fakeArguments['table'] = 'products';
+
+        $result = $command->handle();
+
+        $this->assertSame(0, $result);
+        $this->assertSame(['protected $creatable = ["name","price"]'], $command->capturedInfos);
+    }
+
+    public function testViewClearCommandRemovesCompiledViewFiles(): void
+    {
+        $command = new class extends ViewClearCommand
+        {
+            use InteractsWithFakeCommandIO;
+        };
+
+        $viewCacheDir = Env::path('storage/framework/views');
+        mkdir($viewCacheDir, 0755, true);
+        file_put_contents($viewCacheDir . '/one.php', 'a');
+        file_put_contents($viewCacheDir . '/two.php', 'b');
+
+        $result = $command->handle();
+
+        $this->assertSame(0, $result);
+        $this->assertFileDoesNotExist($viewCacheDir . '/one.php');
+        $this->assertFileDoesNotExist($viewCacheDir . '/two.php');
+        $this->assertContains('Compiled views cleared successfully', $command->capturedSuccesses);
+    }
+
+    public function testViewCacheCommandDiscoversViewsAndCreatesCacheDirectory(): void
+    {
+        $command = new class extends ViewCacheCommand
+        {
+            use InteractsWithFakeCommandIO;
+        };
+
+        $viewDir = Env::path('resources/views/admin');
+        mkdir($viewDir, 0755, true);
+        file_put_contents($viewDir . '/dashboard.odo.php', '<h1>Dashboard</h1>');
+
+        $cacheDir = Env::path('storage/framework/views');
+        $this->invokeMethod($command, 'ensureDirectoriesExist', [Env::path('resources/views'), $cacheDir]);
+        $files = $this->invokeMethod($command, 'getAllViewFiles', [Env::path('resources/views')]);
+
+        $this->assertDirectoryExists($cacheDir);
+        $this->assertSame([realpath($viewDir . '/dashboard.odo.php')], $files);
+    }
+
+    public function testCronDaemonCommandFormatsRuntimeDisplayHelpers(): void
+    {
+        $command = new class extends CronDaemonCommand
+        {
+            use InteractsWithFakeCommandIO;
+        };
+
+        $this->assertSame('1h 1m 1s', $this->invokeMethod($command, 'formatUptime', [3661]));
+        $this->assertSame('2 KB', $this->invokeMethod($command, 'formatBytes', [2048]));
+        $this->assertSame(1, $this->invokeMethod($command, 'invalidAction', ['pause']));
+        $this->assertContains('Invalid action: pause', $command->capturedErrors);
+    }
+
+    public function testCronFinishCommandReleasesMatchingLockAndReportsFailure(): void
+    {
+        $command = new class extends CronFinishCommand
+        {
+            use InteractsWithFakeCommandIO;
+        };
+
+        $hash = md5('finish-test');
+        $pidFile = sys_get_temp_dir() . "/doppar_cron_lock_{$hash}.pid";
+        $lockFile = sys_get_temp_dir() . "/doppar_cron_lock_{$hash}";
+
+        file_put_contents($pidFile, json_encode(['finish_id' => 'abc-123']));
+        file_put_contents($lockFile, 'locked');
+
+        $command->fakeArguments = [
+            'finish_id' => 'abc-123',
+            'release_lock' => '1',
+            'exit_code' => '7',
+        ];
+
+        try {
+            $result = $command->handle();
+        } finally {
+            @unlink($pidFile);
+            @unlink($lockFile);
+        }
+
+        $this->assertSame(7, $result);
+        $this->assertContains('Cron task failed with exit code: 7', Env::$errors);
+        $this->assertFileDoesNotExist($pidFile);
+        $this->assertFileDoesNotExist($lockFile);
+    }
+
+    public function testServerStartCommandValidatesPortsThroughPrivateHelper(): void
+    {
+        $command = new class extends ServerStartCommand
+        {
+            use InteractsWithFakeCommandIO;
+        };
+
+        $this->assertFalse($this->invokeMethod($command, 'isPortOk', [null]));
+        $this->assertTrue($this->invokeMethod($command, 'isPortOk', [8080]));
+    }
+
+    public function testServerStopCommandRejectsInvalidPort(): void
+    {
+        $command = new class extends ServerStopCommand
+        {
+            use InteractsWithFakeCommandIO;
+        };
+
+        $command->fakeArguments['port'] = 'invalid-port';
+
+        $result = $command->handle();
+
+        $this->assertSame(1, $result);
+        $this->assertContains('Port must be a valid integer', $command->capturedErrors);
+    }
+
+    public function testUnitTestCommandBuildsExpectedPhpUnitCommandAndFormatsSummary(): void
+    {
+        $command = new class extends UnitTestCommand
+        {
+            use InteractsWithFakeCommandIO;
+        };
+
+        $phpUnitCommand = $this->invokeMethod($command, 'buildPHPUnitCommand', [
+            'tests/Unit/ExampleTest.php',
+            'it_works',
+            true,
+        ]);
+
+        $this->invokeMethod($command, 'displaySummary', [
+            'OK (3 tests, 5 assertions)',
+            0.123,
+            0,
+        ]);
+
+        $this->assertSame([
+            Env::path('vendor/bin/phpunit'),
+            Env::path('tests/Unit/ExampleTest.php'),
+            '--filter',
+            'it_works',
+            '--testdox',
+            '--disallow-test-output',
+            '--colors=never',
+        ], $phpUnitCommand);
+        $this->assertContains('Test suite completed successfully with 5 assertion(s)', $command->capturedSuccesses);
+    }
+
+    public function testVendorPublishCommandCopiesFilesAndSkipsExistingTargets(): void
+    {
+        $command = new class extends VendorPublishCommand
+        {
+            use InteractsWithFakeCommandIO;
+        };
+
+        $sourceDir = Env::path('vendor/package/config');
+        $targetDir = Env::path('published/config');
+        $sourceFile = $sourceDir . '/demo.php';
+        $targetFile = $targetDir . '/demo.php';
+
+        mkdir($sourceDir, 0755, true);
+        file_put_contents($sourceFile, '<?php return [];');
+
+        $this->invokeMethod($command, 'publishDirectory', [$sourceDir, $targetDir, false]);
+        $this->invokeMethod($command, 'publishFile', [$sourceFile, $targetFile, false]);
+
+        $this->assertFileExists($targetFile);
+        $this->assertContains('Skipping: File already exists at ' . $targetFile, $command->capturedWarnings);
+    }
+
+    private function invokeMethod(object $instance, string $method, array $arguments = []): mixed
+    {
+        $reflection = new \ReflectionMethod($instance, $method);
+
+        return $reflection->invokeArgs($instance, $arguments);
+    }
+}

--- a/tests/Console/CommandSignatureCoverageTest.php
+++ b/tests/Console/CommandSignatureCoverageTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Tests\Unit\Console;
+
+require_once __DIR__ . '/Support/CommandTestEnvironment.php';
+
+use Phaseolies\Application;
+use Phaseolies\Console\Commands\VendorPublishCommand;
+use Phaseolies\Database\Migration\MigrationCreator;
+use Phaseolies\Database\Migration\Migrator;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Tests\Unit\Console\Support\CommandTestEnvironment as Env;
+
+#[AllowMockObjectsWithoutExpectations]
+class CommandSignatureCoverageTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Env::reset();
+        Env::$appInstance = $this->createMock(Application::class);
+        Env::bind('migrator', $this->createMock(Migrator::class));
+        Env::bind('config', new class
+        {
+            public int $clearCount = 0;
+
+            public function clearCache(): void
+            {
+                $this->clearCount++;
+            }
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Env::cleanup();
+
+        parent::tearDown();
+    }
+
+    #[DataProvider('commandClassProvider')]
+    public function testEveryCommandClassHasParsedSignatureAndDescription(string $className): void
+    {
+        $command = $this->instantiateCommand($className);
+        $reflection = new \ReflectionClass($className);
+
+        $signature = $this->normalizeWhitespace($this->readProtectedProperty($reflection, $command, 'name'));
+        $description = trim((string) $this->readProtectedProperty($reflection, $command, 'description'));
+
+        $this->assertNotSame('', $signature, $className . ' should define a command signature');
+        $this->assertNotSame('', $description, $className . ' should define a description');
+        $this->assertTrue($reflection->hasMethod('handle'), $className . ' should define handle()');
+        $this->assertSame(strtok($signature, ' '), $command->getName());
+
+        preg_match_all('/{([^}]+)}/', $signature, $matches);
+        $tokens = $matches[1];
+
+        foreach ($tokens as $token) {
+            $token = trim($token);
+
+            if (str_contains($token, ':')) {
+                [$token] = explode(':', $token, 2);
+                $token = trim($token);
+            }
+
+            if (preg_match('/^(?:-([a-zA-Z])\|)?--([\w-]+)(?:=(.*))?$/', $token, $optionMatches)) {
+                $option = $command->getDefinition()->getOption($optionMatches[2]);
+
+                $this->assertInstanceOf(InputOption::class, $option);
+                if (isset($optionMatches[1]) && $optionMatches[1] !== '') {
+                    $this->assertSame($optionMatches[1], $option->getShortcut());
+                } else {
+                    $this->assertEmpty($option->getShortcut());
+                }
+                $expectsValue = str_contains($token, '=');
+                $this->assertSame($expectsValue, $option->acceptValue(), $className . ' option ' . $optionMatches[2]);
+                continue;
+            }
+
+            if (preg_match('/^(\w+)(\?)?$/', $token, $argumentMatches)) {
+                $argument = $command->getDefinition()->getArgument($argumentMatches[1]);
+
+                $this->assertInstanceOf(InputArgument::class, $argument);
+                $expectedRequired = !isset($argumentMatches[2]) || $argumentMatches[2] !== '?';
+                $this->assertSame($expectedRequired, $argument->isRequired(), $className . ' argument ' . $argumentMatches[1]);
+            }
+        }
+    }
+
+    public static function commandClassProvider(): array
+    {
+        $classes = [];
+        $root = realpath(__DIR__ . '/../../src/Phaseolies/Console/Commands');
+
+        foreach (self::commandFiles($root ?: '') as $file) {
+            $relative = substr($file, strlen($root) + 1);
+            $class = 'Phaseolies\\Console\\Commands\\' . str_replace(
+                ['/', '.php'],
+                ['\\', ''],
+                $relative
+            );
+
+            $classes[$class] = [$class];
+        }
+
+        ksort($classes);
+
+        return $classes;
+    }
+
+    private static function commandFiles(string $root): array
+    {
+        $files = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $item) {
+            if (!$item->isFile() || $item->getExtension() !== 'php') {
+                continue;
+            }
+
+            $files[] = str_replace('\\', '/', $item->getPathname());
+        }
+
+        sort($files);
+
+        return $files;
+    }
+
+    private function instantiateCommand(string $className): object
+    {
+        if ($className === VendorPublishCommand::class) {
+            Env::$appInstance = $this->createMock(Application::class);
+        }
+
+        $reflection = new \ReflectionClass($className);
+        $constructor = $reflection->getConstructor();
+
+        if (
+            $constructor === null
+            || $constructor->getDeclaringClass()->getName() !== $className
+            || $constructor->getNumberOfParameters() === 0
+        ) {
+            return $reflection->newInstance();
+        }
+
+        $dependencies = [];
+
+        foreach ($constructor->getParameters() as $parameter) {
+            $typeName = $parameter->getType()?->getName();
+
+            $dependencies[] = match ($typeName) {
+                MigrationCreator::class => $this->createMock(MigrationCreator::class),
+                default => throw new \RuntimeException('Unhandled constructor dependency for ' . $className . ': ' . $typeName),
+            };
+        }
+
+        return $reflection->newInstanceArgs($dependencies);
+    }
+
+    private function readProtectedProperty(\ReflectionClass $reflection, object $instance, string $property): mixed
+    {
+        $prop = $reflection->getProperty($property);
+
+        return $prop->getValue($instance);
+    }
+
+    private function normalizeWhitespace(string $value): string
+    {
+        return trim((string) preg_replace('/\s+/', ' ', $value));
+    }
+}

--- a/tests/Console/MigrateTemporalCommandTest.php
+++ b/tests/Console/MigrateTemporalCommandTest.php
@@ -1,9 +1,11 @@
 <?php
 
 namespace Phaseolies\Console\Commands\Migrations {
-    function config($key = null, $default = null)
-    {
-        return $key === 'database.default' ? 'default_connection' : $default;
+    if (!function_exists(__NAMESPACE__ . '\config')) {
+        function config($key = null, $default = null)
+        {
+            return $key === 'database.default' ? 'default_connection' : $default;
+        }
     }
 }
 
@@ -17,6 +19,15 @@ use Tests\Support\Model\MockTemporalRecord;
 
 class MigrateTemporalCommandTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (class_exists(\Tests\Unit\Console\Support\CommandTestEnvironment::class)) {
+            \Tests\Unit\Console\Support\CommandTestEnvironment::$config['database.default'] = 'default_connection';
+        }
+    }
+
     public function testResolveConnectionForModelPrefersModelConnectionWhenNoOverride(): void
     {
         $command = new MigrateTemporalCommand();

--- a/tests/Console/Support/CommandTestEnvironment.php
+++ b/tests/Console/Support/CommandTestEnvironment.php
@@ -1,0 +1,385 @@
+<?php
+
+namespace Tests\Unit\Console\Support {
+
+final class CommandTestEnvironment
+{
+    public static string $root;
+
+    public static array $config = [];
+
+    public static array $appBindings = [];
+
+    public static ?object $appInstance = null;
+
+    public static array $errors = [];
+
+    public static function reset(): void
+    {
+        self::$root = sys_get_temp_dir() . '/doppar-command-tests-' . bin2hex(random_bytes(5));
+        self::$config = [
+            'app.name' => 'Doppar Demo',
+            'app.timezone' => 'UTC',
+            'database.default' => 'testing',
+        ];
+        self::$appBindings = [];
+        self::$appInstance = null;
+        self::$errors = [];
+
+        if (!is_dir(self::$root)) {
+            mkdir(self::$root, 0755, true);
+        }
+    }
+
+    public static function cleanup(): void
+    {
+        if (!isset(self::$root) || !is_dir(self::$root)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator(self::$root, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($iterator as $item) {
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+                continue;
+            }
+
+            unlink($item->getPathname());
+        }
+
+        rmdir(self::$root);
+    }
+
+    public static function path(string $path = ''): string
+    {
+        $base = rtrim(self::$root, '/');
+
+        if ($path === '') {
+            return $base;
+        }
+
+        return $base . '/' . ltrim($path, '/');
+    }
+
+    public static function config(?string $key = null, mixed $default = null): mixed
+    {
+        if ($key === null) {
+            return self::$config;
+        }
+
+        return self::$config[$key] ?? $default;
+    }
+
+    public static function app(?string $key = null): mixed
+    {
+        if ($key === null) {
+            return self::$appInstance;
+        }
+
+        return self::$appBindings[$key] ?? null;
+    }
+
+    public static function bind(string $key, mixed $value): void
+    {
+        self::$appBindings[$key] = $value;
+    }
+
+    public static function recordError(string $message): void
+    {
+        self::$errors[] = $message;
+    }
+}
+
+final class FakeStringHelper
+{
+    public function suffixAppend(string $value, string $suffix): string
+    {
+        return str_ends_with($value, $suffix) ? $value : $value . $suffix;
+    }
+
+    public function removeSuffix(string $value, string $suffix): string
+    {
+        if (!str_ends_with($value, $suffix)) {
+            return $value;
+        }
+
+        return substr($value, 0, -strlen($suffix));
+    }
+
+    public function snake(string $value): string
+    {
+        $value = preg_replace('/(?<!^)[A-Z]/', '_$0', $value) ?? $value;
+
+        return strtolower($value);
+    }
+}
+
+final class FakeSessionStore
+{
+    public int $flushCount = 0;
+
+    public function flush(): void
+    {
+        $this->flushCount++;
+    }
+}
+
+final class FakeDatabaseInspector
+{
+    public array $columns = [];
+
+    public function getTableColumns(string $table): array
+    {
+        return $this->columns[$table] ?? [];
+    }
+}
+
+trait InteractsWithFakeCommandIO
+{
+    public array $fakeArguments = [];
+
+    public array $fakeOptions = [];
+
+    public array $capturedLines = [];
+
+    public array $capturedInfos = [];
+
+    public array $capturedErrors = [];
+
+    public array $capturedWarnings = [];
+
+    public array $capturedSuccesses = [];
+
+    protected function argument($key = null)
+    {
+        if ($key === null) {
+            return $this->fakeArguments;
+        }
+
+        return $this->fakeArguments[$key] ?? null;
+    }
+
+    protected function option($key = null)
+    {
+        if ($key === null) {
+            return $this->fakeOptions;
+        }
+
+        return $this->fakeOptions[$key] ?? null;
+    }
+
+    protected function info($string): void
+    {
+        $this->capturedInfos[] = (string) $string;
+    }
+
+    protected function error($string): void
+    {
+        $this->capturedErrors[] = (string) $string;
+    }
+
+    protected function line(string $string, ?string $style = null): void
+    {
+        $this->capturedLines[] = [$string, $style];
+    }
+
+    protected function newLine($count = 1): void
+    {
+    }
+
+    protected function displaySuccess(string $message): void
+    {
+        $this->capturedSuccesses[] = $message;
+    }
+
+    protected function displayError(string $message): void
+    {
+        $this->capturedErrors[] = $message;
+    }
+
+    protected function displayWarning(string $message): void
+    {
+        $this->capturedWarnings[] = $message;
+    }
+
+    protected function displayInfo(string $message): void
+    {
+        $this->capturedInfos[] = $message;
+    }
+
+    protected function executeWithTiming(callable $callback): int
+    {
+        $result = $callback();
+
+        return is_int($result) ? $result : 0;
+    }
+
+    protected function withTiming(callable $operation, ?string $successMessage = null): int
+    {
+        $result = $operation();
+
+        if ($successMessage !== null) {
+            $this->displaySuccess($successMessage);
+        }
+
+        return is_int($result) ? $result : 0;
+    }
+}
+}
+
+namespace Phaseolies\Console\Commands {
+
+    use Tests\Unit\Console\Support\CommandTestEnvironment;
+    use Tests\Unit\Console\Support\FakeDatabaseInspector;
+    use Tests\Unit\Console\Support\FakeSessionStore;
+    use Tests\Unit\Console\Support\FakeStringHelper;
+
+    if (!function_exists(__NAMESPACE__ . '\base_path')) {
+        function base_path(string $path = ''): string
+        {
+            return CommandTestEnvironment::path($path);
+        }
+    }
+
+    if (!function_exists(__NAMESPACE__ . '\storage_path')) {
+        function storage_path(string $path = ''): string
+        {
+            return CommandTestEnvironment::path('storage/' . ltrim($path, '/'));
+        }
+    }
+
+    if (!function_exists(__NAMESPACE__ . '\resource_path')) {
+        function resource_path(string $path = ''): string
+        {
+            return CommandTestEnvironment::path('resources/' . ltrim($path, '/'));
+        }
+    }
+
+    if (!function_exists(__NAMESPACE__ . '\public_path')) {
+        function public_path(string $path = ''): string
+        {
+            return CommandTestEnvironment::path('public/' . ltrim($path, '/'));
+        }
+    }
+
+    if (!function_exists(__NAMESPACE__ . '\config')) {
+        function config(?string $key = null, mixed $default = null): mixed
+        {
+            return CommandTestEnvironment::config($key, $default);
+        }
+    }
+
+    if (!function_exists(__NAMESPACE__ . '\app')) {
+        function app(?string $key = null): mixed
+        {
+            return CommandTestEnvironment::app($key);
+        }
+    }
+
+    if (!function_exists(__NAMESPACE__ . '\session')) {
+        function session(): FakeSessionStore
+        {
+            $session = CommandTestEnvironment::app('session');
+
+            if ($session instanceof FakeSessionStore) {
+                return $session;
+            }
+
+            $session = new FakeSessionStore();
+            CommandTestEnvironment::bind('session', $session);
+
+            return $session;
+        }
+    }
+
+    if (!function_exists(__NAMESPACE__ . '\db')) {
+        function db(): FakeDatabaseInspector
+        {
+            $db = CommandTestEnvironment::app('db');
+
+            if ($db instanceof FakeDatabaseInspector) {
+                return $db;
+            }
+
+            $db = new FakeDatabaseInspector();
+            CommandTestEnvironment::bind('db', $db);
+
+            return $db;
+        }
+    }
+
+    if (!function_exists(__NAMESPACE__ . '\str')) {
+        function str(): FakeStringHelper
+        {
+            return new FakeStringHelper();
+        }
+    }
+
+    if (!function_exists(__NAMESPACE__ . '\error')) {
+        function error(string $message): void
+        {
+            CommandTestEnvironment::recordError($message);
+        }
+    }
+}
+
+namespace Phaseolies\Console\Commands\Migrations {
+
+    use Tests\Unit\Console\Support\CommandTestEnvironment;
+
+    if (!function_exists(__NAMESPACE__ . '\base_path')) {
+        function base_path(string $path = ''): string
+        {
+            return CommandTestEnvironment::path($path);
+        }
+    }
+
+    if (!function_exists(__NAMESPACE__ . '\config')) {
+        function config(?string $key = null, mixed $default = null): mixed
+        {
+            return CommandTestEnvironment::config($key, $default);
+        }
+    }
+
+    if (!function_exists(__NAMESPACE__ . '\app')) {
+        function app(?string $key = null): mixed
+        {
+            return CommandTestEnvironment::app($key);
+        }
+    }
+}
+
+namespace Phaseolies\Console\Commands\Cron {
+
+    use Tests\Unit\Console\Support\CommandTestEnvironment;
+
+    if (!function_exists(__NAMESPACE__ . '\storage_path')) {
+        function storage_path(string $path = ''): string
+        {
+            return CommandTestEnvironment::path('storage/' . ltrim($path, '/'));
+        }
+    }
+
+    if (!function_exists(__NAMESPACE__ . '\error')) {
+        function error(string $message): void
+        {
+            CommandTestEnvironment::recordError($message);
+        }
+    }
+}
+
+namespace Phaseolies\Console\Commands\Tests {
+
+    use Tests\Unit\Console\Support\CommandTestEnvironment;
+
+    if (!function_exists(__NAMESPACE__ . '\base_path')) {
+        function base_path(string $path = ''): string
+        {
+            return CommandTestEnvironment::path($path);
+        }
+    }
+}


### PR DESCRIPTION
This PR expands unit coverage for Doppar console commands by adding shared test infrastructure, automatic signature coverage for all command classes, and focused behavior tests for previously untested command flows.