### PR TITLE
Add ghostable providers for lazy-loading framework services

### DIFF
--- a/src/Phaseolies/Application.php
+++ b/src/Phaseolies/Application.php
@@ -4,6 +4,7 @@ namespace Phaseolies;
 
 use Phaseolies\Auth\ActorManager;
 use Phaseolies\Support\Router;
+use Phaseolies\Providers\GhostableProvider;
 use Phaseolies\Providers\ServiceProvider;
 use Phaseolies\Http\DispatchResult;
 use Phaseolies\Http\Response;
@@ -128,11 +129,53 @@ class Application extends Container
     protected $serviceProviders = [];
 
     /**
+     * The queued ghost providers keyed by class name.
+     *
+     * @var array<class-string<ServiceProvider>, ServiceProvider>
+     */
+    protected array $ghostProviders = [];
+
+    /**
+     * Map of service identifiers to ghost provider classes.
+     *
+     * @var array<string, class-string<ServiceProvider>>
+     */
+    protected array $ghostServices = [];
+
+    /**
+     * Tracks ghost providers that have already been loaded.
+     *
+     * @var array<class-string<ServiceProvider>, true>
+     */
+    protected array $loadedGhostProviders = [];
+
+    /**
+     * Tracks ghost providers currently being loaded.
+     *
+     * @var array<class-string<ServiceProvider>, true>
+     */
+    protected array $loadingGhostProviders = [];
+
+    /**
      * Indicates if the providers has been booted
      *
      * @var bool
      */
     protected $providersBooted = false;
+
+    /**
+     * Indicates if the application is currently booting eager providers.
+     *
+     * @var bool
+     */
+    protected bool $bootingProviders = false;
+
+    /**
+     * Tracks providers whose boot method has already run.
+     *
+     * @var array<class-string<ServiceProvider>, true>
+     */
+    protected array $bootedProviderClasses = [];
 
     /**
      * @var Router
@@ -304,10 +347,61 @@ class Application extends Container
     {
         foreach ($providers as $provider) {
             $providerInstance = new $provider($this);
+
             if ($providerInstance instanceof ServiceProvider) {
-                $providerInstance->register();
-                $this->serviceProviders[] = $providerInstance;
+                if ($this->shouldQueueGhostProvider($providerInstance)) {
+                    $this->queueGhostProvider($providerInstance);
+                    continue;
+                }
+
+                $this->registerProviderInstance($providerInstance);
             }
+        }
+    }
+
+    /**
+     * Determine if the provider should be queued as a ghost provider
+     *
+     * @param ServiceProvider $providerInstance
+     * @return bool
+     */
+    protected function shouldQueueGhostProvider(ServiceProvider $providerInstance): bool
+    {
+        return !$this->runningInConsole() && $providerInstance instanceof GhostableProvider;
+    }
+
+    /**
+     * Register and track an eager provider instance.
+     *
+     * @param ServiceProvider $providerInstance
+     * @return void
+     */
+    protected function registerProviderInstance(ServiceProvider $providerInstance): void
+    {
+        $providerInstance->register();
+
+        $this->serviceProviders[] = $providerInstance;
+    }
+
+    /**
+     * Queue a ghost provider until one of its services is requested.
+     *
+     * @param ServiceProvider $providerInstance
+     * @return void
+     */
+    protected function queueGhostProvider(ServiceProvider $providerInstance): void
+    {
+        /** @var GhostableProvider $providerInstance */
+        $providerClass = $providerInstance::class;
+
+        $this->ghostProviders[$providerClass] = $providerInstance;
+
+        foreach ($providerInstance->ghosts() as $ghost) {
+            if (!is_string($ghost) || $ghost === '') {
+                continue;
+            }
+
+            $this->ghostServices[$ghost] = $providerClass;
         }
     }
 
