### PR TITLE
Harden response lifecycle consistency and add lifecycle regression coverage

### DIFF
--- a/src/Phaseolies/Error/WebErrorRenderer.php
+++ b/src/Phaseolies/Error/WebErrorRenderer.php
@@ -190,13 +190,11 @@ class WebErrorRenderer
             $content = ob_get_clean() ?: '';
 
             return response($content, $statusCode)
-                ->setOriginal($content)
-                ->setStatusCode($statusCode);
+                ->setOriginal($exception);
         }
 
         return response($message, $statusCode)
-            ->setOriginal($message)
-            ->setStatusCode($statusCode);
+            ->setOriginal($exception);
     }
 
     /**

--- a/src/Phaseolies/Helpers/helpers.php
+++ b/src/Phaseolies/Helpers/helpers.php
@@ -189,7 +189,10 @@ if (!function_exists('view')) {
         $instance = app(Controller::class);
         $content = $instance->render($view, $data, true);
 
-        return response($content, 200, $headers)->setOriginal($content);
+        return response($content, 200, $headers)->setOriginal([
+            'view' => $view,
+            'data' => $data,
+        ]);
     }
 }
 
@@ -205,11 +208,13 @@ if (!function_exists('redirect')) {
      */
     function redirect($to = null, $status = 302, $headers = [], $secure = null)
     {
+        $redirect = app(RedirectResponse::class);
+
         if (is_null($to)) {
-            return app('redirect');
+            return $redirect;
         }
 
-        return app('redirect')->to($to, $status, $headers, $secure);
+        return $redirect->to($to, $status, $headers, $secure);
     }
 }
 
@@ -224,7 +229,7 @@ if (!function_exists('back')) {
      */
     function back($status = 302, $headers = [], $fallback = false)
     {
-        return app('redirect')->back($status, $headers, $fallback);
+        return redirect()->back($status, $headers, $fallback);
     }
 }
 

--- a/src/Phaseolies/Helpers/helpers.php
+++ b/src/Phaseolies/Helpers/helpers.php
@@ -208,7 +208,7 @@ if (!function_exists('redirect')) {
      */
     function redirect($to = null, $status = 302, $headers = [], $secure = null)
     {
-        $redirect = app(RedirectResponse::class);
+        $redirect = new RedirectResponse();
 
         if (is_null($to)) {
             return $redirect;

--- a/src/Phaseolies/Http/Response.php
+++ b/src/Phaseolies/Http/Response.php
@@ -192,7 +192,7 @@ class Response implements HttpStatus
      * Set the HTTP status code for the response.
      *
      * @param int $statusCode The HTTP status code.
-     * @return int The updated status code.
+     * @return static
      */
     public function setStatusCode(int $statusCode, ?string $text = null): static
     {

--- a/src/Phaseolies/Http/Response/RedirectResponse.php
+++ b/src/Phaseolies/Http/Response/RedirectResponse.php
@@ -40,6 +40,7 @@ class RedirectResponse extends Response
             throw new \InvalidArgumentException('Cannot redirect to an empty URL.');
         }
 
+        $this->setOriginal($url);
         $this->setBody(
             sprintf('<!DOCTYPE html>
 <html>

--- a/tests/Error/JsonErrorRendererTest.php
+++ b/tests/Error/JsonErrorRendererTest.php
@@ -78,6 +78,7 @@ PHP);
 
         $payload = json_decode($response->getBody(), true);
 
+        $this->assertSame($payload, $response->getOriginal());
         $this->assertSame('Boom', $payload['message']);
         $this->assertIsArray($payload['errors']);
         $this->assertArrayHasKey('trace', $payload['errors']);
@@ -96,6 +97,7 @@ PHP);
 
         $payload = json_decode($response->getBody(), true);
 
+        $this->assertSame($payload, $response->getOriginal());
         $this->assertSame($errors, $payload['errors']);
         $this->assertIsString($payload['message']);
         $this->assertNotSame('', $payload['message']);

--- a/tests/Error/WebErrorRendererTest.php
+++ b/tests/Error/WebErrorRendererTest.php
@@ -24,12 +24,14 @@ class WebErrorRendererTest extends TestCase
     public function testRenderProductionReturnsResponseForGenericException(): void
     {
         $renderer = new WebErrorRenderer();
+        $exception = new RuntimeException('Boom');
 
-        $response = $renderer->renderProduction(new RuntimeException('Boom'));
+        $response = $renderer->renderProduction($exception);
 
         $this->assertInstanceOf(Response::class, $response);
         $this->assertSame(500, $response->getStatusCode());
         $this->assertSame('Something went wrong', $response->getBody());
+        $this->assertSame($exception, $response->getOriginal());
     }
 
     public function testRenderProductionPreservesHttpExceptionStatus(): void
@@ -41,5 +43,6 @@ class WebErrorRendererTest extends TestCase
 
         $this->assertSame(404, $response->getStatusCode());
         $this->assertSame('Not Found', $response->getBody());
+        $this->assertSame($exception, $response->getOriginal());
     }
 }

--- a/tests/RedirectResponseTest.php
+++ b/tests/RedirectResponseTest.php
@@ -67,6 +67,11 @@ class MockRequest
             }
         };
     }
