### PR TITLE
Fix: Make JsonResponse use a single response body source

### DIFF
--- a/src/Phaseolies/Http/Response.php
+++ b/src/Phaseolies/Http/Response.php
@@ -1570,20 +1570,45 @@ class Response implements HttpStatus
 
         if (
             is_array($content) ||
-            $content instanceof \JsonSerializable ||
-            $content instanceof \Phaseolies\Database\Entity\Model ||
-            $content instanceof \Phaseolies\Database\Entity\Builder ||
-            $content instanceof \stdClass ||
-            $content instanceof \ArrayObject
+            is_object($content)
         ) {
-            $content = json_encode($content);
-        } elseif ($content instanceof \Phaseolies\Support\Collection || is_object($content)) {
-            $content = json_encode($content->toArray());
+            $content = $this->encodeJsonContent($content);
         }
 
         $this->setBody($content);
 
         return $content;
+    }
+
+    /**
+     * Encode a value for JSON responses without assuming every object has toArray().
+     *
+     * @param mixed $content
+     * @param int $options
+     * @return string
+     */
+    protected function encodeJsonContent(mixed $content, int $options = 0): string
+    {
+        if ($content instanceof \Phaseolies\Support\Collection) {
+            return json_encode($content->toArray(), $options);
+        }
+
+        if (
+            $content instanceof \Phaseolies\Database\Entity\Model ||
+            $content instanceof \Phaseolies\Database\Entity\Builder ||
+            $content instanceof \JsonSerializable ||
+            $content instanceof \stdClass ||
+            $content instanceof \ArrayObject ||
+            is_array($content)
+        ) {
+            return json_encode($content, $options);
+        }
+
+        if (is_object($content) && method_exists($content, 'toArray')) {
+            return json_encode($content->toArray(), $options);
+        }
+
+        return json_encode($content, $options);
     }
 
     /**

--- a/src/Phaseolies/Http/Response/JsonResponse.php
+++ b/src/Phaseolies/Http/Response/JsonResponse.php
@@ -2,17 +2,19 @@
 
 namespace Phaseolies\Http\Response;
 
-use Phaseolies\Http\Response\Stream\StreamedResponse;
+use Phaseolies\Http\Response;
 
-class JsonResponse extends StreamedResponse
+class JsonResponse extends Response
 {
-    private const PLACEHOLDER = '__symfony_json__';
+    // Encode <, >, ', &, and " characters in the JSON, making it also safe to be embedded into HTML.
+    // 15 === JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT
+    public const DEFAULT_ENCODING_OPTIONS = 15;
 
     /**
-     * @param mixed[]                        $data            JSON Data containing PHP generators which will be streamed as list of data or a Generator
-     * @param int                            $status          The HTTP status code (200 "OK" by default)
-     * @param array<string, string|string[]> $headers         An array of HTTP headers
-     * @param int                            $encodingOptions Flags for the json_encode() function
+     * @param mixed $data The payload to encode as JSON.
+     * @param int $status The HTTP status code (200 "OK" by default).
+     * @param array<string, string|string[]> $headers An array of HTTP headers.
+     * @param int $encodingOptions Flags for the json_encode() function.
      */
     public function __construct(
         private readonly mixed $data,
@@ -20,106 +22,38 @@ class JsonResponse extends StreamedResponse
         array $headers = [],
         private int $encodingOptions = self::DEFAULT_ENCODING_OPTIONS,
     ) {
-        parent::__construct($this->stream(...), $status, $headers);
+        parent::__construct(null, $status, $headers);
 
-        $this->prepareBody($data);
+        $this->setOriginal($data);
+        $this->setBody($this->encodePayload($data));
+
         if (!$this->headers->get('Content-Type')) {
             $this->headers->set('Content-Type', 'application/json');
         }
     }
 
-    private function stream(): void
+    /**
+     * Get the original payload assigned to the response.
+     *
+     * @return mixed
+     */
+    public function getData(): mixed
     {
-        $jsonEncodingOptions = \JSON_THROW_ON_ERROR | $this->encodingOptions;
-        $keyEncodingOptions = $jsonEncodingOptions & ~\JSON_NUMERIC_CHECK;
-
-        $this->streamData($this->data, $jsonEncodingOptions, $keyEncodingOptions);
+        return $this->data;
     }
 