@@ -334,8 +428,14 @@ class Application extends Container
      */
     protected function bootProviders(): void
     {
-        foreach ($this->serviceProviders as $providerInstance) {
-            $providerInstance->boot();
+        $this->bootingProviders = true;
+
+        try {
+            foreach ($this->serviceProviders as $providerInstance) {
+                $this->bootProviderInstance($providerInstance);
+            }
+        } finally {
+            $this->bootingProviders = false;
         }
 
         $this->bootstrap();
@@ -728,6 +828,81 @@ class Application extends Container
         }
 
         return null;
+    }
+
+    /**
+     * Determine if the application has a binding or queued ghost for the given service.
+     *
+     * @param string $key
+     * @return bool
+     */
+    public function has(string $key): bool
+    {
+        return parent::has($key) || isset($this->ghostServices[$key]);
+    }
+
+    /**
+     * Load a queued ghost provider when one of its services is requested.
+     *
+     * @param string $abstract
+     * @return bool
+     */
+    public function loadGhostProvider(string $abstract): bool
+    {
+        $providerClass = $this->ghostServices[$abstract] ?? null;
+
+        if ($providerClass === null) {
+            return false;
+        }
+
+        if (isset($this->loadedGhostProviders[$providerClass]) || isset($this->loadingGhostProviders[$providerClass])) {
+            return true;
+        }
+
+        $providerInstance = $this->ghostProviders[$providerClass] ?? null;
+
+        if (!$providerInstance instanceof ServiceProvider) {
+            return false;
+        }
+
+        $this->loadingGhostProviders[$providerClass] = true;
+
+        foreach (($providerInstance instanceof GhostableProvider ? $providerInstance->ghosts() : []) as $ghost) {
+            unset($this->ghostServices[$ghost]);
+        }
+
+        try {
+            $this->registerProviderInstance($providerInstance);
+
+            if ($this->providersBooted || $this->bootingProviders) {
+                $this->bootProviderInstance($providerInstance);
+            }
+
+            $this->loadedGhostProviders[$providerClass] = true;
+
+            return true;
+        } finally {
+            unset($this->loadingGhostProviders[$providerClass], $this->ghostProviders[$providerClass]);
+        }
+    }
+
+    /**
+     * Boot a provider instance once.
+     *
+     * @param ServiceProvider $providerInstance
+     * @return void
+     */
+    protected function bootProviderInstance(ServiceProvider $providerInstance): void
+    {
+        $providerClass = $providerInstance::class;
+
+        if (isset($this->bootedProviderClasses[$providerClass])) {
+            return;
+        }
+
+        $providerInstance->boot();
+
+        $this->bootedProviderClasses[$providerClass] = true;
     }
 
     /**

--- a/src/Phaseolies/DI/Container.php
+++ b/src/Phaseolies/DI/Container.php
@@ -166,6 +166,14 @@ class Container implements ArrayAccess
         $this->resolving[$abstract] = true;
 
         try {
+            if (
+                !isset(self::$bindings[$abstract]) &&
+                !array_key_exists($abstract, self::$instances) &&
+                method_exists($this, 'loadGhostProvider')
+            ) {
+                $this->loadGhostProvider($abstract);
+            }
+
             if (isset(self::$instances[$abstract]) && self::$instances[$abstract] !== null) {
                 return self::$instances[$abstract];
             }

--- a/src/Phaseolies/DI/Container.php
+++ b/src/Phaseolies/DI/Container.php
@@ -163,17 +163,17 @@ class Container implements ArrayAccess
             throw new \RuntimeException("Circular dependency detected while resolving [{$abstract}]");
         }
 
+        if (
+            !isset(self::$bindings[$abstract]) &&
+            !array_key_exists($abstract, self::$instances) &&
+            method_exists($this, 'loadGhostProvider')
+        ) {
+            $this->loadGhostProvider($abstract);
+        }
+
         $this->resolving[$abstract] = true;
 
         try {
-            if (
-                !isset(self::$bindings[$abstract]) &&
-                !array_key_exists($abstract, self::$instances) &&
-                method_exists($this, 'loadGhostProvider')
-            ) {
-                $this->loadGhostProvider($abstract);
-            }
-
             if (isset(self::$instances[$abstract]) && self::$instances[$abstract] !== null) {
                 return self::$instances[$abstract];
             }

--- a/src/Phaseolies/Providers/CacheServiceProvider.php
+++ b/src/Phaseolies/Providers/CacheServiceProvider.php
@@ -8,10 +8,11 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
 use Psr\SimpleCache\CacheInterface;
 use Phaseolies\Providers\ServiceProvider;
+use Phaseolies\Providers\GhostableProvider;
 use Phaseolies\Cache\CacheStore;
 use Phaseolies\Cache\IncrementableCacheInterface;
 
-class CacheServiceProvider extends ServiceProvider
+class CacheServiceProvider extends ServiceProvider implements GhostableProvider
 {
     /**
      * @var \Closure[] Custom adapter factories
@@ -157,5 +158,20 @@ class CacheServiceProvider extends ServiceProvider
     public function boot()
     {
         //
+    }
+
+    /**
+     * Get the services that should ghost-load this provider.
+     *
+     * @return array<int, string>
+     */
+    public function ghosts(): array
+    {
+        return [
+            CacheStore::class,
+            IncrementableCacheInterface::class,
+            CacheInterface::class,
+            'cache',
+        ];
     }
 }