+
+    public function except(...$keys): array
+    {
+        return [];
+    }
 }
 
 class MockMessageBag
@@ -125,6 +130,8 @@ class RedirectResponseTest extends TestCase
         MockRouter::$namedRoutes = [];
 
         $this->setupGlobalMocks();
+        $container->instance('session', $this->session);
+        $container->instance('request', $this->request);
 
         $this->replaceMessageBag();
     }
@@ -198,6 +205,7 @@ class RedirectResponseTest extends TestCase
         $result = $this->redirect->setTargetUrl($url);
 
         $this->assertSame($this->redirect, $result);
+        $this->assertSame($url, $this->redirect->getOriginal());
         $this->assertEquals($url, $this->redirect->headers->get('Location'));
         $this->assertEquals('text/html; charset=utf-8', $this->redirect->headers->get('Content-Type'));
         $this->assertStringContainsString('Redirecting to', $this->redirect->getBody());
@@ -222,6 +230,7 @@ class RedirectResponseTest extends TestCase
 
         $this->assertSame($this->redirect, $result);
         $this->assertEquals($statusCode, $this->redirect->getStatusCode());
+        $this->assertSame($url, $this->redirect->getOriginal());
         $this->assertEquals($url, $this->redirect->headers->get('Location'));
         $this->assertEquals('value', $this->redirect->headers->get('X-Custom'));
     }
@@ -259,6 +268,8 @@ class RedirectResponseTest extends TestCase
 
         $this->assertSame($this->redirect, $result);
         $this->assertEquals(301, $this->redirect->getStatusCode());
+        $this->assertSame($referer, $this->redirect->getOriginal());
+        $this->assertEquals($referer, $this->redirect->headers->get('Location'));
         $this->assertEquals('value', $this->redirect->headers->get('X-Test'));
     }
 
@@ -268,6 +279,7 @@ class RedirectResponseTest extends TestCase
 
         $result = $this->redirect->back();
 
+        $this->assertSame('/', $this->redirect->getOriginal());
         $this->assertEquals('/', $this->redirect->headers->get('Location'));
     }
 
@@ -278,7 +290,9 @@ class RedirectResponseTest extends TestCase
 
         $result = $this->redirect->intended('/default');
 
-        $this->assertEquals($intendedUrl, $this->session->get('url.intended'));
+        $this->assertSame($intendedUrl, $this->redirect->getOriginal());
+        $this->assertEquals($intendedUrl, $this->redirect->headers->get('Location'));
+        $this->assertNull($this->session->get('url.intended'));
     }
 
     public function testIntendedMethodWithoutStoredUrl()
