### PR TITLE
Fix: Normalize the error paths onto real Response objects

### DIFF
--- a/src/Phaseolies/Error/Handlers/JsonErrorHandler.php
+++ b/src/Phaseolies/Error/Handlers/JsonErrorHandler.php
@@ -17,21 +17,25 @@ class JsonErrorHandler implements ErrorHandlerInterface
      */
     public function handle(Throwable $exception): void
     {
-        $renderer = new JsonErrorRenderer();
+        if ($exception instanceof HttpResponseException && $exception->hasResponse()) {
+            $exception->getResponse()?->prepare(request())->send();
 
-        if ($exception instanceof HttpResponseException) {
-            $responseErrors = $exception->getValidationErrors();
-  
-            $statusCode = (int) $exception->getStatusCode() ?: 500;
-            $renderer->render($exception, $statusCode, $responseErrors);
-        } else {
-            $statusCode = (int) $exception->getCode() ?: 500;
-            $renderer->render($exception, $statusCode);
+            return;
         }
 
-        exit(1);
-    }
+        $renderer = new JsonErrorRenderer();
+        if ($exception instanceof HttpResponseException) {
+            $responseErrors = $exception->getValidationErrors();
 
+            $statusCode = (int) $exception->getStatusCode() ?: 500;
+            $response = $renderer->render($exception, $statusCode, $responseErrors);
+        } else {
+            $statusCode = (int) $exception->getCode() ?: 500;
+            $response = $renderer->render($exception, $statusCode);
+        }
+
+        $response->prepare(request())->send();
+    }
 
     /**
      * Determines whether this handler supports the current request context.

--- a/src/Phaseolies/Error/Handlers/WebErrorHandler.php
+++ b/src/Phaseolies/Error/Handlers/WebErrorHandler.php
@@ -26,12 +26,12 @@ class WebErrorHandler implements ErrorHandlerInterface
         $renderer = new WebErrorRenderer();
 
         if (env('APP_DEBUG') === "true") {
-            $renderer->renderDebug($exception);
+            $response = $renderer->renderDebug($exception);
         } else {
-            $renderer->renderProduction($exception);
+            $response = $renderer->renderProduction($exception);
         }
 
-        exit(1);
+        $response->prepare(request())->send();
     }
 
     /**

--- a/src/Phaseolies/Error/Handlers/WebErrorHandler.php
+++ b/src/Phaseolies/Error/Handlers/WebErrorHandler.php
@@ -5,6 +5,7 @@ namespace Phaseolies\Error\Handlers;
 use Throwable;
 use Phaseolies\Error\WebErrorRenderer;
 use Phaseolies\Error\Contracts\ErrorHandlerInterface;
+use Phaseolies\Http\Exceptions\HttpResponseException;
 
 class WebErrorHandler implements ErrorHandlerInterface
 {
@@ -16,6 +17,12 @@ class WebErrorHandler implements ErrorHandlerInterface
      */
     public function handle(Throwable $exception): void
     {
+        if ($exception instanceof HttpResponseException && $exception->hasResponse()) {
+            $exception->getResponse()?->prepare(request())->send();
+
+            return;
+        }
+
         $renderer = new WebErrorRenderer();
 
         if (env('APP_DEBUG') === "true") {

--- a/src/Phaseolies/Error/JsonErrorRenderer.php
+++ b/src/Phaseolies/Error/JsonErrorRenderer.php
@@ -3,6 +3,7 @@
 namespace Phaseolies\Error;
 
 use Phaseolies\Http\Response;
+use Phaseolies\Http\Response\JsonResponse;
 use Throwable;
 
 class JsonErrorRenderer
@@ -13,9 +14,9 @@ class JsonErrorRenderer
      * @param Throwable $exception
      * @param int $statusCode
      * @param mixed|null $errorDetails
-     * @return void
+     * @return \Phaseolies\Http\Response\JsonResponse
      */
-    public function render(Throwable $exception, int $statusCode, mixed $errorDetails = null): void
+    public function render(Throwable $exception, int $statusCode, mixed $errorDetails = null): JsonResponse
     {
         $messages = [
             Response::HTTP_TOO_MANY_REQUESTS    => trans('validation.rate_limit.message'),
@@ -40,11 +41,6 @@ class JsonErrorRenderer
                 ],
             ];
 
-        header('Content-Type: application/json');
-        http_response_code($statusCode);
-
-        echo json_encode($response, JSON_UNESCAPED_SLASHES);
-
-        exit;
+        return response()->json($response, $statusCode);
     }
 }

