### PR TITLE
Add model helpers for clearing and reloading cached relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## v3.26.4 - 2026-06-04
+
+* Fix many-to-many embedCount() when multiple relations are eager loaded by [@techmahedy](https://github.com/techmahedy) in https://github.com/doppar/framework/pull/286
+
 ## v3.26.3 - 2026-05-21
 
 * Fix lazy bindToMany relation caching to match eager-loaded collections by [@techmahedy](https://github.com/techmahedy) in https://github.com/doppar/framework/pull/285

--- a/src/Phaseolies/Application.php
+++ b/src/Phaseolies/Application.php
@@ -21,7 +21,7 @@ class Application extends Container
     /**
      * The current version of the Doppar framework.
      */
-    const VERSION = '3.26.3';
+    const VERSION = '3.26.4';
 
     /**
      * The base path of the application installation.

--- a/src/Phaseolies/Database/Entity/Model.php
+++ b/src/Phaseolies/Database/Entity/Model.php
@@ -975,6 +975,32 @@ abstract class Model implements Jsonable, \ArrayAccess, \JsonSerializable, \Stri
     }
 
     /**
+     * Forget a loaded relationship so it will be queried again on next access.
+     *
+     * @param string $relation
+     * @return $this
+     */
+    public function forget(string $relation): self
+    {
+        unset($this->relations[$relation]);
+
+        return $this;
+    }
+
+    /**
+     * Reload a relationship from the database.
+     *
+     * @param string $relation
+     * @return mixed
+     */
+    public function reload(string $relation)
+    {
+        $this->forget($relation);
+
+        return $this->{$relation};
+    }
+
+    /**
      * Magic getter for accessing model attributes and relationships
      *
      * @param string $name

--- a/tests/Model/Query/EntityRelationshipBehavior.php
+++ b/tests/Model/Query/EntityRelationshipBehavior.php
@@ -926,6 +926,22 @@ abstract class EntityRelationshipTest extends ModelQueryDriverTestCase
         $this->assertEquals([], $changes['detached']);
     }
 
+    /**
+     * Refreshing a loaded relation exposes pivot changes on the same model.
+     */
+    public function testRefreshRelationClearsStaleRelationCache(): void
+    {
+        $post = MockPost::find(1);
+
+        $this->assertEquals([1, 2], $post->tags->pluck('id')->sort()->values()->toArray());
+
+        $post->tags()->relate([1, 4]);
+
+        $this->assertEquals([1, 2], $post->tags->pluck('id')->sort()->values()->toArray());
+        $this->assertEquals([1, 4], $post->reload('tags')->pluck('id')->sort()->values()->toArray());
+        $this->assertEquals([1, 4], $post->tags->pluck('id')->sort()->values()->toArray());
+    }
+
     // =========================================================================
     // 16. MIXED omit + embed
     // =========================================================================


### PR DESCRIPTION
## Problem
Loaded relationships are cached on the model instance. If a many-to-many relationship is modified afterward, the model can continue returning stale data:
```php
$post = Post::find(1);

$post->tags; // Loads and caches tags

$post->tags()->relate([1, 4]); // Updates the database

$post->tags; // Still returns the old cached tags
```

## Solution
Added two methods to the base model:
```php
$post->forget('tags');
```
Clears the cached relationship without executing a new query.
```php
$post->reload('tags');
```

Clears the cached relationship and immediately loads the latest data from the database.
## Example:
```php
$post->tags()->relate([1, 4]);

$tags = $post->reload('tags');
```

Subsequent access also returns the refreshed relationship:
```php
$post->tags; // Returns tags 1 and 4
```

### Changes

1. Added Model::forget(string $relation)
2. Added Model::reload(string $relation)
3. Added regression coverage for stale relationship data after relate()
4. Preserved existing relationship caching behavior for normal access