@@ -286,6 +300,7 @@ class RedirectResponseTest extends TestCase
         $defaultUrl = '/dashboard';
         $result = $this->redirect->intended($defaultUrl, 301);
 
+        $this->assertSame($defaultUrl, $this->redirect->getOriginal());
         $this->assertEquals($defaultUrl, $this->redirect->headers->get('Location'));
         $this->assertEquals(301, $this->redirect->getStatusCode());
     }
@@ -297,6 +312,7 @@ class RedirectResponseTest extends TestCase
         $result = $this->redirect->away($externalUrl, 301);
 
         $this->assertSame($this->redirect, $result);
+        $this->assertSame($externalUrl, $this->redirect->getOriginal());
         $this->assertEquals($externalUrl, $this->redirect->headers->get('Location'));
         $this->assertEquals(301, $this->redirect->getStatusCode());
     }

--- a/tests/ResponseLifecycleTest.php
+++ b/tests/ResponseLifecycleTest.php
@@ -1,0 +1,286 @@
+<?php
+
+namespace Tests\Unit;
+
+require_once __DIR__ . '/Support/MockContainer.php';
+
+use Mockery;
+use Phaseolies\Application;
+use Phaseolies\DI\Container;
+use Phaseolies\Error\JsonErrorRenderer;
+use Phaseolies\Http\Controllers\Controller;
+use Phaseolies\Http\Exceptions\HttpResponseException;
+use Phaseolies\Http\Request;
+use Phaseolies\Http\Response;
+use Phaseolies\Http\Response\RedirectResponse;
+use Phaseolies\Http\Support\RequestAbortion;
+use Phaseolies\Support\Router;
+use Phaseolies\Support\Session;
+use Phaseolies\Translation\FileLoader;
+use Phaseolies\Translation\Translator;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\Kernel;
+use Tests\Support\MockContainer;
+
+if (!class_exists('App\Http\Kernel')) {
+    class_alias(Kernel::class, 'App\Http\Kernel');
+}
+
+class LifecycleRouteRequestStub extends Request
+{
+    private string $testMethod;
+    private string $testPath;
+    private string $testHost;
+    private array $testRouteParams = [];
+
+    public function __construct(string $method, string $path, string $host)
+    {
+        $this->testMethod = strtoupper($method);
+        $this->testPath = $path;
+        $this->testHost = $host;
+    }
+
+    public function getMethod(): string
+    {
+        return $this->testMethod;
+    }
+
+    public function getPath(): string
+    {
+        return $this->testPath;
+    }
+
+    public function getHost(): string
+    {
+        return $this->testHost;
+    }
+
+    public function getRouteParams(): array
+    {
+        return $this->testRouteParams;
+    }
+
+    public function setRouteParams(array $params): self
+    {
+        $this->testRouteParams = $params;
+
+        return $this;
+    }
+}
+
+class LifecycleTestableRouter extends Router
+{
+    public function handle(Request $request, \Closure $handler): Response
+    {
+        return $handler($request);
+    }
+}
+
+class ResponseLifecycleTest extends TestCase
+{
+    private MockContainer $container;
+    private string $translationPath;
+    private array $originalServer;
+    private array $originalGet;
+    private array $originalPost;
+    private array $originalSession;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalServer = $_SERVER ?? [];
+        $this->originalGet = $_GET ?? [];
+        $this->originalPost = $_POST ?? [];
+        $this->originalSession = $_SESSION ?? [];
+
+        $_SERVER = [];
+        $_GET = [];
+        $_POST = [];
+        $_SESSION = [];
+
+        $this->container = new MockContainer();
+        Container::setInstance($this->container);
+
+        $this->translationPath = sys_get_temp_dir() . '/phaseolies_response_lifecycle_lang_' . uniqid();
+        mkdir($this->translationPath . '/en', 0777, true);
+        file_put_contents($this->translationPath . '/en/validation.php', <<<'PHP'
+<?php
+
+return [
+    'default' => 'Validation failed.',
+    'rate_limit' => ['message' => 'Too many requests.'],
+    'unauthorized' => ['message' => 'Unauthorized.'],
+    'required' => 'The :attribute field is required.',
+];
+PHP);
+
+        $this->container->bind('translator', fn() => new Translator(new FileLoader($this->translationPath), 'en'));
+        $this->container->bind('session', Session::class);
+        $this->container->instance('session', new Session());
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        $this->deleteDir($this->translationPath);
+
+        $_SERVER = $this->originalServer;
+        $_GET = $this->originalGet;
+        $_POST = $this->originalPost;
+        $_SESSION = $this->originalSession;
+
+        parent::tearDown();
+    }
+
+    public function testControllerReturnAndResponseHelperProduceSameJsonLifecycleOutput(): void
+    {
+        $payload = ['framework' => 'Doppar', 'version' => 3];
+        $app = $this->createStub(Application::class);
+        $router = new LifecycleTestableRouter($app);
+
+        $router->get('/payload', fn() => $payload);
+
+        $request = new LifecycleRouteRequestStub('GET', '/payload', 'localhost');
+
+        $routeResponse = $router->resolve($app, $request);
+        $helperResponse = response($payload);
+
+        $this->assertSame(200, $routeResponse->getStatusCode());
+        $this->assertSame(200, $helperResponse->getStatusCode());
+        $this->assertSame('application/json', $routeResponse->headers->get('Content-Type'));
+        $this->assertSame('application/json', $helperResponse->headers->get('Content-Type'));
+        $this->assertSame($payload, $routeResponse->getOriginal());
+        $this->assertSame($payload, $helperResponse->getOriginal());
+        $this->assertSame($helperResponse->getBody(), $routeResponse->getBody());
+    }
+
+    public function testHeadPreparationStripsBodyForControllerAndHelperJsonResponses(): void
+    {
+        $payload = ['framework' => 'Doppar'];
+        $app = $this->createStub(Application::class);
+        $router = new LifecycleTestableRouter($app);
+
+        $router->get('/payload', fn() => $payload);
+
+        $routeRequest = new LifecycleRouteRequestStub('GET', '/payload', 'localhost');
+        $routeResponse = $router->resolve($app, $routeRequest);
+        $helperResponse = response($payload);
+
+        $_SERVER['REQUEST_METHOD'] = 'HEAD';
+        $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
+        $headRequest = new Request();
+
+        $routeResponse->prepare($headRequest);
+        $helperResponse->prepare($headRequest);
+
+        $this->assertNull($routeResponse->getBody());
+        $this->assertNull($helperResponse->getBody());
+        $this->assertSame('application/json', $routeResponse->headers->get('Content-Type'));
+        $this->assertSame('application/json', $helperResponse->headers->get('Content-Type'));
+    }
+
+    public function testAbortJsonBranchReturnsPreparedJsonResponse(): void
+    {
+        $request = Mockery::mock(Request::class);
+        $request->shouldReceive('isAjax')->andReturn(true);
+        $request->shouldReceive('isApiRequest')->andReturn(false);
+        $this->container->instance('request', $request);
+
+        $abortion = new RequestAbortion();
+
+        try {
+            $abortion->abort(403, 'Forbidden');
+            $this->fail('Expected HttpResponseException was not thrown.');
+        } catch (HttpResponseException $exception) {
+            $response = $exception->getResponse();
+            $payload = json_decode($response?->getBody() ?? '', true);
+
+            $this->assertNotNull($response);
+            $this->assertSame(403, $response->getStatusCode());
+            $this->assertSame('application/json', $response->headers->get('Content-Type'));
+            $this->assertSame($payload, $response->getOriginal());
+            $this->assertSame('Forbidden', $payload['message']);
+            $this->assertIsArray($payload['errors']);
+        }
+    }
+
+    public function testValidationRedirectBranchReturnsPreparedRedirectResponse(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_SERVER['REQUEST_URI'] = '/submit';
+        $_SERVER['HTTP_REFERER'] = '/form';
+        $_POST = [];
+
+        $request = new Request();
+        $this->container->instance('request', $request);
+
+        try {
+            $request->sanitize(['email' => 'required']);
+            $this->fail('Expected HttpResponseException was not thrown.');
+        } catch (HttpResponseException $exception) {
+            $response = $exception->getResponse();
+
+            $this->assertInstanceOf(RedirectResponse::class, $response);
+            $this->assertSame(302, $response->getStatusCode());
+            $this->assertSame('/form', $response->headers->get('Location'));
+            $this->assertSame('/form', $response->getOriginal());
+            $this->assertArrayHasKey('email', $this->container->get('session')->get('errors'));
+            $this->assertSame([], $this->container->get('session')->get('input'));
+        }
+    }
+
+    public function testViewJsonAndRedirectHelpersDoNotReuseStaleSharedInstances(): void
+    {
+        $sharedResponse = new Response('stale body', 202, ['X-Leaked' => 'yes']);
+        $sharedRedirect = (new RedirectResponse())->to('/old', 302, ['X-Redirect-Leaked' => 'yes']);
+        $controller = $this->createMock(Controller::class);
+
+        $controller->expects($this->once())
+            ->method('render')
+            ->with('demo', ['name' => 'Doppar'], true)
+            ->willReturn('<h1>Doppar</h1>');
+
+        $this->container->instance('response', $sharedResponse);
+        $this->container->instance('redirect', $sharedRedirect);
+        $this->container->instance(Controller::class, $controller);
+
+        $viewResponse = view('demo', ['name' => 'Doppar']);
+        $jsonResponse = response(['fresh' => true]);
+        $redirectResponse = redirect('/fresh');
+
+        $this->assertNotSame($sharedResponse, $viewResponse);
+        $this->assertNotSame($sharedResponse, $jsonResponse);
+        $this->assertNotSame($sharedRedirect, $redirectResponse);
+
+        $this->assertNull($viewResponse->headers->get('X-Leaked'));
+        $this->assertNull($jsonResponse->headers->get('X-Leaked'));
+        $this->assertNull($redirectResponse->headers->get('X-Redirect-Leaked'));
+
+        $this->assertSame([
+            'view' => 'demo',
+            'data' => ['name' => 'Doppar'],
+        ], $viewResponse->getOriginal());
+        $this->assertSame(['fresh' => true], $jsonResponse->getOriginal());
+        $this->assertSame('/fresh', $redirectResponse->getOriginal());
+        $this->assertSame('/fresh', $redirectResponse->headers->get('Location'));
+    }
+
+    private function deleteDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($files as $file) {
+            $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+        }
+
+        @rmdir($dir);
+    }
+}

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -5,9 +5,11 @@ namespace Tests\Unit;
 use Phaseolies\Http\Response;
 use Phaseolies\Http\Request;
 use Phaseolies\Http\Response\JsonResponse;