--- a/src/Phaseolies/Error/WebErrorRenderer.php
+++ b/src/Phaseolies/Error/WebErrorRenderer.php
@@ -7,6 +7,8 @@ use Phaseolies\Error\Traces\Frame;
 use Phaseolies\Error\Utils\ExceptionMarkdownReport;
 use Phaseolies\Error\Utils\Highlighter;
 use Phaseolies\Http\Controllers\Controller;
+use Phaseolies\Http\Exceptions\HttpException;
+use Phaseolies\Http\Response;
 use Throwable;
 
 class WebErrorRenderer
@@ -15,9 +17,9 @@ class WebErrorRenderer
      * Render a detailed debug error page.
      *
      * @param Throwable $exception
-     * @return void
+     * @return \Phaseolies\Http\Response
      */
-    public function renderDebug(Throwable $exception): string
+    public function renderDebug(Throwable $exception): Response
     {
         $errorFile = $exception->getFile();
         $errorLine = $exception->getLine();
@@ -55,7 +57,7 @@ class WebErrorRenderer
         // to start a fresh view
         $this->clearOutputBufferIfActive();
 
-        return $controller->render('template', [
+        $content = $controller->render('template', [
             'traces'          => Frame::extractFramesCollectionFromEngine($exception->getTrace()),
             'headers'         => ($this->getHeaders()),
             'error_message'   => ucfirst($exception->getMessage()),
@@ -83,6 +85,10 @@ class WebErrorRenderer
             'current_route_action' => \Phaseolies\Support\Facades\Route::currentRouteAction(),
             'current_route_params' => request()->getRouteParams()
         ]);
+
+        return response($content, $this->resolveStatusCode($exception))
+            ->setOriginal($content)
+            ->setStatusCode($this->resolveStatusCode($exception));
     }
 
     /**
@@ -169,10 +175,78 @@ class WebErrorRenderer
      * Render a simple production-safe error response.
      *
      * @param Throwable $exception
-     * @return void
+     * @return \Phaseolies\Http\Response
      */
-    public function renderProduction(Throwable $exception): void
+    public function renderProduction(Throwable $exception): Response
     {
-        abort(500, "Something went wrong");
+        $statusCode = $this->resolveStatusCode($exception);
+        $message = $statusCode >= 500 ? 'Something went wrong' : ($exception->getMessage() ?: 'An error occurred.');
+        $viewPath = $this->resolveErrorViewPath($statusCode);
+
+        if ($viewPath !== null) {
+            $this->clearOutputBufferIfActive();
+            ob_start();
+            include $viewPath;
+            $content = ob_get_clean() ?: '';
+
+            return response($content, $statusCode)
+                ->setOriginal($content)
+                ->setStatusCode($statusCode);
+        }
+
+        return response($message, $statusCode)
+            ->setOriginal($message)
+            ->setStatusCode($statusCode);
+    }
+
+    /**
+     * Resolve the current HTTP status code for the exception.
+     *
+     * @param Throwable $exception
+     * @return int
+     */
+    protected function resolveStatusCode(Throwable $exception): int
+    {
+        if ($exception instanceof HttpException) {
+            return $exception->getStatusCode();
+        }
+
+        $statusCode = (int) $exception->getCode();
+
+        return ($statusCode >= 400 && $statusCode < 600) ? $statusCode : 500;
+    }
+
+    /**
+     * Resolve a matching error view path for the given status.
+     *
+     * @param int $statusCode
+     * @return string|null
+     */
+    protected function resolveErrorViewPath(int $statusCode): ?string
+    {
+        $customPath = base_path(
+            'resources'
+            . DIRECTORY_SEPARATOR . 'views'
+            . DIRECTORY_SEPARATOR . 'errors'
+            . DIRECTORY_SEPARATOR . "{$statusCode}.odo.php"
+        );
+
+        if (file_exists($customPath)) {
+            return $customPath;
+        }
+
+        $packagePath = base_path(
+            'vendor'
+            . DIRECTORY_SEPARATOR . 'doppar'
+            . DIRECTORY_SEPARATOR . 'framework'
+            . DIRECTORY_SEPARATOR . 'src'
+            . DIRECTORY_SEPARATOR . 'Phaseolies'
+            . DIRECTORY_SEPARATOR . 'Support'
+            . DIRECTORY_SEPARATOR . 'View'
+            . DIRECTORY_SEPARATOR . 'errors'
+            . DIRECTORY_SEPARATOR . "{$statusCode}.odo.php"
+        );
+
+        return file_exists($packagePath) ? $packagePath : null;
     }
 }

--- a/src/Phaseolies/Http/Exceptions/HttpResponseException.php
+++ b/src/Phaseolies/Http/Exceptions/HttpResponseException.php
@@ -2,6 +2,7 @@
 
 namespace Phaseolies\Http\Exceptions;
 
+use Phaseolies\Http\Response;
 use RuntimeException;
 use Throwable;
 
@@ -22,6 +23,13 @@ class HttpResponseException extends RuntimeException
     protected $statusCode;
 
     /**
+     * The prepared response instance, if available.
+     *
+     * @var \Phaseolies\Http\Response|null
+     */
+    protected ?Response $response = null;
+
+    /**
      * Create a new HTTP response exception instance.
      *
      * @param mixed $message
@@ -29,12 +37,19 @@ class HttpResponseException extends RuntimeException
      * @param \Throwable|null $previous
      * @return void
      */
-    public function __construct(mixed $message = null,  int $status = 500,  ?Throwable $previous = null)
+    public function __construct(mixed $message = null, int $status = 500, ?Throwable $previous = null, ?Response $response = null)
     {
-        parent::__construct($previous?->getMessage() ?? '', $previous?->getCode() ?? 0, $previous);
+        $exceptionMessage = $previous?->getMessage();
+
+        if (($exceptionMessage === null || $exceptionMessage === '') && is_string($message)) {
+            $exceptionMessage = $message;
+        }
+
+        parent::__construct($exceptionMessage ?? '', $status, $previous);
 
         $this->validationErrors = $message;
         $this->statusCode = $status;
+        $this->response = $response;
     }
 
     /**
@@ -55,5 +70,38 @@ class HttpResponseException extends RuntimeException
     public function getStatusCode(): int
     {
         return $this->statusCode;
+    }
+
+    /**
+     * Attach a prepared response instance to the exception.
+     *
+     * @param \Phaseolies\Http\Response $response
+     * @return $this
+     */
+    public function setResponse(Response $response): static
+    {
+        $this->response = $response;
+
+        return $this;
+    }
+
+    /**
+     * Get the prepared response instance.
+     *
+     * @return \Phaseolies\Http\Response|null
+     */
+    public function getResponse(): ?Response
+    {
+        return $this->response;
+    }
+
+    /**
+     * Determine whether the exception already has a prepared response.
+     *
+     * @return bool
+     */
+    public function hasResponse(): bool
+    {
+        return $this->response instanceof Response;
     }
 }

