### PR TITLE
Fix: per-request singleton state leakage in worker mode

### DIFF
--- a/src/Phaseolies/Application.php
+++ b/src/Phaseolies/Application.php
@@ -2,6 +2,7 @@
 
 namespace Phaseolies;
 
+use Phaseolies\Auth\ActorManager;
 use Phaseolies\Support\Router;
 use Phaseolies\Providers\ServiceProvider;
 use Phaseolies\Http\DispatchResult;
@@ -871,12 +872,32 @@ class Application extends Container
      */
     public function terminate(Request $request, ?Response $response = null, ?\Throwable $exception = null): void
     {
-        if (empty($this->terminatingCallbacks)) {
-            return;
+        try {
+            foreach ($this->terminatingCallbacks as $callback) {
+                $this->callTerminatingCallback($callback, $request, $response, $exception);
+            }
+        } finally {
+            $this->cleanupRequestScopedServices();
+        }
+    }
+
+    /**
+     * Drop resolved request-scoped services while preserving their bindings.
+     *
+     * @return void
+     */
+    protected function cleanupRequestScopedServices(): void
+    {
+        if ($this->has('auth')) {
+            $auth = $this->make('auth');
+
+            if ($auth instanceof ActorManager) {
+                $auth->forgetActors();
+            }
         }
 
-        foreach ($this->terminatingCallbacks as $callback) {
-            $this->callTerminatingCallback($callback, $request, $response, $exception);
+        foreach (['session', 'request', 'response', 'redirect'] as $abstract) {
+            $this->forgetResolved($abstract);
         }
     }
 
@@ -1012,6 +1033,8 @@ class Application extends Container
     public function dispatch($request): DispatchResult
     {
         try {
+            $this->instance('request', $request);
+
             $response = $this->handle($request);
 
             $response->prepare($request)->send();

--- a/src/Phaseolies/DI/Container.php
+++ b/src/Phaseolies/DI/Container.php
@@ -399,6 +399,17 @@ class Container implements ArrayAccess
     }
 
     /**
+     * Forget a resolved instance while keeping its binding intact.
+     *
+     * @param string $abstract
+     * @return void
+     */
+    public function forgetResolved(string $abstract): void
+    {
+        unset(self::$instances[$abstract]);
+    }
+
+    /**
      * Flush the container of all instances and bindings.
      *
      * @return void

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -5,13 +5,16 @@ namespace Tests\Unit\Application;
 use ReflectionClass;
 use Tests\Support\Kernel;
 use Phaseolies\Application;
+use Phaseolies\Auth\ActorManager;
 use Phaseolies\DI\Container;
 use Phaseolies\Http\DispatchResult;
 use Phaseolies\Http\Request;
 use Phaseolies\Http\Response;
 use Phaseolies\Http\Exceptions\HttpException;
 use Phaseolies\Config\Config;
+use Phaseolies\Http\Response\RedirectResponse;
 use Phaseolies\Support\Router;
+use Phaseolies\Support\Session;
 use Phaseolies\Console\Console;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -408,6 +411,45 @@ final class ApplicationTest extends TestCase
         $this->assertNull($captured[2]);
     }
 
+    public function testDispatchRebindsCurrentRequestBeforeResolvingRoutes(): void
+    {
+        $oldRequest = new Request();
+        $newRequest = new Request();
+
+        $this->app->instance('request', $oldRequest);
+
+        $response = $this->getMockBuilder(Response::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['prepare', 'send'])
+            ->getMock();
+
+        $response->expects($this->once())
+            ->method('prepare')
+            ->with($newRequest)
+            ->willReturnSelf();
+
+        $response->expects($this->once())
+            ->method('send')
+            ->with()
+            ->willReturnSelf();
+
+        $router = $this->createMock(Router::class);
+        $router->expects($this->once())
+            ->method('resolve')
+            ->with($this->app, $newRequest)
+            ->willReturnCallback(function () use ($oldRequest, $newRequest, $response) {
+                $this->assertSame($newRequest, app('request'));
+                $this->assertSame($newRequest, app(Request::class));
+                $this->assertNotSame($oldRequest, app('request'));
+
+                return $response;
+            });
+
+        $this->app->router = $router;
+
+        $this->app->dispatch($newRequest);
+    }
+
     public function testDispatchResultDoesNotTerminateTwiceAfterExplicitTermination(): void
     {
         $request = new Request();
@@ -443,5 +485,76 @@ final class ApplicationTest extends TestCase
         $this->assertSame($request, $captured['request']);
         $this->assertSame($response, $captured['response']);
         $this->assertSame($exception, $captured['exception']);
+    }
+
+    public function testTerminateCleansRequestScopedServicesAfterCallbacks(): void
+    {
+        $_SESSION = [];
+
+        $request = new Request();
+        $response = new Response('ok');
+        $session = new Session();
+        $redirect = new RedirectResponse();
+
+        $auth = $this->getMockBuilder(ActorManager::class)
+            ->onlyMethods(['forgetActors'])
+            ->getMock();
+
+        $auth->expects($this->once())
+            ->method('forgetActors');
+
+        $this->app->instance('request', $request);
+        $this->app->instance('response', $response);
+        $this->app->instance('session', $session);
+        $this->app->instance('redirect', $redirect);
+        $this->app->instance('auth', $auth);
+
+        $seenInsideCallback = [];
+
+        $this->app->terminating(function () use (&$seenInsideCallback): void {
+            $seenInsideCallback = [
+                'request' => $this->app->hasInstance('request'),
+                'response' => $this->app->hasInstance('response'),
+                'session' => $this->app->hasInstance('session'),
+                'redirect' => $this->app->hasInstance('redirect'),
+                'auth' => $this->app->hasInstance('auth'),
+            ];
+        });
+
+        $this->app->terminate($request, $response);
+
+        $this->assertSame([
+            'request' => true,
+            'response' => true,
+            'session' => true,
+            'redirect' => true,
+            'auth' => true,
+        ], $seenInsideCallback);
+
+        $this->assertFalse($this->app->hasInstance('request'));
+        $this->assertFalse($this->app->hasInstance('response'));
+        $this->assertFalse($this->app->hasInstance('session'));
+        $this->assertFalse($this->app->hasInstance('redirect'));
+        $this->assertTrue($this->app->hasInstance('auth'));
+    }
+
+    public function testTerminateStillCleansRequestScopedServicesWithoutCallbacks(): void
+    {
+        $_SESSION = [];
+
+        $request = new Request();
+        $response = new Response('ok');
+
+        $this->app->instance('request', $request);
+        $this->app->instance('response', $response);
+        $this->app->instance('session', new Session());
+        $this->app->instance('redirect', new RedirectResponse());
+
+        $this->app->terminate($request, $response);
+
+        $this->assertFalse($this->app->hasInstance('request'));
+        $this->assertFalse($this->app->hasInstance('response'));
+        $this->assertFalse($this->app->hasInstance('session'));
+        $this->assertFalse($this->app->hasInstance('redirect'));
     }
 }

--- a/tests/Application/ContainerTest.php
+++ b/tests/Application/ContainerTest.php
@@ -884,6 +884,36 @@ class ContainerTest extends TestCase
         $this->assertFalse($this->container->hasInstance('service2'));
     }
 
+    public function testForgetResolvedClearsResolvedSingletonInstanceButKeepsBinding()
+    {
+        $this->container->singleton('service', fn() => new \stdClass());
+        $this->container->get('service');
+
+        $this->container->forgetResolved('service');
+
+        $this->assertTrue($this->container->has('service'));
+        $this->assertFalse($this->container->hasInstance('service'));
+        $this->assertFalse($this->container->resolved('service'));
+    }
+
+    public function testForgetResolvedAllowsSingletonToBeResolvedFresh()
+    {
+        $this->container->singleton('service', fn() => new \stdClass());
+
+        $first = $this->container->get('service');
+        $this->container->forgetResolved('service');
+        $second = $this->container->get('service');
+
+        $this->assertNotSame($first, $second);
+    }
+
+    public function testForgetResolvedForUnknownBindingDoesNotThrow()
+    {
+        $this->container->forgetResolved('missing-service');
+
+        $this->assertFalse($this->container->hasInstance('missing-service'));
+    }
+
     public function testFlushAllowsRebinding()
     {
         $this->container->bind('service', fn() => 'value1');


### PR DESCRIPTION
In worker mode, the PHP process stays alive across requests. The DI container stores resolved singletons in private static array `$instances`, which is never cleared between requests. This means it may leak user-specific state from Request 1 into Request 2.

This is invisible in development (spawns a fresh process per request) and only surfaces under real concurrent traffic in worker mode — making it a silent production security issue.

## Does this break anything
No existing behaviour changes in PHP-FPM mode — processes reset between requests naturally, so the terminating callback runs but nulling already-null instances is a no-op