### PR TITLE
Fix many-to-many embedCount() when multiple relations are eager loaded

### DIFF
--- a/src/Phaseolies/Database/Entity/Builder.php
+++ b/src/Phaseolies/Database/Entity/Builder.php
@@ -1678,7 +1678,9 @@ class Builder
         $relationType = $firstModel->getLastRelationType();
         $relatedModel = $firstModel->getLastRelatedModel();
         $foreignKey = $firstModel->getLastForeignKey();
-        $localKey = $firstModel->getLastLocalKey();
+        $localKey = $relationType === "bindToMany"
+            ? $firstModel->getKeyName()
+            : $firstModel->getLastLocalKey();
 
         // Collect all local keys
         $localKeys = array_map(fn($model) => $model->{$localKey}, $models);
@@ -1710,7 +1712,7 @@ class Builder
         // Set the count on each model
         $countAttribute = $relation . '_count';
         foreach ($models as $model) {
-            $key = $model->{$localKey};
+            $key = $model->getKey();
             $model->{$countAttribute} = $counts[$key] ?? 0;
         }
     }
@@ -1738,7 +1740,6 @@ class Builder
         $foreignKey = $firstModel->getLastForeignKey();
         $relatedKey = $firstModel->getLastRelatedKey();
         $pivotTable = $firstModel->getLastPivotTable();
-        $localKey = $firstModel->getLastLocalKey();
 
         $relatedModelInstance = new $relatedModel();
         $relatedTable = $relatedModelInstance->getTable();
@@ -1768,7 +1769,7 @@ class Builder
         // Set the count on each model
         $countAttribute = $relation . '_count';
         foreach ($models as $model) {
-            $key = $model->{$localKey};
+            $key = $model->getKey();
             $model->{$countAttribute} = $counts[$key] ?? 0;
         }
     }


### PR DESCRIPTION
## Summary
This PR fixes wrong `relationship_count` values when `embed()` is used with multiple relations.

## Problem
When `category`, `user`, and `tags` were eager-loaded together, the many-to-many count logic used stale relation key state and could return incorrect counts.

## Solution
The framework now uses the model primary key directly for many-to-many count grouping instead of relying on mutable relation state.

## Changes
- Fixed many-to-many count key resolution in `Builder.php`
- Removed the stale `$localKey` dependency in count handling

## Verification
- Confirmed `Post::embed(['category:name', 'user:name', 'tags:name'])->embedCount('tags')` returns correct counts