### PR TITLE
Fix: storage:link cross-platform support

### DIFF
--- a/src/Phaseolies/Console/Commands/StorageLinkCommand.php
+++ b/src/Phaseolies/Console/Commands/StorageLinkCommand.php
@@ -3,6 +3,8 @@
 namespace Phaseolies\Console\Commands;
 
 use Phaseolies\Console\Schedule\Command;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 use Symfony\Component\Process\Process;
 use RuntimeException;
 
@@ -29,7 +31,7 @@ class StorageLinkCommand extends Command
      */
     public function handle(): int
     {
-        return $this->executeWithTiming(function() {
+        return $this->executeWithTiming(function () {
             $links = config('filesystem.links');
 
             if (empty($links)) {
@@ -46,7 +48,11 @@ class StorageLinkCommand extends Command
     }
 
     /**
-     * Process a single symbolic link.
+     * Process a single symbolic link
+     *
+     * @param string $link
+     * @param string $target
+     * @return void
      */
     protected function processLink(string $link, string $target): void
     {
@@ -69,32 +75,133 @@ class StorageLinkCommand extends Command
     }
 
     /**
-     * Remove existing file/directory at path.
+     * Remove existing file/directory at path
+     *
+     * @param string $path
+     * @return void
      */
     protected function removeExistingPath(string $path): void
     {
-        $process = Process::fromShellCommandline(sprintf('rm -rf %s', escapeshellarg($path)));
-        $process->run();
+        if (is_link($path)) {
+            if (@unlink($path) || (is_dir($path) && @rmdir($path))) {
+                return;
+            }
 
-        if (!$process->isSuccessful()) {
-            throw new RuntimeException('Failed to remove: ' . $process->getErrorOutput());
+            throw new RuntimeException('Failed to remove existing link: ' . $path);
+        }
+
+        if (is_file($path)) {
+            if (@unlink($path)) {
+                return;
+            }
+
+            throw new RuntimeException('Failed to remove file: ' . $path);
+        }
+
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($iterator as $item) {
+            $itemPath = $item->getPathname();
+
+            if ($item->isDir() && !$item->isLink()) {
+                if (!@rmdir($itemPath)) {
+                    throw new RuntimeException('Failed to remove directory: ' . $itemPath);
+                }
+
+                continue;
+            }
+
+            if (!@unlink($itemPath)) {
+                throw new RuntimeException('Failed to remove file: ' . $itemPath);
+            }
+        }
+
+        if (!@rmdir($path)) {
+            throw new RuntimeException('Failed to remove directory: ' . $path);
         }
     }
 
     /**
-     * Create a new symbolic link.
+     * Create a new symbolic link
+     *
+     * @param string $link
+     * @param string $target
+     * @return void
      */
     protected function createSymlink(string $link, string $target): void
     {
-        $process = Process::fromShellCommandline(
-            sprintf('ln -s %s %s', escapeshellarg($target), escapeshellarg($link))
-        );
+        $directory = dirname($link);
+        if (!is_dir($directory) && !@mkdir($directory, 0755, true) && !is_dir($directory)) {
+            throw new RuntimeException('Failed to create link directory: ' . $directory);
+        }
+
+        if ($this->createNativeSymlink($target, $link) || $this->createWindowsFallbackLink($target, $link)) {
+            $this->line('<fg=green>✓ Created symbolic link:</> <fg=white>' . $link . ' → ' . $target . '</>');
+            return;
+        }
+
+        throw new RuntimeException('Failed to create symbolic link for: ' . $link);
+    }
+
+    /**
+     * Attempt to create a symlink using PHP's built-in support
+     *
+     * @param string $target
+     * @param string $link
+     * @return bool
+     */
+    protected function createNativeSymlink(string $target, string $link): bool
+    {
+        return function_exists('symlink') && @symlink($target, $link);
+    }
+
+    /**
+     * Attempt a Windows-specific fallback when native symlink creation is unavailable
+     *
+     * @param string $target
+     * @param string $link
+     * @return bool
+     */
+    protected function createWindowsFallbackLink(string $target, string $link): bool
+    {
+        if (!$this->isWindows()) {
+            return false;
+        }
+
+        $process = new Process($this->buildWindowsLinkCommand($target, $link));
         $process->run();
 
-        if ($process->isSuccessful()) {
-            $this->line('<fg=green>✓ Created symbolic link:</> <fg=white>' . $link . ' → ' . $target . '</>');
-        } else {
-            throw new RuntimeException('Failed to create symlink: ' . $process->getErrorOutput());
+        return $process->isSuccessful();
+    }
+
+    /**
+     * Build the Windows command used to create a link or junction.
+     *
+     * @return array<int, string>
+     */
+    protected function buildWindowsLinkCommand(string $target, string $link): array
+    {
+        if (is_dir($target)) {
+            return ['cmd', '/c', 'mklink', '/J', $link, $target];
         }
+
+        return ['cmd', '/c', 'mklink', $link, $target];
+    }
+
+    /**
+     * Determine whether the current operating system is Windows.
+     *
+     * @return bool
+     */
+    protected function isWindows(): bool
+    {
+        return stripos(PHP_OS_FAMILY, 'Windows') !== false;
     }
 }

--- a/tests/Console/CommandBehaviorCoverageTest.php
+++ b/tests/Console/CommandBehaviorCoverageTest.php
@@ -28,6 +28,7 @@ use Phaseolies\Console\Commands\PaginationPublishCommand;
 use Phaseolies\Console\Commands\Server\ServerStartCommand;
 use Phaseolies\Console\Commands\Server\ServerStopCommand;
 use Phaseolies\Console\Commands\SetCreatablePropertyCommand;
+use Phaseolies\Console\Commands\StorageLinkCommand;
 use Phaseolies\Console\Commands\StorageUnlinkCommand;
 use Phaseolies\Console\Commands\Tests\UnitTestCommand;
 use Phaseolies\Console\Commands\VendorPublishCommand;
@@ -346,6 +347,55 @@ class CommandBehaviorCoverageTest extends TestCase
         $this->assertSame(0, $result);
         $this->assertFalse(is_link($link));
         $this->assertContains('Symbolic link removed successfully', $command->capturedSuccesses);
+    }
+
+    public function testStorageLinkCommandCreatesConfiguredPublicLink(): void
+    {
+        if (!function_exists('symlink')) {
+            $this->markTestSkipped('symlink is not available in this environment.');
+        }
+
+        $command = new class extends StorageLinkCommand
+        {
+            use InteractsWithFakeCommandIO;
+        };
+
+        $target = Env::path('storage/app/public');
+        $link = Env::path('public/storage');
+        $marker = $target . '/avatar.txt';
+
+        Env::$config['filesystem.links'] = [$link => $target];
+
+        mkdir($target, 0755, true);
+        mkdir(dirname($link), 0755, true);
+        file_put_contents($marker, 'ok');
+
+        $result = $command->handle();
+
+        $this->assertSame(0, $result);
+        $this->assertTrue(is_link($link) || is_dir($link));
+        $this->assertFileExists($link . '/avatar.txt');
+    }
+
+    public function testStorageLinkCommandBuildsWindowsJunctionCommandForDirectories(): void
+    {
+        $command = new class extends StorageLinkCommand
+        {
+            public function exposeBuildWindowsLinkCommand(string $target, string $link): array
+            {
+                return $this->buildWindowsLinkCommand($target, $link);
+            }
+        };
+
+        $target = Env::path('storage/app/public');
+        $link = Env::path('public/storage');
+
+        mkdir($target, 0755, true);
+
+        $this->assertSame(
+            ['cmd', '/c', 'mklink', '/J', $link, $target],
+            $command->exposeBuildWindowsLinkCommand($target, $link)
+        );
     }
 
     public function testStorageUnlinkCommandFallsBackToRemovingDirectoryLink(): void

--- a/tests/Console/Support/CommandTestEnvironment.php
+++ b/tests/Console/Support/CommandTestEnvironment.php
@@ -43,6 +43,11 @@ final class CommandTestEnvironment
         );
 
         foreach ($iterator as $item) {
+            if ($item->isLink()) {
+                unlink($item->getPathname());
+                continue;
+            }
+
             if ($item->isDir()) {
                 rmdir($item->getPathname());
                 continue;

--- a/tests/Storage/FileUploadTest.php
+++ b/tests/Storage/FileUploadTest.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace Phaseolies\Support {
+    function move_uploaded_file(string $from, string $to): bool
+    {
+        return \Tests\Unit\Storage\Support\UploadTestHooks::moveUploadedFile($from, $to);
+    }
+}
+
+namespace Phaseolies\Support\Storage {
+    function config(string|array $key, mixed $default = null): mixed
+    {
+        return \Tests\Unit\Storage\Support\UploadTestConfig::get($key, $default);
+    }
+}
+
+namespace Tests\Unit\Storage\Support {
+    final class UploadTestConfig
+    {
+        public static array $values = [];
+
+        public static function reset(): void
+        {
+            self::$values = [];
+        }
+
+        public static function setMany(array $values): void
+        {
+            foreach ($values as $key => $value) {
+                self::set($key, $value);
+            }
+        }
+
+        public static function set(string $key, mixed $value): void
+        {
+            $segments = explode('.', $key);
+            $data = &self::$values;
+
+            foreach ($segments as $segment) {
+                if (!isset($data[$segment]) || !is_array($data[$segment])) {
+                    $data[$segment] = [];
+                }
+
+                $data = &$data[$segment];
+            }
+
+            $data = $value;
+        }
+
+        public static function get(string|array $key, mixed $default = null): mixed
+        {
+            if (is_array($key)) {
+                self::setMany($key);
+                return null;
+            }
+
+            $segments = explode('.', $key);
+            $data = self::$values;
+
+            foreach ($segments as $segment) {
+                if (!is_array($data) || !array_key_exists($segment, $data)) {
+                    return $default;
+                }
+
+                $data = $data[$segment];
+            }
+
+            return $data;
+        }
+    }
+
+    final class UploadTestHooks
+    {
+        public static bool $shouldSucceed = true;
+
+        /**
+         * @var array<int, array{from: string, to: string}>
+         */
+        public static array $calls = [];
+
+        public static function reset(): void
+        {
+            self::$shouldSucceed = true;
+            self::$calls = [];
+        }
+
+        public static function moveUploadedFile(string $from, string $to): bool
+        {
+            self::$calls[] = ['from' => $from, 'to' => $to];
+
+            if (!self::$shouldSucceed || !is_file($from)) {
+                return false;
+            }
+
+            $directory = dirname($to);
+            if (!is_dir($directory)) {
+                mkdir($directory, 0755, true);
+            }
+
+            $copied = copy($from, $to);
+            if ($copied) {
+                unlink($from);
+            }
+
+            return $copied;
+        }
+    }
+}
+
+namespace Tests\Unit\Storage {
+
+    use Phaseolies\DI\Container;
+    use Phaseolies\Support\File;
+    use Phaseolies\Support\Facades\Storage;
+    use Phaseolies\Support\Storage\LocalFileSystem;
+    use Phaseolies\Support\Storage\PublicFileSystem;
+    use Phaseolies\Support\Storage\StorageFileService;
+    use PHPUnit\Framework\TestCase;
+    use Tests\Unit\Storage\Support\UploadTestConfig;
+    use Tests\Unit\Storage\Support\UploadTestHooks;
+
+    class FileUploadTest extends TestCase
+    {
+        private string $tmpDir;
+        private string $localRoot;
+        private string $publicRoot;
+        private Container $container;
+
+        protected function setUp(): void
+        {
+            parent::setUp();
+
+            $this->tmpDir = sys_get_temp_dir() . '/doppar_upload_test_' . uniqid();
+            $this->localRoot = $this->tmpDir . '/storage/app';
+            $this->publicRoot = $this->tmpDir . '/storage/app/public';
+
+            mkdir($this->localRoot, 0755, true);
+            mkdir($this->publicRoot, 0755, true);
+
+            UploadTestConfig::reset();
+            UploadTestConfig::setMany([
+                'filesystem.disks.local.root' => $this->localRoot,
+                'filesystem.disks.public.root' => $this->publicRoot,
+            ]);
+
+            UploadTestHooks::reset();
+
+            $this->container = new Container();
+            $this->container->bind('storage', fn() => new StorageFileService(), true);
+            Container::setInstance($this->container);
+            Storage::setFacadeApplication(null);
+        }
+
+        protected function tearDown(): void
+        {
+            UploadTestHooks::reset();
+            UploadTestConfig::reset();
+
+            $this->container->flush();
+            Container::forgetInstance();
+            Storage::setFacadeApplication(null);
+
+            $this->removeDirectory($this->tmpDir);
+
+            parent::tearDown();
+        }
+
+        public function testStorageFacadeResolvesLocalDiskAndStoresUpload(): void
+        {
+            $disk = Storage::disk('local');
+            $file = $this->makeUploadedStyleFile('invoice.txt', 'local disk content');
+
+            $this->assertInstanceOf(LocalFileSystem::class, $disk);
+            $this->assertTrue($disk->store('documents', $file, 'stored.txt'));
+            $this->assertFileExists($this->localRoot . '/documents/stored.txt');
+            $this->assertSame('local disk content', (string) file_get_contents($this->localRoot . '/documents/stored.txt'));
+        }
+
+        public function testStorageFacadeResolvesPublicDiskAndStoresUpload(): void
+        {
+            $disk = Storage::disk('public');
+            $file = $this->makeUploadedStyleFile('photo.jpg', 'public image payload', 'image/jpeg');
+
+            $this->assertInstanceOf(PublicFileSystem::class, $disk);
+            $this->assertTrue($disk->store('images', $file, 'hero.jpg'));
+            $this->assertFileExists($this->publicRoot . '/images/hero.jpg');
+            $this->assertSame('public image payload', (string) file_get_contents($this->publicRoot . '/images/hero.jpg'));
+        }
+
+        public function testFileStoreAsStoresUploadToLocalDiskAndReturnsRelativePath(): void
+        {
+            $file = $this->makeUploadedStyleFile('contract.pdf', 'pdf payload', 'application/pdf');
+
+            $storedPath = $file->storeAs('contracts', 'signed.pdf', 'local');
+
+            $this->assertSame('contracts/signed.pdf', $storedPath);
+            $this->assertFileExists($this->localRoot . '/contracts/signed.pdf');
+            $this->assertSame('pdf payload', (string) file_get_contents($this->localRoot . '/contracts/signed.pdf'));
+            $this->assertCount(1, UploadTestHooks::$calls);
+        }
+
+        public function testFileStoreDefaultsToPublicDiskAndGeneratesUniqueName(): void
+        {
+            $file = $this->makeUploadedStyleFile('avatar.png', 'avatar payload', 'image/png');
+
+            $stored = $file->store('avatars');
+            $storedFiles = glob($this->publicRoot . '/avatars/*') ?: [];
+
+            $this->assertTrue($stored);
+            $this->assertCount(1, $storedFiles);
+            $this->assertMatchesRegularExpression('/^\d+_avatar\.png$/', basename($storedFiles[0]));
+            $this->assertSame('avatar payload', (string) file_get_contents($storedFiles[0]));
+        }
+
+        public function testFileStoreAsStopsWhenCallbackRejectsUpload(): void
+        {
+            $file = $this->makeUploadedStyleFile('archive.zip', 'zip payload', 'application/zip');
+
+            $storedPath = $file->storeAs('archives', 'blocked.zip', 'public', static fn() => false);
+
+            $this->assertFalse($storedPath);
+            $this->assertFileDoesNotExist($this->publicRoot . '/archives/blocked.zip');
+            $this->assertSame([], UploadTestHooks::$calls);
+        }
+
+        public function testFileStoreAsReturnsFalseForInvalidUpload(): void
+        {
+            $file = $this->makeUploadedStyleFile('broken.txt', 'broken payload', 'text/plain', UPLOAD_ERR_PARTIAL);
+
+            $storedPath = $file->storeAs('broken', 'broken.txt', 'local');
+
+            $this->assertFalse($storedPath);
+            $this->assertFileDoesNotExist($this->localRoot . '/broken/broken.txt');
+            $this->assertSame([], UploadTestHooks::$calls);
+        }
+
+        private function makeUploadedStyleFile(
+            string $name,
+            string $contents,
+            string $mimeType = 'text/plain',
+            int $error = UPLOAD_ERR_OK
+        ): File {
+            $directory = $this->tmpDir . '/incoming';
+            if (!is_dir($directory)) {
+                mkdir($directory, 0755, true);
+            }
+
+            $path = $directory . '/' . uniqid('', true) . '_' . $name;
+            file_put_contents($path, $contents);
+
+            return new File([
+                'name' => $name,
+                'type' => $mimeType,
+                'tmp_name' => $path,
+                'error' => $error,
+                'size' => filesize($path),
+            ]);
+        }
+
+        private function removeDirectory(string $dir): void
+        {
+            if (!is_dir($dir)) {
+                return;
+            }
+
+            foreach (scandir($dir) as $item) {
+                if ($item === '.' || $item === '..') {
+                    continue;
+                }
+
+                $path = $dir . '/' . $item;
+                if (is_dir($path) && !is_link($path)) {
+                    $this->removeDirectory($path);
+                    continue;
+                }
+
+                unlink($path);
+            }
+
+            rmdir($dir);
+        }
+    }
+}

--- a/tests/Storage/PublicFileSystemTest.php
+++ b/tests/Storage/PublicFileSystemTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Unit\Storage;
+
+use Phaseolies\Support\Storage\PublicFileSystem;
+use PHPUnit\Framework\TestCase;
+
+class PublicFileSystemTest extends TestCase
+{
+    private string $tmpDir;
+    private PublicFileSystem $fs;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/doppar_public_fs_' . uniqid();
+        mkdir($this->tmpDir, 0755, true);
+        $this->fs = new PublicFileSystem($this->tmpDir);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->tmpDir);
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        foreach (scandir($dir) as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $item;
+            is_dir($path) ? $this->removeDirectory($path) : unlink($path);
+        }
+
+        rmdir($dir);
+    }
+
+    private function createTempFile(string $name, string $content = 'test content'): string
+    {
+        $path = $this->tmpDir . '/' . $name;
+        $directory = dirname($path);
+
+        if (!is_dir($directory)) {
+            mkdir($directory, 0755, true);
+        }
+
+        file_put_contents($path, $content);
+
+        return $path;
+    }
+
+    public function testDeleteReturnsTrueAndRemovesFile(): void
+    {
+        $this->createTempFile('to_delete.txt');
+
+        $result = $this->fs->delete('to_delete.txt');
+
+        $this->assertTrue($result);
+        $this->assertFileDoesNotExist($this->tmpDir . '/to_delete.txt');
+    }
+
+    public function testDeleteMultipleFilesReturnsTrueWhenAllDeleted(): void
+    {
+        $this->createTempFile('first.txt');
+        $this->createTempFile('nested/second.txt');
+
+        $result = $this->fs->delete(['first.txt', 'nested/second.txt']);
+
+        $this->assertTrue($result);
+        $this->assertFileDoesNotExist($this->tmpDir . '/first.txt');
+        $this->assertFileDoesNotExist($this->tmpDir . '/nested/second.txt');
+    }
+
+    public function testDeleteReturnsFalseWhenFileDoesNotExist(): void
+    {
+        $result = $this->fs->delete('missing.txt');
+
+        $this->assertFalse($result);
+    }
+}


### PR DESCRIPTION
## Summary
This updates the framework storage:link command to work across Linux, macOS, and native Windows environments.

## Changes

- replaced Unix-only rm -rf cleanup with native PHP filesystem removal
- replaced Unix-only ln -s dependency with PHP symlink() support
- added a Windows fallback using mklink /J for directory targets
- added command behavior coverage for link creation and Windows junction command generation
- fixed console test cleanup so symlinked directories are unlinked correctly during teardown

## Verification

- php -l package/doppar/src/Phaseolies/Console/Commands/StorageLinkCommand.php
- php -l package/doppar/tests/Console/CommandBehaviorCoverageTest.php
- vendor/bin/phpunit package/doppar/tests/Console/CommandBehaviorCoverageTest.php
- vendor/bin/phpunit --display-warnings