-    private function streamData(mixed $data, int $jsonEncodingOptions, int $keyEncodingOptions): void
+    /**
+     * Encode the JSON payload once so the stored body matches what gets sent.
+     *
+     * @param mixed $data
+     * @return string
+     */
+    protected function encodePayload(mixed $data): string
     {
-        if (\is_array($data)) {
-            $this->streamArray($data, $jsonEncodingOptions, $keyEncodingOptions);
-
-            return;
+        if ($data === null) {
+            return json_encode(new \stdClass(), \JSON_THROW_ON_ERROR | $this->encodingOptions);
         }
 
-        if (is_iterable($data) && !$data instanceof \JsonSerializable) {
-            $this->streamIterable($data, $jsonEncodingOptions, $keyEncodingOptions);
-
-            return;
-        }
-
-        echo json_encode($data ?? new \stdClass(), $jsonEncodingOptions);
-    }
-
-    private function streamArray(array $data, int $jsonEncodingOptions, int $keyEncodingOptions): void
-    {
-        $generators = [];
-
-        array_walk_recursive($data, function (&$item, $key) use (&$generators) {
-            if (self::PLACEHOLDER === $key) {
-                // if the placeholder is already in the structure it should be replaced with a new one that explode
-                // works like expected for the structure
-                $generators[] = $key;
-            }
-
-            // generators should be used but for better DX all kind of Traversable and objects are supported
-            if (\is_object($item)) {
-                $generators[] = $item;
-                $item = self::PLACEHOLDER;
-            } elseif (self::PLACEHOLDER === $item) {
-                // if the placeholder is already in the structure it should be replaced with a new one that explode
-                // works like expected for the structure
-                $generators[] = $item;
-            }
-        });
-
-        $jsonParts = explode('"' . self::PLACEHOLDER . '"', json_encode($data, $jsonEncodingOptions));
-
-        foreach ($generators as $index => $generator) {
-            // send first and between parts of the structure
-            echo $jsonParts[$index];
-
-            $this->streamData($generator, $jsonEncodingOptions, $keyEncodingOptions);
-        }
-
-        // send last part of the structure
-        echo $jsonParts[array_key_last($jsonParts)];
-    }
-
-    private function streamIterable(iterable $iterable, int $jsonEncodingOptions, int $keyEncodingOptions): void
-    {
-        $isFirstItem = true;
-        $startTag = '[';
-
-        foreach ($iterable as $key => $item) {
-            if ($isFirstItem) {
-                $isFirstItem = false;
-                // depending on the first elements key the generator is detected as a list or map
-                // we can not check for a whole list or map because that would hurt the performance
-                // of the streamed response which is the main goal of this response class
-                if (0 !== $key) {
-                    $startTag = '{';
-                }
-
-                echo $startTag;
-            } else {
-                // if not first element of the generic, a separator is required between the elements
-                echo ',';
-            }
-
-            if ('{' === $startTag) {
-                echo json_encode((string) $key, $keyEncodingOptions) . ':';
-            }
-
-            $this->streamData($item, $jsonEncodingOptions, $keyEncodingOptions);
-        }
-
-        if ($isFirstItem) { // indicates that the generator was empty
-            echo '[';
-        }
-
-        echo '[' === $startTag ? ']' : '}';
+        return $this->encodeJsonContent($data, \JSON_THROW_ON_ERROR | $this->encodingOptions);
     }
 }

--- a/src/Phaseolies/Http/Response/Stream/StreamedJsonResponse.php
+++ b/src/Phaseolies/Http/Response/Stream/StreamedJsonResponse.php
@@ -62,7 +62,7 @@ class StreamedJsonResponse extends StreamedResponse
     ) {
         parent::__construct($this->stream(...), $status, $headers);
 
-        $this->prepareBody($data);
+        $this->setOriginal($data);
         if (!$this->headers->get('Content-Type')) {
             $this->headers->set('Content-Type', 'application/json');
         }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -4,6 +4,8 @@ namespace Tests\Unit;
 
 use Phaseolies\Http\Response;
 use Phaseolies\Http\Request;
+use Phaseolies\Http\Response\JsonResponse;
+use Phaseolies\Http\Response\Stream\StreamedJsonResponse;
 use Phaseolies\Http\Response\ResponseHeaderBag;
 use Phaseolies\Http\Exceptions\HttpException;
 use PHPUnit\Framework\TestCase;
@@ -128,7 +130,45 @@ class ResponseTest extends TestCase
     public function testJson()
     {
         $jsonResponse = $this->response->json(['test' => 'value'], 201);
-        $this->assertInstanceOf(Response\JsonResponse::class, $jsonResponse);
+        $this->assertInstanceOf(JsonResponse::class, $jsonResponse);
+    }
+
+    public function testJsonResponseUsesBufferedBodyAsSingleSourceOfTruth()
+    {
+        $jsonResponse = $this->response->json(['test' => 'value'], 201);
+
+        ob_start();
+        $jsonResponse->sendContent();
+        $output = ob_get_clean();
+
+        $this->assertSame('{"test":"value"}', $jsonResponse->getBody());
+        $this->assertSame($jsonResponse->getBody(), $output);
+        $this->assertSame('application/json', $jsonResponse->headers->get('Content-Type'));
+    }
+
+    public function testStreamedJsonResponseDoesNotCachePretendBody()
+    {
+        $response = new StreamedJsonResponse([['test' => 'value']]);
+
+        ob_start();
+        $response->sendContent();
+        $output = ob_get_clean();
+
+        $this->assertNull($response->body);
+        $this->assertSame('[{"test":"value"}]', $output);
+    }
+
+    public function testPrepareBodySerializesGenericObjectWithoutToArray()
+    {
+        $payload = new class {
+            public string $name = 'Doppar';
+        };
+
+        $body = $this->response->prepareBody($payload);
+
+        $this->assertSame('{"name":"Doppar"}', $body);
+        $this->assertSame($payload, $this->response->getOriginal());
+        $this->assertSame('{"name":"Doppar"}', $this->response->getBody());
     }
 
     public function testText()


### PR DESCRIPTION
JsonResponse now uses a single buffered body as the source of truth for what gets sent. This removes the old split where the class cached one JSON body while separately streaming another output path.

## What changed
Converted JsonResponse into a buffered JSON response that encodes its payload once and sends that exact body
Kept StreamedJsonResponse as the dedicated streaming JSON path and removed its fake prebuilt body cache
Updated `Response::prepareBody()` so generic objects are no longer assumed to implement `toArray()`

## Why
This makes JSON response behavior more predictable across the request lifecycle:

getBody() now matches the bytes actually sent for normal JSON responses streamed JSON stays truly streamed instead of pretending to have a cached body arbitrary objects no longer risk failing because Doppar blindly calls toArray() on them

## Tests
Added and updated response tests to cover:

1. buffered JsonResponse body matches sent output
2. StreamedJsonResponse does not cache a pretend body
3. generic objects without toArray() serialize safely