--- a/src/Phaseolies/Http/Support/RequestAbortion.php
+++ b/src/Phaseolies/Http/Support/RequestAbortion.php
@@ -2,8 +2,10 @@
 
 namespace Phaseolies\Http\Support;
 
+use Phaseolies\Error\JsonErrorRenderer;
 use Phaseolies\Http\Exceptions\HttpResponseException;
 use Phaseolies\Http\Exceptions\HttpException;
+use Phaseolies\Http\Response;
 
 class RequestAbortion
 {
@@ -51,17 +53,18 @@ class RequestAbortion
             $viewPath = file_exists($customPath) ? $customPath : (file_exists($packagePath) ? $packagePath : null);
 
             if ($viewPath) {
-                if (ob_get_level() > 0) {
-                    ob_get_clean();
-                }
-                http_response_code($code);
-                include $viewPath;
-                exit;
+                throw (new HttpResponseException($message, $code, $httpException))
+                    ->setResponse($this->buildErrorViewResponse($viewPath, $code, $headers));
             }
         }
 
         if ($shouldJsonResponse) {
-            throw new HttpResponseException($message, $code, null);
+            $response = (new JsonErrorRenderer())
+                ->render($httpException, $code, $message)
+                ->withHeaders($headers);
+
+            throw (new HttpResponseException($message, $code, $httpException))
+                ->setResponse($response);
         }
 
         throw $httpException;
@@ -82,5 +85,28 @@ class RequestAbortion
         if ($condition) {
             $this->abort($code, $message, $headers);
         }
+    }
+
+    /**
+     * Build an HTML response for a resolved error view.
+     *
+     * @param string $viewPath
+     * @param int $statusCode
+     * @param array<string, string> $headers
+     * @return \Phaseolies\Http\Response
+     */
+    protected function buildErrorViewResponse(string $viewPath, int $statusCode, array $headers = []): Response
+    {
+        if (ob_get_level() > 0) {
+            ob_get_clean();
+        }
+
+        ob_start();
+        include $viewPath;
+        $content = ob_get_clean() ?: '';
+
+        return response($content, $statusCode, $headers)
+            ->setOriginal($content)
+            ->setStatusCode($statusCode);
     }
 }

