### PR TITLE
Fix: Stop using the shared singleton response object as the mutable envelope for route results

### DIFF
--- a/src/Phaseolies/Helpers/helpers.php
+++ b/src/Phaseolies/Helpers/helpers.php
@@ -188,14 +188,8 @@ if (!function_exists('view')) {
     {
         $instance = app(Controller::class);
         $content = $instance->render($view, $data, true);
-        $response = app('response');
-        $response->setBody($content);
 
-        foreach ($headers as $name => $value) {
-            $response->headers->set($name, $value);
-        }
-
-        return $response;
+        return response($content, 200, $headers)->setOriginal($content);
     }
 }
 

--- a/src/Phaseolies/Support/Router.php
+++ b/src/Phaseolies/Support/Router.php
@@ -1002,10 +1002,8 @@ class Router extends Kernel
 
         $handler = function ($request) use ($callback, $app, $routeParams) {
             $result = $this->resolveAction($callback, $app, $routeParams);
-            $response = $app->make('response');
-            $response->setOriginal($result);
             if (!($result instanceof Response)) {
-                return $this->getResolutionResponse($request, $result, $response);
+                return $this->getResolutionResponse($request, $result);
             }
             return $result;
         };
@@ -1137,11 +1135,13 @@ class Router extends Kernel
      *
      * @param $request
      * @param $result
-     * @param mixed $response
      * @return Response
      */
-    private function getResolutionResponse($request, $result, $response): Response
+    private function getResolutionResponse($request, $result): Response
     {
+        $response = response()->make();
+        $response->setOriginal($result);
+
         if ($this->shouldBeJson($result)) {
             $request->setRequestFormat('json');
             $response->headers->set('Content-Type', 'application/json');

--- a/tests/Router/RouterTest.php
+++ b/tests/Router/RouterTest.php
@@ -7,6 +7,8 @@ use Tests\Support\Kernel;
 use Phaseolies\Utilities\Attributes\Middleware;
 use Phaseolies\Support\Router;
 use Phaseolies\Http\Request;
+use Phaseolies\Http\Response;
+use Phaseolies\Http\Controllers\Controller;
 use Phaseolies\DI\Container;
 use Phaseolies\Application;
 use PHPUnit\Framework\TestCase;
@@ -55,6 +57,14 @@ class TestRequestStub extends Request
         $this->testRouteParams = $params;
 
         return $this;
+    }
+}
+
+class TestableRouter extends Router
+{
+    public function handle(Request $request, \Closure $handler): Response
+    {
+        return $handler($request);
     }
 }
 
@@ -412,6 +422,46 @@ class RouterTest extends TestCase
         $result = $this->router->getCallback($request);
 
         $this->assertFalse($result);
+    }
+
+    public function testResolveUsesFreshResponseForScalarRouteResults(): void
+    {
+        $freshRouter = new TestableRouter($this->app);
+        $sharedResponse = new Response('stale body', 202, ['X-Leaked' => 'yes']);
+
+        Container::getInstance()->instance('response', $sharedResponse);
+
+        $freshRouter->get('/fresh', fn() => 'fresh body');
+
+        $request = new TestRequestStub('GET', '/fresh', 'localhost');
+        $response = $freshRouter->resolve($this->app, $request);
+
+        $this->assertNotSame($sharedResponse, $response);
+        $this->assertSame('fresh body', $response->getBody());
+        $this->assertNull($response->headers->get('X-Leaked'));
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testViewHelperReturnsFreshResponseInstance(): void
+    {
+        $sharedResponse = new Response('stale body', 202, ['X-Leaked' => 'yes']);
+        $controller = $this->createMock(Controller::class);
+        $controller->expects($this->once())
+            ->method('render')
+            ->with('demo', ['name' => 'Doppar'], true)
+            ->willReturn('<h1>Doppar</h1>');
+
+        Container::getInstance()->instance('response', $sharedResponse);
+        Container::getInstance()->instance(Controller::class, $controller);
+
+        $response = view('demo', ['name' => 'Doppar'], ['X-Test' => 'ok']);
+
+        $this->assertNotSame($sharedResponse, $response);
+        $this->assertSame('<h1>Doppar</h1>', $response->getBody());
+        $this->assertSame('<h1>Doppar</h1>', $response->getOriginal());
+        $this->assertSame('ok', $response->headers->get('X-Test'));
+        $this->assertNull($response->headers->get('X-Leaked'));
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     // =========================================================================


### PR DESCRIPTION
For normal `controller/closure` returns, `Router::resolve()` should use a fresh response instance per resolution instead of mutating `app('response')` in Router. 

Now the issue has been resolved by using proper factory calling and removing previous implementation.