--- a/src/Phaseolies/Providers/GhostableProvider.php
+++ b/src/Phaseolies/Providers/GhostableProvider.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Phaseolies\Providers;
+
+interface GhostableProvider
+{
+    /**
+     * Get the service identifiers that should trigger loading this provider.
+     *
+     * @return array<int, string>
+     */
+    public function ghosts(): array;
+}

--- a/src/Phaseolies/Providers/LanguageServiceProvider.php
+++ b/src/Phaseolies/Providers/LanguageServiceProvider.php
@@ -6,8 +6,9 @@ use Phaseolies\Support\Facades\Lang;
 use Phaseolies\Translation\FileLoader;
 use Phaseolies\Translation\Translator;
 use Phaseolies\Providers\ServiceProvider;
+use Phaseolies\Providers\GhostableProvider;
 
-class LanguageServiceProvider extends ServiceProvider
+class LanguageServiceProvider extends ServiceProvider implements GhostableProvider
 {
     /**
      * Register the service provider.
@@ -54,5 +55,18 @@ class LanguageServiceProvider extends ServiceProvider
     public function boot()
     {
         Lang::setFacadeApplication($this->app);
+    }
+
+    /**
+     * Get the services that should ghost-load this provider.
+     *
+     * @return array<int, string>
+     */
+    public function ghosts(): array
+    {
+        return [
+            'translation.loader',
+            'translator',
+        ];
     }
 }

--- a/src/Phaseolies/Providers/RateLimiterServiceProvider.php
+++ b/src/Phaseolies/Providers/RateLimiterServiceProvider.php
@@ -3,10 +3,11 @@
 namespace Phaseolies\Providers;
 
 use Phaseolies\Providers\ServiceProvider;
+use Phaseolies\Providers\GhostableProvider;
 use Phaseolies\Cache\IncrementableCacheInterface;
 use Phaseolies\Cache\RateLimiter;
 
-class RateLimiterServiceProvider extends ServiceProvider
+class RateLimiterServiceProvider extends ServiceProvider implements GhostableProvider
 {
     /**
      * Register the service provider.
@@ -28,5 +29,17 @@ class RateLimiterServiceProvider extends ServiceProvider
     public function boot()
     {
         //
+    }
+
+    /**
+     * Get the services that should ghost-load this provider.
+     *
+     * @return array<int, string>
+     */
+    public function ghosts(): array
+    {
+        return [
+            RateLimiter::class,
+        ];
     }
 }

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -16,6 +16,7 @@ use Phaseolies\Http\Response\RedirectResponse;
 use Phaseolies\Support\Router;
 use Phaseolies\Support\Session;
 use Phaseolies\Console\Console;
+use Tests\Application\Mock\Providers\GhostableTestProvider;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Phaseolies\Support\StringService;
@@ -96,6 +97,7 @@ final class ApplicationTest extends TestCase
 
     protected function tearDown(): void
     {
+        GhostableTestProvider::resetState();
         $this->deleteDirectory($this->tempBasePath);
     }
 
@@ -214,6 +216,56 @@ final class ApplicationTest extends TestCase
         $this->assertIsArray($providers);
         $this->assertContains(\Phaseolies\Providers\RouteServiceProvider::class, $providers);
         $this->assertContains(\Phaseolies\Providers\LanguageServiceProvider::class, $providers);
