### PR TITLE
fix collection first() and null-key existence handling

### DIFF
--- a/src/Phaseolies/Support/Collection.php
+++ b/src/Phaseolies/Support/Collection.php
@@ -99,7 +99,7 @@ class Collection extends RamseyCollection implements IteratorAggregate, ArrayAcc
      */
     public function __isset($name)
     {
-        return isset($this->data[$name]);
+        return array_key_exists($name, $this->data);
     }
 
     /**
@@ -110,7 +110,7 @@ class Collection extends RamseyCollection implements IteratorAggregate, ArrayAcc
      */
     public function offsetExists($offset): bool
     {
-        return isset($this->data[$offset]);
+        return array_key_exists($offset, $this->data);
     }
 
     /**
@@ -194,7 +194,11 @@ class Collection extends RamseyCollection implements IteratorAggregate, ArrayAcc
      */
     public function first(): mixed
     {
-        return $this->data[0] ?? null;
+        foreach ($this->data as $item) {
+            return $item;
+        }
+
+        return null;
     }
 
     /**

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -68,6 +68,17 @@ class CollectionTest extends TestCase
         $this->assertFalse(isset($collection->baz));
     }
 
+    public function testNullValuesAreStillConsideredPresent()
+    {
+        $collection = new Collection(Model::class, ["foo" => null]);
+
+        $this->assertArrayHasKey("foo", $collection->all());
+        $this->assertTrue(isset($collection["foo"]));
+        $this->assertTrue(isset($collection->foo));
+        $this->assertNull($collection["foo"]);
+        $this->assertNull($collection->foo);
+    }
+
     public function testGetIterator()
     {
         $items = [1, 2, 3];
@@ -96,6 +107,9 @@ class CollectionTest extends TestCase
     {
         $collection = new Collection(Model::class, [1, 2, 3]);
         $this->assertEquals(1, $collection->first());
+
+        $associativeCollection = new Collection(Model::class, ['a' => 10, 'b' => 20]);
+        $this->assertEquals(10, $associativeCollection->first());
 
         $emptyCollection = new Collection(Model::class, []);
         $this->assertNull($emptyCollection->first());


### PR DESCRIPTION
## Description
This PR fixes two issues in `Phaseolies\Support\Collection` and adds unit coverage to prevent regressions.

## What changed

- Fixed Collection::first() so it returns the first actual item in the collection, even when the collection uses associative keys.
- Fixed Collection::__isset() and Collection::offsetExists() to use array_key_exists() instead of isset(), so keys with null values are still treated as present.