### PR TITLE
Fix lazy bindToMany relation caching to match eager-loaded collections

### DIFF
--- a/src/Phaseolies/Database/Entity/Model.php
+++ b/src/Phaseolies/Database/Entity/Model.php
@@ -1019,6 +1019,7 @@ abstract class Model implements Jsonable, \ArrayAccess, \JsonSerializable, \Stri
 
                         case 'bindToMany':
                             $relatedModel = app($this->getLastRelatedModel());
+                            $relatedModelClass = get_class($relatedModel);
                             $pivotColumns = app('db')->getTableColumns($this->getLastPivotTable());
                             $pivotTable = $this->getLastPivotTable();
                             $pivotSelects = array_map(function ($column) use ($pivotTable) {
@@ -1050,7 +1051,11 @@ abstract class Model implements Jsonable, \ArrayAccess, \JsonSerializable, \Stri
                                 $result->pivot = $pivotObj;
                                 $grouped[$pivot[$this->getLastForeignKey()]][] = $result;
                             }
-                            $this->setRelation($name, $grouped);
+
+                            $this->setRelation(
+                                $name,
+                                new Collection($relatedModelClass, $grouped[$this->getKey()] ?? [])
+                            );
 
                             return $results;
                     }

--- a/tests/Model/Query/EntityModelQueryBehavior.php
+++ b/tests/Model/Query/EntityModelQueryBehavior.php
@@ -2563,12 +2563,15 @@ abstract class EntityModelQueryTest extends ModelQueryDriverTestCase
         $post = MockPost::find(1);
         $post->tags()->relate([1, 2, 3]);
         $this->assertEquals([1, 2, 3], $post->tags->pluck('id')->sort()->values()->toArray());
-        $this->assertCount(1, $post->tags);
+        $this->assertCount(3, $post->tags);
 
         $changes = $post->tags()->relate([1, 2, 4]);
         $this->assertEquals([4], array_keys($changes['attached']));
-        $this->assertEquals([2], array_keys($changes['detached']));
+        $this->assertEquals([3], array_values($changes['detached']));
         $this->assertEquals([], $changes['updated']);
+
+        $post = MockPost::find(1);
+        $this->assertEquals([1, 2, 4], $post->tags->pluck('id')->sort()->values()->toArray());
     }
 
     public function testRepairMethodFetchingRecords()

--- a/tests/Model/Query/EntityRelationshipBehavior.php
+++ b/tests/Model/Query/EntityRelationshipBehavior.php
@@ -229,6 +229,24 @@ abstract class EntityRelationshipTest extends ModelQueryDriverTestCase
     }
 
     /**
+     * Re-reading a lazy bindToMany relation should return the cached collection,
+     * not the internal grouped array keyed by the pivot foreign key.
+     */
+    public function testBindToManyLazyLoadCachesCollectionForRepeatedAccess(): void
+    {
+        $post = MockPost::find(1);
+
+        $firstRead = $post->tags;
+        $secondRead = $post->tags;
+
+        $this->assertInstanceOf(Collection::class, $firstRead);
+        $this->assertInstanceOf(Collection::class, $secondRead);
+        $this->assertCount(2, $secondRead);
+        $this->assertEquals('PHP', $secondRead[0]->name);
+        $this->assertEquals(1, $secondRead[0]->pivot->post_id);
+    }
+
+    /**
      * Inverse: Tag 1 (PHP) belongs to many Posts.
      */
     public function testBindToManyInverseLazyLoad(): void


### PR DESCRIPTION
This fixes an inconsistency in lazy bindToMany loading where the first property access returned a collection of related models, but the cached relation on subsequent access was stored as a grouped raw array keyed by the pivot foreign key.

With this change, lazy bindToMany now caches the relation as a proper Collection, matching the eager-loading path. Repeated access to many-to-many relations now stays consistent and related items continue to include pivot data as expected.

Also adds regression coverage for repeated lazy bindToMany access and updates the related query test expectations to match the corrected collection behavior.