+use Phaseolies\Http\Response\RedirectResponse;
 use Phaseolies\Http\Response\Stream\StreamedJsonResponse;
 use Phaseolies\Http\Response\ResponseHeaderBag;
 use Phaseolies\Http\Exceptions\HttpException;
+use Phaseolies\DI\Container;
 use PHPUnit\Framework\TestCase;
 
 class ResponseTest extends TestCase
@@ -170,6 +172,19 @@ class ResponseTest extends TestCase
         $this->assertSame('application/json', $jsonResponse->headers->get('Content-Type'));
     }
 
+    public function testJsonResponsePrepareNullsBodyForHeadRequests()
+    {
+        $jsonResponse = $this->response->json(['test' => 'value'], 200);
+        $request = new Request();
+        $request->server->set('SERVER_PROTOCOL', 'HTTP/1.1');
+        $request->server->set('REQUEST_METHOD', 'HEAD');
+
+        $jsonResponse->prepare($request);
+
+        $this->assertNull($jsonResponse->getBody());
+        $this->assertSame('application/json', $jsonResponse->headers->get('Content-Type'));
+    }
+
     public function testStreamedJsonResponseDoesNotCachePretendBody()
     {
         $response = new StreamedJsonResponse([['test' => 'value']]);
@@ -201,6 +216,43 @@ class ResponseTest extends TestCase
         $this->assertEquals('Plain text', $response->getBody());
         $this->assertEquals('Value', $response->headers->get('X-Test'));
         $this->assertEquals('text/plain', $response->headers->get('Content-Type'));
+    }
+
+    public function testRedirectHelperSetsOriginalToTargetUrl()
+    {
+        $response = redirect('/dashboard');
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame('/dashboard', $response->getOriginal());
+        $this->assertSame('/dashboard', $response->headers->get('Location'));
+    }
+
+    public function testBackHelperSetsOriginalToPreviousUrl()
+    {
+        $container = new Container();
+        Container::setInstance($container);
+
+        $request = new Request();
+        $request->headers->set('referer', '/previous');
+        $container->instance('request', $request);
+
+        $response = back();
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame('/previous', $response->getOriginal());
+        $this->assertSame('/previous', $response->headers->get('Location'));
+    }
+
+    public function testRedirectHelperReturnsFreshInstancesWithoutHeaderLeakage()
+    {
+        $first = redirect('/first', 302, ['X-Test' => 'first']);
+        $second = redirect('/second');
+
+        $this->assertNotSame($first, $second);
+        $this->assertSame('/first', $first->getOriginal());
+        $this->assertSame('/second', $second->getOriginal());
+        $this->assertSame('first', $first->headers->get('X-Test'));
+        $this->assertNull($second->headers->get('X-Test'));
     }
 
     public function testIsNotCacheable()