--- a/src/Phaseolies/Http/Validation/Rule.php
+++ b/src/Phaseolies/Http/Validation/Rule.php
@@ -2,6 +2,7 @@
 
 namespace Phaseolies\Http\Validation;
 
+use Phaseolies\Error\JsonErrorRenderer;
 use Phaseolies\Session\MessageBag;
 use Phaseolies\Http\Support\ValidationRules;
 use Phaseolies\Http\Response;
@@ -50,18 +51,31 @@ trait Rule
 
         if (!empty($errors)) {
             if (request()->isAjax() || request()->isApiRequest()) {
-                throw new HttpResponseException(
+                $exception = new HttpResponseException(
                     $errors,
                     Response::HTTP_UNPROCESSABLE_ENTITY
                 );
+
+                $exception->setResponse(
+                    (new JsonErrorRenderer())->render(
+                        $exception,
+                        Response::HTTP_UNPROCESSABLE_ENTITY,
+                        $errors
+                    )
+                );
+
+                throw $exception;
             }
 
             $this->setErrors($errors);
             foreach ($errors as $key => $error) {
                 session()->putPeek($key, implode(' ', (array)$error));
             }
-            redirect()->back()->withInput()->withErrors($errors)->send();
-            exit;
+
+            $response = redirect()->back()->withInput()->withErrors($errors);
+
+            throw (new HttpResponseException($errors, $response->getStatusCode()))
+                ->setResponse($response);
         }
 
         $this->setPassedData($input);

--- a/tests/Error/JsonErrorRendererTest.php
+++ b/tests/Error/JsonErrorRendererTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Unit\Error;
+
+require_once __DIR__ . '/../Support/MockContainer.php';
+
+use Phaseolies\DI\Container;
+use Phaseolies\Error\JsonErrorRenderer;
+use Phaseolies\Http\Response;
+use Phaseolies\Http\Response\JsonResponse;
+use Phaseolies\Translation\FileLoader;
+use Phaseolies\Translation\Translator;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Tests\Support\MockContainer;
+
+class JsonErrorRendererTest extends TestCase
+{
+    protected string $translationPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $container = new MockContainer();
+        Container::setInstance($container);
+        $this->translationPath = sys_get_temp_dir() . '/phaseolies_json_error_lang_' . uniqid();
+        mkdir($this->translationPath . '/en', 0777, true);
+        file_put_contents($this->translationPath . '/en/validation.php', <<<'PHP'
+<?php
+
+return [
+    'default' => 'Validation failed.',
+    'rate_limit' => ['message' => 'Too many requests.'],
+    'unauthorized' => ['message' => 'Unauthorized.'],
+];
+PHP);
+        $container->bind('translator', fn() => new Translator(new FileLoader($this->translationPath), 'en'));
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteDir($this->translationPath);
+
+        parent::tearDown();
+    }
+
+    protected function deleteDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($files as $file) {
+            $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+        }
+
+        @rmdir($dir);
+    }
+
+    public function testRenderReturnsJsonResponseInstance(): void
+    {
+        $renderer = new JsonErrorRenderer();
+
+        $response = $renderer->render(
+            new RuntimeException('Boom', Response::HTTP_INTERNAL_SERVER_ERROR),
+            Response::HTTP_INTERNAL_SERVER_ERROR
+        );
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $response->getStatusCode());
+        $this->assertSame('application/json', $response->headers->get('Content-Type'));
+
+        $payload = json_decode($response->getBody(), true);
+
+        $this->assertSame('Boom', $payload['message']);
+        $this->assertIsArray($payload['errors']);
+        $this->assertArrayHasKey('trace', $payload['errors']);
+    }
+
+    public function testRenderUsesValidationEnvelopeForKnownStatuses(): void
+    {
+        $renderer = new JsonErrorRenderer();
+        $errors = ['email' => ['The email field is required.']];
+
+        $response = $renderer->render(
+            new RuntimeException('Validation failed', Response::HTTP_UNPROCESSABLE_ENTITY),
+            Response::HTTP_UNPROCESSABLE_ENTITY,
+            $errors
+        );
+
+        $payload = json_decode($response->getBody(), true);
+
+        $this->assertSame($errors, $payload['errors']);
+        $this->assertIsString($payload['message']);
+        $this->assertNotSame('', $payload['message']);
+    }
+}