+    }
+
+    public function testGhostableProvidersAreQueuedOutsideConsole(): void
+    {
+        GhostableTestProvider::resetState();
+
+        $this->setProtectedProperty($this->app, 'isRunningInConsole', false);
+
+        $this->callProtectedMethod($this->app, 'registerProviders', [
+            [GhostableTestProvider::class],
+        ]);
+
+        $this->assertTrue($this->app->has('ghost.service'));
+        $this->assertSame([], $this->app->getProviders());
+        $this->assertSame(0, GhostableTestProvider::$registerCount);
+    }
+
+    public function testGhostServiceResolutionLoadsQueuedProviderAndBootsIt(): void
+    {
+        GhostableTestProvider::resetState();
+
+        $this->setProtectedProperty($this->app, 'isRunningInConsole', false);
+        $this->setProtectedProperty($this->app, 'providersBooted', true);
+
+        $this->callProtectedMethod($this->app, 'registerProviders', [
+            [GhostableTestProvider::class],
+        ]);
+
+        $this->assertSame('ghost-value', $this->app->make('ghost.service'));
+        $this->assertSame('booted', $this->app->make('ghost.booted'));
+        $this->assertSame(1, GhostableTestProvider::$registerCount);
+        $this->assertSame(1, GhostableTestProvider::$bootCount);
+        $this->assertInstanceOf(
+            GhostableTestProvider::class,
+            $this->app->getProvider(GhostableTestProvider::class)
+        );
+    }
+
+    public function testGhostableProvidersRemainEagerInConsole(): void
+    {
+        GhostableTestProvider::resetState();
+
+        $this->setProtectedProperty($this->app, 'isRunningInConsole', true);
+
+        $this->callProtectedMethod($this->app, 'registerProviders', [
+            [GhostableTestProvider::class],
+        ]);
+
+        $this->assertSame(1, GhostableTestProvider::$registerCount);
+        $this->assertCount(1, $this->app->getProviders());
     }
 
     public function testSingletonBindings(): void

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -63,6 +63,7 @@ final class ApplicationTest extends TestCase
     protected function setUp(): void
     {
         $container = new Container();
+        $container->flush();
         $container->bind('config', fn() => Config::class);
 
         // Create a temporary directory structure
@@ -98,6 +99,8 @@ final class ApplicationTest extends TestCase
     protected function tearDown(): void
     {
         GhostableTestProvider::resetState();
+        $this->app->flush();
+        Container::forgetInstance();
         $this->deleteDirectory($this->tempBasePath);
     }
 
@@ -252,6 +255,21 @@ final class ApplicationTest extends TestCase
             GhostableTestProvider::class,
             $this->app->getProvider(GhostableTestProvider::class)
         );
+    }
+
+    public function testGhostServiceCanBeResolvedDuringProviderRegistration(): void
+    {
+        GhostableTestProvider::resetState();
+        GhostableTestProvider::$resolveDuringRegister = true;
+
+        $this->setProtectedProperty($this->app, 'isRunningInConsole', false);
+
+        $this->callProtectedMethod($this->app, 'registerProviders', [
+            [GhostableTestProvider::class],
+        ]);
+
+        $this->assertSame('ghost-value', $this->app->make('ghost.service'));
+        $this->assertSame(1, GhostableTestProvider::$registerCount);
     }
 
     public function testGhostableProvidersRemainEagerInConsole(): void

--- a/tests/Application/Mock/Providers/GhostableTestProvider.php
+++ b/tests/Application/Mock/Providers/GhostableTestProvider.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Application\Mock\Providers;
+
+use Phaseolies\Providers\ServiceProvider;
+use Phaseolies\Providers\GhostableProvider;
+
+class GhostableTestProvider extends ServiceProvider implements GhostableProvider
+{
+    public static int $registerCount = 0;
+    public static int $bootCount = 0;
+
+    public static function resetState(): void
+    {
+        self::$registerCount = 0;
+        self::$bootCount = 0;
+    }
+
+    public function register(): void
+    {
+        self::$registerCount++;
+
+        $this->app->singleton('ghost.service', fn() => 'ghost-value');
+    }
+
+    public function boot(): void
+    {
+        self::$bootCount++;
+
+        $this->app->singleton('ghost.booted', fn() => 'booted');
+    }
+
+    public function ghosts(): array
+    {
+        return [
+            'ghost.service',
+        ];
+    }
+}

--- a/tests/Application/Mock/Providers/GhostableTestProvider.php
+++ b/tests/Application/Mock/Providers/GhostableTestProvider.php
@@ -9,11 +9,13 @@ class GhostableTestProvider extends ServiceProvider implements GhostableProvider
 {
     public static int $registerCount = 0;
     public static int $bootCount = 0;
+    public static bool $resolveDuringRegister = false;
 
     public static function resetState(): void
     {
         self::$registerCount = 0;
         self::$bootCount = 0;
+        self::$resolveDuringRegister = false;
     }
 
     public function register(): void
@@ -21,6 +23,10 @@ class GhostableTestProvider extends ServiceProvider implements GhostableProvider
         self::$registerCount++;
 
         $this->app->singleton('ghost.service', fn() => 'ghost-value');
+
+        if (self::$resolveDuringRegister) {
+            $this->app->make('ghost.service');
+        }
     }
 
     public function boot(): void


### PR DESCRIPTION
This PR adds ghostable provider support so selected service providers can be queued during app startup and only loaded when one of their declared services is actually resolved outside the console.

It introduces a new `GhostableProvider` contract, updates `Application` and `Container` to track and load queued ghost providers safely, and keeps console execution on the existing eager-loading path. The `cache`, `language`, and `rate limiter` providers are now marked as ghostable with their trigger services, and application tests were added to cover queued loading, lazy resolution with boot execution, and console-mode eager registration.