--- a/tests/Router/RouterTest.php
+++ b/tests/Router/RouterTest.php
@@ -237,7 +237,7 @@ class RouterTest extends TestCase
 
         $request = new Request();
         $container = Container::getInstance();
-        $container->bind('request', fn() => $request);
+        $container->instance('request', $request);
 
         $result = $this->router->any('/test', $callback);
 
@@ -458,7 +458,10 @@ class RouterTest extends TestCase
 
         $this->assertNotSame($sharedResponse, $response);
         $this->assertSame('<h1>Doppar</h1>', $response->getBody());
-        $this->assertSame('<h1>Doppar</h1>', $response->getOriginal());
+        $this->assertSame([
+            'view' => 'demo',
+            'data' => ['name' => 'Doppar'],
+        ], $response->getOriginal());
         $this->assertSame('ok', $response->headers->get('X-Test'));
         $this->assertNull($response->headers->get('X-Leaked'));
         $this->assertSame(200, $response->getStatusCode());


### PR DESCRIPTION
This PR tightens Doppar’s request/response lifecycle so response semantics stay consistent across normal, redirect, JSON, view, and error flows.

## What changed

1. Made redirect responses consistently store the final target URL in original
2. Kept view responses semantic by storing ['view' => ..., 'data' => ...] in original
3. Kept production web error responses tied to the triggering exception in original
4. Fixed the redirect() helper to always return a fresh RedirectResponse instance instead of reusing a stale resolved redirect singleton
5. Added a focused lifecycle regression suite covering controller JSON, helper JSON, HEAD handling, abort JSON responses, validation redirect responses, and stale instance leakage checks.

## Why
The framework already had the right high-level lifecycle shape, but some response branches were still inconsistent about:

1. what goes into original
2. whether helpers reuse stale response instances
3. whether equivalent response paths behave the same under preparation and error handling

This PR makes those paths behave more predictably and adds regression coverage around the lifecycle edges that were easiest to break.