--- a/tests/Error/WebErrorRendererTest.php
+++ b/tests/Error/WebErrorRendererTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Unit\Error;
+
+require_once __DIR__ . '/../Support/MockContainer.php';
+
+use Phaseolies\DI\Container;
+use Phaseolies\Error\WebErrorRenderer;
+use Phaseolies\Http\Exceptions\HttpException;
+use Phaseolies\Http\Response;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Tests\Support\MockContainer;
+
+class WebErrorRendererTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Container::setInstance(new MockContainer());
+    }
+
+    public function testRenderProductionReturnsResponseForGenericException(): void
+    {
+        $renderer = new WebErrorRenderer();
+
+        $response = $renderer->renderProduction(new RuntimeException('Boom'));
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(500, $response->getStatusCode());
+        $this->assertSame('Something went wrong', $response->getBody());
+    }
+
+    public function testRenderProductionPreservesHttpExceptionStatus(): void
+    {
+        $renderer = new WebErrorRenderer();
+        $exception = HttpException::fromStatusCode(404, 'Not Found');
+
+        $response = $renderer->renderProduction($exception);
+
+        $this->assertSame(404, $response->getStatusCode());
+        $this->assertSame('Not Found', $response->getBody());
+    }
+}

--- a/tests/Requests/RequestAbortionTest.php
+++ b/tests/Requests/RequestAbortionTest.php
@@ -9,6 +9,8 @@ use Phaseolies\Http\Request;
 use Phaseolies\Http\Exceptions\HttpResponseException;
 use Phaseolies\Http\Exceptions\HttpException;
 use Phaseolies\DI\Container;
+use Phaseolies\Translation\FileLoader;
+use Phaseolies\Translation\Translator;
 use stdClass;
 use PHPUnit\Framework\TestCase;
 use Mockery;
@@ -18,19 +20,51 @@ class RequestAbortionTest extends TestCase
 {
     protected RequestAbortion $requestAbortion;
     protected Container $container;
+    protected string $translationPath;
 
     protected function setUp(): void
     {
         parent::setUp();
         Container::setInstance(new MockContainer());
         $this->container = Container::getInstance();
+        $this->translationPath = sys_get_temp_dir() . '/phaseolies_request_abortion_lang_' . uniqid();
+        mkdir($this->translationPath . '/en', 0777, true);
+        file_put_contents($this->translationPath . '/en/validation.php', <<<'PHP'
+<?php
+
+return [
+    'default' => 'Validation failed.',
+    'rate_limit' => ['message' => 'Too many requests.'],
+    'unauthorized' => ['message' => 'Unauthorized.'],
+];
+PHP);
+        $this->container->bind('translator', fn() => new Translator(new FileLoader($this->translationPath), 'en'));
         $this->requestAbortion = new RequestAbortion();
     }
 
     protected function tearDown(): void
     {
         Mockery::close();
+        $this->deleteDir($this->translationPath);
         parent::tearDown();
+    }
+
+    protected function deleteDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($files as $file) {
+            $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+        }
+
+        @rmdir($dir);
     }
 
     // public function testAbortThrowsHttpResponseExceptionForAjaxRequests()
@@ -81,6 +115,9 @@ class RequestAbortionTest extends TestCase
         } catch (HttpResponseException $e) {
             $this->assertEquals(403, $e->getStatusCode());
             $this->assertSame('Forbidden', $e->getValidationErrors());
+            $this->assertTrue($e->hasResponse());
+            $this->assertSame(403, $e->getResponse()?->getStatusCode());
+            $this->assertStringContainsString('Forbidden', $e->getResponse()?->getBody() ?? '');
             throw $e;
         }
     }
@@ -98,6 +135,7 @@ class RequestAbortionTest extends TestCase
         } catch (HttpResponseException $e) {
             $this->assertEquals(403, $e->getStatusCode());
             $this->assertSame('Forbidden', $e->getValidationErrors());
+            $this->assertSame('Value', $e->getResponse()?->headers->get('X-Custom-Header'));
         }
     }
 
@@ -241,6 +279,8 @@ class RequestAbortionTest extends TestCase
             $this->assertSame(404, $sink->captured[0]->getStatusCode());
             $this->assertSame($mockRequest, $sink->captured[1]);
             $this->assertSame(404, $exception->getStatusCode());
+            $this->assertTrue($exception->hasResponse());
+            $this->assertSame(404, $exception->getResponse()?->getStatusCode());
         }
     }
 }


### PR DESCRIPTION
All of abort(), validation JSON errors, and JsonErrorRenderer should stop echo/include/exit-ing directly and instead return or throw something that becomes a proper Response. 

The main hotspots are RequestAbortion.php, Rule.php, and JsonErrorRenderer.php. Now all the error handler usages proper response send before terminating the request lifecycle.