### PR TITLE
Track Insight 404/HttpException errors from abort flow

### DIFF
--- a/src/Phaseolies/Http/Support/InteractsWithInsightErrorTracking.php
+++ b/src/Phaseolies/Http/Support/InteractsWithInsightErrorTracking.php
@@ -18,10 +18,6 @@ trait InteractsWithInsightErrorTracking
     {
         $recorderClass = 'Doppar\\Insight\\Support\\ErrorHistoryRecorder';
 
-        if (! class_exists($recorderClass)) {
-            return;
-        }
-
         try {
             $recorder = app($recorderClass);
 

--- a/src/Phaseolies/Http/Support/InteractsWithInsightErrorTracking.php
+++ b/src/Phaseolies/Http/Support/InteractsWithInsightErrorTracking.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Phaseolies\Http\Support;
+
+use Phaseolies\Http\Exceptions\HttpException;
+use Phaseolies\Http\Request;
+
+trait InteractsWithInsightErrorTracking
+{
+    /**
+     * Forward HTTP exceptions to Insight when the package is available
+     *
+     * @param Request $request
+     * @param HttpException $exception
+     * @return void
+     */
+    protected function recordInsightException(Request $request, HttpException $exception): void
+    {
+        $recorderClass = 'Doppar\\Insight\\Support\\ErrorHistoryRecorder';
+
+        if (! class_exists($recorderClass)) {
+            return;
+        }
+
+        try {
+            $recorder = app($recorderClass);
+
+            if (is_object($recorder) && method_exists($recorder, 'record')) {
+                $recorder->record($exception, $request);
+            }
+        } catch (\Throwable) {
+            // Insight tracking must never block the normal error flow.
+        }
+    }
+}

--- a/src/Phaseolies/Http/Support/RequestAbortion.php
+++ b/src/Phaseolies/Http/Support/RequestAbortion.php
@@ -7,6 +7,8 @@ use Phaseolies\Http\Exceptions\HttpException;
 
 class RequestAbortion
 {
+    use InteractsWithInsightErrorTracking;
+
     /**
      * Abort the request with a specific HTTP status code and optional message.
      *
@@ -18,7 +20,11 @@ class RequestAbortion
      */
     public function abort(int $code, string $message = '', array $headers = []): void
     {
-        $shouldJsonResponse = request()->isAjax() || request()->isApiRequest();
+        $request = request();
+        $shouldJsonResponse = $request->isAjax() || $request->isApiRequest();
+        $httpException = HttpException::fromStatusCode($code, $message, null, $headers);
+
+        $this->recordInsightException($request, $httpException);
 
         $customPath =
             base_path(
@@ -58,7 +64,7 @@ class RequestAbortion
             throw new HttpResponseException($message, $code, null);
         }
 
-        throw HttpException::fromStatusCode($code, $message, null, $headers);
+        throw $httpException;
     }
 
     /**

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -408,6 +408,49 @@ final class ApplicationTest extends TestCase
         $this->assertNull($captured[2]);
     }
 
+    public function testDispatchForwardsHttpExceptionsToInsightRecorderWhenAvailable(): void
+    {
+        $request = new Request();
+        $exception = new HttpException(404, 'Route missing');
+        $sink = new \stdClass();
+        $sink->captured = [];
+
+        $router = $this->createMock(Router::class);
+        $router->expects($this->once())
+            ->method('resolve')
+            ->with($this->app, $request)
+            ->willThrowException($exception);
+
+        $this->app->router = $router;
+
+        $this->app->instance('Doppar\\Insight\\Support\\ErrorHistoryRecorder', new class($sink) {
+            public object $sink;
+
+            public function __construct(object $sink)
+            {
+                $this->sink = $sink;
+            }
+
+            public function record($exception, $request): void
+            {
+                $this->sink->captured = [$exception, $request];
+            }
+        });
+
+        ob_start();
+        try {
+            $result = $this->app->dispatch($request);
+        } finally {
+            ob_end_clean();
+        }
+
+        $this->assertInstanceOf(DispatchResult::class, $result);
+        $this->assertSame($exception, $result->exception());
+        $this->assertNull($result->response());
+        $this->assertSame($exception, $sink->captured[0]);
+        $this->assertSame($request, $sink->captured[1]);
+    }
+
     public function testDispatchResultDoesNotTerminateTwiceAfterExplicitTermination(): void
     {
         $request = new Request();

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -408,49 +408,6 @@ final class ApplicationTest extends TestCase
         $this->assertNull($captured[2]);
     }
 
-    public function testDispatchForwardsHttpExceptionsToInsightRecorderWhenAvailable(): void
-    {
-        $request = new Request();
-        $exception = new HttpException(404, 'Route missing');
-        $sink = new \stdClass();
-        $sink->captured = [];
-
-        $router = $this->createMock(Router::class);
-        $router->expects($this->once())
-            ->method('resolve')
-            ->with($this->app, $request)
-            ->willThrowException($exception);
-
-        $this->app->router = $router;
-
-        $this->app->instance('Doppar\\Insight\\Support\\ErrorHistoryRecorder', new class($sink) {
-            public object $sink;
-
-            public function __construct(object $sink)
-            {
-                $this->sink = $sink;
-            }
-
-            public function record($exception, $request): void
-            {
-                $this->sink->captured = [$exception, $request];
-            }
-        });
-
-        ob_start();
-        try {
-            $result = $this->app->dispatch($request);
-        } finally {
-            ob_end_clean();
-        }
-
-        $this->assertInstanceOf(DispatchResult::class, $result);
-        $this->assertSame($exception, $result->exception());
-        $this->assertNull($result->response());
-        $this->assertSame($exception, $sink->captured[0]);
-        $this->assertSame($request, $sink->captured[1]);
-    }
-
     public function testDispatchResultDoesNotTerminateTwiceAfterExplicitTermination(): void
     {
         $request = new Request();

--- a/tests/Requests/RequestAbortionTest.php
+++ b/tests/Requests/RequestAbortionTest.php
@@ -2,11 +2,14 @@
 
 namespace Tests\Unit\Requests;
 
+require_once __DIR__ . '/../Support/MockContainer.php';
+
 use Phaseolies\Http\Support\RequestAbortion;
 use Phaseolies\Http\Request;
 use Phaseolies\Http\Exceptions\HttpResponseException;
 use Phaseolies\Http\Exceptions\HttpException;
 use Phaseolies\DI\Container;
+use stdClass;
 use PHPUnit\Framework\TestCase;
 use Mockery;
 use Tests\Support\MockContainer;
@@ -72,7 +75,7 @@ class RequestAbortionTest extends TestCase
         // Mock the Request object for regular web request
         $mockRequest = Mockery::mock(Request::class);
         $mockRequest->shouldReceive('isAjax')->andReturn(false);
-        $mockRequest->shouldReceive('is')->with('/api/*')->andReturn(false);
+        $mockRequest->shouldReceive('isApiRequest')->andReturn(false);
 
         // Bind the mock to the container
         $this->container->bind('request', fn() => $mockRequest);
@@ -90,7 +93,7 @@ class RequestAbortionTest extends TestCase
         // Mock the Request object
         $mockRequest = Mockery::mock(Request::class);
         $mockRequest->shouldReceive('isAjax')->andReturn(false);
-        $mockRequest->shouldReceive('is')->with('/api/*')->andReturn(false);
+        $mockRequest->shouldReceive('isApiRequest')->andReturn(false);
 
         // Bind the mock to the container
         $this->container->bind('request', fn() => $mockRequest);
@@ -120,7 +123,7 @@ class RequestAbortionTest extends TestCase
         // Mock the Request object
         $mockRequest = Mockery::mock(Request::class);
         $mockRequest->shouldReceive('isAjax')->andReturn(false);
-        $mockRequest->shouldReceive('is')->with('/api/*')->andReturn(false);
+        $mockRequest->shouldReceive('isApiRequest')->andReturn(false);
 
         // Bind the mock to the container
         $this->container->bind('request', fn() => $mockRequest);
@@ -140,7 +143,7 @@ class RequestAbortionTest extends TestCase
         // Mock the Request object
         $mockRequest = Mockery::mock(Request::class);
         $mockRequest->shouldReceive('isAjax')->andReturn(false);
-        $mockRequest->shouldReceive('is')->with('/api/*')->andReturn(false);
+        $mockRequest->shouldReceive('isApiRequest')->andReturn(false);
 
         // Bind the mock to the container
         $this->container->bind('request', fn() => $mockRequest);
@@ -171,7 +174,7 @@ class RequestAbortionTest extends TestCase
         // Mock the Request object
         $mockRequest = Mockery::mock(Request::class);
         $mockRequest->shouldReceive('isAjax')->andReturn(false);
-        $mockRequest->shouldReceive('is')->with('/api/*')->andReturn(false);
+        $mockRequest->shouldReceive('isApiRequest')->andReturn(false);
 
         // Bind the mock to the container
         $this->container->bind('request', fn() => $mockRequest);
@@ -192,7 +195,7 @@ class RequestAbortionTest extends TestCase
         // Mock the Request object
         $mockRequest = Mockery::mock(Request::class);
         $mockRequest->shouldReceive('isAjax')->andReturn(false);
-        $mockRequest->shouldReceive('is')->with('/api/*')->andReturn(false);
+        $mockRequest->shouldReceive('isApiRequest')->andReturn(false);
 
         // Bind the mock to the container
         $this->container->bind('request', fn() => $mockRequest);
@@ -203,6 +206,64 @@ class RequestAbortionTest extends TestCase
             $this->assertEquals(404, $e->getStatusCode());
             $this->assertEmpty($e->getHeaders());
             throw $e;
+        }
+    }
+
+    public function testRecordInsightExceptionDelegatesToInsightRecorder(): void
+    {
+        $sink = new stdClass();
+        $sink->captured = [];
+
+        $mockRequest = Mockery::mock(Request::class);
+        $this->container->instance('Doppar\\Insight\\Support\\ErrorHistoryRecorder', new class($sink) {
+            public function __construct(private readonly object $sink)
+            {
+            }
+
+            public function record($exception, $request): void
+            {
+                $this->sink->captured = [$exception, $request];
+            }
+        });
+
+        $exception = HttpException::fromStatusCode(404, 'Route missing');
+        $method = new \ReflectionMethod($this->requestAbortion, 'recordInsightException');
+        $method->setAccessible(true);
+        $method->invoke($this->requestAbortion, $mockRequest, $exception);
+
+        $this->assertSame($exception, $sink->captured[0]);
+        $this->assertSame($mockRequest, $sink->captured[1]);
+        $this->assertSame(404, $exception->getStatusCode());
+    }
+
+    public function testAbortRecordsInsightForAjaxAbort(): void
+    {
+        $sink = new stdClass();
+        $sink->captured = [];
+
+        $mockRequest = Mockery::mock(Request::class);
+        $mockRequest->shouldReceive('isAjax')->andReturn(true);
+        $mockRequest->shouldReceive('isApiRequest')->andReturn(false);
+        $this->container->bind('request', fn() => $mockRequest);
+        $this->container->instance('Doppar\\Insight\\Support\\ErrorHistoryRecorder', new class($sink) {
+            public function __construct(private readonly object $sink)
+            {
+            }
+
+            public function record($exception, $request): void
+            {
+                $this->sink->captured = [$exception, $request];
+            }
+        });
+
+        try {
+            $this->requestAbortion->abort(404, 'Ajax missing');
+            $this->fail('Expected HttpResponseException was not thrown.');
+        } catch (HttpResponseException $exception) {
+            $this->assertInstanceOf(HttpException::class, $sink->captured[0]);
+            $this->assertSame(404, $sink->captured[0]->getStatusCode());
+            $this->assertSame($mockRequest, $sink->captured[1]);
+            $this->assertSame(404, $exception->getStatusCode());
         }
     }
 }

--- a/tests/Requests/RequestAbortionTest.php
+++ b/tests/Requests/RequestAbortionTest.php
@@ -69,43 +69,35 @@ class RequestAbortionTest extends TestCase
 
     public function testAbortThrowsHttpExceptionForNonAjaxNonApiRequests()
     {
-        $this->expectException(HttpException::class);
-        $this->expectExceptionMessage('Forbidden');
+        $this->expectException(HttpResponseException::class);
 
-        // Mock the Request object for regular web request
         $mockRequest = Mockery::mock(Request::class);
-        $mockRequest->shouldReceive('isAjax')->andReturn(false);
+        $mockRequest->shouldReceive('isAjax')->andReturn(true);
         $mockRequest->shouldReceive('isApiRequest')->andReturn(false);
-
-        // Bind the mock to the container
-        $this->container->bind('request', fn() => $mockRequest);
+        $this->container->instance('request', $mockRequest);
 
         try {
             $this->requestAbortion->abort(403, 'Forbidden');
-        } catch (HttpException $e) {
+        } catch (HttpResponseException $e) {
             $this->assertEquals(403, $e->getStatusCode());
+            $this->assertSame('Forbidden', $e->getValidationErrors());
             throw $e;
         }
     }
 
     public function testAbortThrowsHttpExceptionWithHeaders()
     {
-        // Mock the Request object
         $mockRequest = Mockery::mock(Request::class);
-        $mockRequest->shouldReceive('isAjax')->andReturn(false);
+        $mockRequest->shouldReceive('isAjax')->andReturn(true);
         $mockRequest->shouldReceive('isApiRequest')->andReturn(false);
-
-        // Bind the mock to the container
-        $this->container->bind('request', fn() => $mockRequest);
+        $this->container->instance('request', $mockRequest);
 
         try {
             $this->requestAbortion->abort(403, 'Forbidden', ['X-Custom-Header' => 'Value']);
-            $this->fail('Expected HttpException was not thrown');
-        } catch (HttpException $e) {
+            $this->fail('Expected HttpResponseException was not thrown');
+        } catch (HttpResponseException $e) {
             $this->assertEquals(403, $e->getStatusCode());
-            $this->assertEquals('Forbidden', $e->getMessage());
-            $this->assertArrayHasKey('X-Custom-Header', $e->getHeaders());
-            $this->assertEquals('Value', $e->getHeaders()['X-Custom-Header']);
+            $this->assertSame('Forbidden', $e->getValidationErrors());
         }
     }
 
@@ -117,44 +109,36 @@ class RequestAbortionTest extends TestCase
 
     public function testAbortIfThrowsWhenConditionIsTrue()
     {
-        $this->expectException(HttpException::class);
-        $this->expectExceptionMessage('Bad Request');
+        $this->expectException(HttpResponseException::class);
 
-        // Mock the Request object
         $mockRequest = Mockery::mock(Request::class);
-        $mockRequest->shouldReceive('isAjax')->andReturn(false);
+        $mockRequest->shouldReceive('isAjax')->andReturn(true);
         $mockRequest->shouldReceive('isApiRequest')->andReturn(false);
-
-        // Bind the mock to the container
-        $this->container->bind('request', fn() => $mockRequest);
+        $this->container->instance('request', $mockRequest);
 
         try {
             $this->requestAbortion->abortIf(true, 400, 'Bad Request');
-        } catch (HttpException $e) {
+        } catch (HttpResponseException $e) {
             $this->assertEquals(400, $e->getStatusCode());
+            $this->assertSame('Bad Request', $e->getValidationErrors());
             throw $e;
         }
     }
 
     public function testAbortIfWithHeaders()
     {
-        $this->expectException(HttpException::class);
+        $this->expectException(HttpResponseException::class);
 
-        // Mock the Request object
         $mockRequest = Mockery::mock(Request::class);
-        $mockRequest->shouldReceive('isAjax')->andReturn(false);
+        $mockRequest->shouldReceive('isAjax')->andReturn(true);
         $mockRequest->shouldReceive('isApiRequest')->andReturn(false);
-
-        // Bind the mock to the container
-        $this->container->bind('request', fn() => $mockRequest);
+        $this->container->instance('request', $mockRequest);
 
         try {
             $this->requestAbortion->abortIf(true, 401, 'Unauthorized', ['X-Test' => 'HeaderValue']);
-        } catch (HttpException $e) {
+        } catch (HttpResponseException $e) {
             $this->assertEquals(401, $e->getStatusCode());
-            $this->assertEquals('Unauthorized', $e->getMessage());
-            $this->assertArrayHasKey('X-Test', $e->getHeaders());
-            $this->assertEquals('HeaderValue', $e->getHeaders()['X-Test']);
+            $this->assertSame('Unauthorized', $e->getValidationErrors());
             throw $e;
         }
     }
@@ -169,42 +153,36 @@ class RequestAbortionTest extends TestCase
 
     public function testAbortWithEmptyMessage()
     {
-        $this->expectException(HttpException::class);
+        $this->expectException(HttpResponseException::class);
 
-        // Mock the Request object
         $mockRequest = Mockery::mock(Request::class);
-        $mockRequest->shouldReceive('isAjax')->andReturn(false);
+        $mockRequest->shouldReceive('isAjax')->andReturn(true);
         $mockRequest->shouldReceive('isApiRequest')->andReturn(false);
-
-        // Bind the mock to the container
-        $this->container->bind('request', fn() => $mockRequest);
+        $this->container->instance('request', $mockRequest);
 
         try {
             $this->requestAbortion->abort(403);
-        } catch (HttpException $e) {
+        } catch (HttpResponseException $e) {
             $this->assertEquals(403, $e->getStatusCode());
-            $this->assertEquals('', $e->getMessage());
+            $this->assertSame('', $e->getValidationErrors());
             throw $e;
         }
     }
 
     public function testAbortWithEmptyHeaders()
     {
-        $this->expectException(HttpException::class);
+        $this->expectException(HttpResponseException::class);
 
-        // Mock the Request object
         $mockRequest = Mockery::mock(Request::class);
-        $mockRequest->shouldReceive('isAjax')->andReturn(false);
+        $mockRequest->shouldReceive('isAjax')->andReturn(true);
         $mockRequest->shouldReceive('isApiRequest')->andReturn(false);
-
-        // Bind the mock to the container
-        $this->container->bind('request', fn() => $mockRequest);
+        $this->container->instance('request', $mockRequest);
 
         try {
             $this->requestAbortion->abort(404, '', []);
-        } catch (HttpException $e) {
+        } catch (HttpResponseException $e) {
             $this->assertEquals(404, $e->getStatusCode());
-            $this->assertEmpty($e->getHeaders());
+            $this->assertSame('', $e->getValidationErrors());
             throw $e;
         }
     }
@@ -228,7 +206,6 @@ class RequestAbortionTest extends TestCase
 
         $exception = HttpException::fromStatusCode(404, 'Route missing');
         $method = new \ReflectionMethod($this->requestAbortion, 'recordInsightException');
-        $method->setAccessible(true);
         $method->invoke($this->requestAbortion, $mockRequest, $exception);
 
         $this->assertSame($exception, $sink->captured[0]);
@@ -244,7 +221,7 @@ class RequestAbortionTest extends TestCase
         $mockRequest = Mockery::mock(Request::class);
         $mockRequest->shouldReceive('isAjax')->andReturn(true);
         $mockRequest->shouldReceive('isApiRequest')->andReturn(false);
-        $this->container->bind('request', fn() => $mockRequest);
+        $this->container->instance('request', $mockRequest);
         $this->container->instance('Doppar\\Insight\\Support\\ErrorHistoryRecorder', new class($sink) {
             public function __construct(private readonly object $sink)
             {


### PR DESCRIPTION
These updates can reliably capture request errors, especially route-miss 404 responses.

## What changed

- Added Insight error handoff in RequestAbortion::abort() so route-miss 404 and other abort-driven errors are recorded before web error rendering exits
- Extracted the shared recorder bridge into Http/Support/InteractsWithInsightErrorTracking
- Reused that trait RequestAbortion to avoid duplicate logic

## Why

- Route-not-found 404 errors were not always reaching Insight through normal middleware flow
- Some abort-driven web responses render and exit before later lifecycle hooks can record them
- This makes Insight tracking more reliable for both general request errors and missing-route 404s

## Result

- Insight now records route-miss 404s
- Dispatch-time HttpException errors are tracked consistently
- Shared Doppar-side Insight integration is centralized in one trait