### PR TITLE
Fix: Make Response body contract explicitly nullable

### DIFF
--- a/src/Phaseolies/Http/Response.php
+++ b/src/Phaseolies/Http/Response.php
@@ -122,9 +122,9 @@ class Response implements HttpStatus
     /**
      * Get the response body content.
      *
-     * @return string
+     * @return string|null
      */
-    public function getBody(): string
+    public function getBody(): ?string
     {
         return $this->body;
     }

--- a/src/Phaseolies/Support/Facades/Response.php
+++ b/src/Phaseolies/Support/Facades/Response.php
@@ -4,7 +4,7 @@ namespace Phaseolies\Support\Facades;
 
 /**
  * @method static setBody(?string $body): static
- * @method static getBody(): string
+ * @method static getBody(): ?string
  * @method static setOriginal($original): static
  * @method static getOriginal()
  * @method static setCharset(string $charset): static

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -101,6 +101,30 @@ class ResponseTest extends TestCase
         $this->assertStringContainsString('text/html', $this->response->headers->get('Content-Type'));
     }
 
+    public function testPrepareNullsBodyForHeadRequests()
+    {
+        $request = new Request();
+        $request->server->set('SERVER_PROTOCOL', 'HTTP/1.1');
+        $request->server->set('REQUEST_METHOD', 'HEAD');
+
+        $this->response->setBody('Test');
+        $this->response->prepare($request);
+
+        $this->assertNull($this->response->getBody());
+    }
+
+    public function testPrepareNullsBodyForEmptyResponses()
+    {
+        $request = new Request();
+        $request->server->set('SERVER_PROTOCOL', 'HTTP/1.1');
+
+        $this->response->setBody('Test');
+        $this->response->setStatusCode(204);
+        $this->response->prepare($request);
+
+        $this->assertNull($this->response->getBody());
+    }
+
     public function testSendContent()
     {
         $this->response->setBody('Test content');


### PR DESCRIPTION
The Response body contract now matches Doppar’s real runtime behavior.

## What changed

1. Updated Response::getBody() to return ?string
2. Updated the Response facade annotation to reflect the nullable return type
3. Added regression coverage for response preparation paths that intentionally clear the body

## Why
Doppar already allows null response bodies:

## Tests
Added focused response tests to verify:

1. HEAD requests clear the body during prepare()
2. empty responses clear the body during prepare()