### PR TITLE
Introduce Doppar 4.x Application Skeleton

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+
+updates:
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/security-analysis.yml
+++ b/.github/workflows/security-analysis.yml
@@ -45,10 +45,10 @@ jobs:
       - name: Audit dependencies for known vulnerabilities
         run: composer audit --no-dev --format=table --locked
 
-  codeql:
+  semgrep:
     runs-on: ubuntu-24.04
 
-    name: CodeQL
+    name: Semgrep
 
     permissions:
       contents: read
@@ -58,13 +58,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+      - name: Run Semgrep
+        uses: semgrep/semgrep-action@v1
         with:
-          languages: php
-          queries: security-extended
+          config: p/security-audit p/php
+          generateSarif: '1'
 
-      - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+      - name: Upload SARIF results
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
         with:
-          category: '/language:php'
+          sarif_file: semgrep.sarif

--- a/.github/workflows/security-analysis.yml
+++ b/.github/workflows/security-analysis.yml
@@ -1,0 +1,70 @@
+name: security analysis
+
+on:
+  push:
+    branches:
+      - master
+      - '*.x'
+  pull_request:
+  schedule:
+    - cron: '0 3 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  composer-audit:
+    runs-on: ubuntu-24.04
+
+    name: Composer audit
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.5
+          tools: composer:v2
+          coverage: none
+
+      - name: Set Framework version
+        run: composer config version "2.x-dev"
+
+      - name: Install dependencies
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
+
+      - name: Audit dependencies for known vulnerabilities
+        run: composer audit --no-dev --format=table --locked
+
+  codeql:
+    runs-on: ubuntu-24.04
+
+    name: CodeQL
+
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: php
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:php'

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         directory: [src]
 
-    name: ${{ matrix.directory == 'src'}}
+    name: PHPStan (${{ matrix.directory }})
 
     steps:
       - name: Checkout code
@@ -38,3 +38,6 @@ jobs:
           timeout_minutes: 5
           max_attempts: 5
           command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress
+
+      - name: Run PHPStan
+        run: composer analyse -- --no-progress --error-format=github

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: 8.5
           tools: composer:v2
           coverage: none
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,16 +31,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.3, 8.4, 8.5]
-        phpunit: ['12.5.0', '12.5.8']
+        php: [8.5]
+        phpunit: ['13.3.0', '13.3.1']
         stability: [prefer-lowest, prefer-stable]
-        exclude:
-          - php: 8.3
-            phpunit: '12.0.0'
-          - php: 8.4
-            phpunit: '12.0.0'
-          - php: 8.5
-            phpunit: '12.0.0'
 
     name: PHP ${{ matrix.php }} - PHPUnit ${{ matrix.phpunit }} - ${{ matrix.stability }}
 
@@ -130,7 +123,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress --with="phpunit/phpunit:~12.5.8"
+          command: composer update --prefer-stable --prefer-dist --no-interaction --no-progress --with="phpunit/phpunit:~13.3.1"
 
       - name: Execute MySQL model query tests
         if: matrix.driver == 'mysql'
@@ -168,16 +161,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.3, 8.4, 8.5]
-        phpunit: ['12.5.0', '12.5.8']
+        php: [8.5]
+        phpunit: ['13.3.0', '13.3.1']
         stability: [prefer-lowest, prefer-stable]
-        exclude:
-          - php: 8.3
-            phpunit: '12.0.0'
-          - php: 8.4
-            phpunit: '12.0.0'
-          - php: 8.5
-            phpunit: '12.0.0'
 
     name: PHP ${{ matrix.php }} - PHPUnit ${{ matrix.phpunit }} - ${{ matrix.stability }} - Windows
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.phpunit.cache
+/.phpstan.cache
 /vendor
 /storage
 composer.phar

--- a/.phpstan/stubs/AppHttpKernel.php
+++ b/.phpstan/stubs/AppHttpKernel.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http;
+
+/**
+ * Stub for static analysis only.
+ *
+ * Phaseolies\Support\Router extends App\Http\Kernel, which is defined by
+ * applications built on the framework (see the Doppar skeleton), not by
+ * the framework package itself. This lets PHPStan resolve the symbol.
+ */
+class Kernel
+{
+}

--- a/composer.json
+++ b/composer.json
@@ -19,26 +19,26 @@
     }
   ],
   "require": {
-    "php": "^8.3",
-    "chillerlan/php-qrcode": "^5.0",
-    "dragonmantank/cron-expression": "^3.4",
-    "monolog/monolog": "^3.0",
-    "nesbot/carbon": "^3.8",
-    "paragonie/constant_time_encoding": "^3.0",
-    "phpmailer/phpmailer": "^6.9",
+    "php": "^8.5",
+    "chillerlan/php-qrcode": "^6.0",
+    "dragonmantank/cron-expression": "^3.6",
+    "monolog/monolog": "^3.10",
+    "nesbot/carbon": "^3.13",
+    "paragonie/constant_time_encoding": "^3.1",
+    "phpmailer/phpmailer": "^7.1",
     "psr/simple-cache": "^3.0",
     "ramsey/collection": "^2.1",
     "react/event-loop": "^1.6",
-    "spomky-labs/otphp": "^11.3",
-    "symfony/cache": "^7.4",
-    "symfony/console": "^7.4",
-    "symfony/process": "^7.4",
-    "symfony/var-dumper": "^7.4",
-    "vlucas/phpdotenv": "^5.6"
+    "spomky-labs/otphp": "^11.5",
+    "symfony/cache": "^8.1",
+    "symfony/console": "^8.1",
+    "symfony/process": "^8.1",
+    "symfony/var-dumper": "^8.1",
+    "vlucas/phpdotenv": "^5.7"
   },
   "require-dev": {
     "mockery/mockery": "^1.6",
-    "phpunit/phpunit": "^12.5"
+    "phpunit/phpunit": "^13.3"
   },
   "autoload": {
     "psr-4": {
@@ -70,7 +70,7 @@
     "ext-pdo": "Provides the core database abstraction required for all DB operations.",
     "ext-pcntl": "Enables full functionality of the queue worker and support for console signal handling.",
     "ext-redis": "Required for using Redis-backed cache.",
-    "symfony/cache": "Supplies the PSR-6 cache integration layer (version ^7.4)."
+    "symfony/cache": "Supplies the PSR-6 cache integration layer (version ^8.1)."
   },
   "config": {
     "sort-packages": true,

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
   },
   "require-dev": {
     "mockery/mockery": "^1.6",
+    "phpstan/phpstan": "^2.1",
     "phpunit/phpunit": "^13.3"
   },
   "autoload": {
@@ -58,7 +59,8 @@
     "test:sqlite": "@test",
     "test:mysql": "vendor/bin/phpunit --group mysql",
     "test:pgsql": "vendor/bin/phpunit --group pgsql",
-    "test:all": "vendor/bin/phpunit"
+    "test:all": "vendor/bin/phpunit",
+    "analyse": "vendor/bin/phpstan analyse --memory-limit=1G"
   },
   "extra": {
     "branch-alias": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,2605 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Phaseolies/Application.php
+
+		-
+			message: '#^Call to method forgetActors\(\) on an unknown class auth\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Phaseolies/Application.php
+
+		-
+			message: '#^Instanceof between Phaseolies\\Http\\Response and Phaseolies\\Http\\Response will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: src/Phaseolies/Application.php
+
+		-
+			message: '#^PHPDoc tag @var with type Phaseolies\\Providers\\GhostableProvider is not subtype of native type Phaseolies\\Providers\\ServiceProvider\.$#'
+			identifier: varTag.nativeType
+			count: 1
+			path: src/Phaseolies/Application.php
+
+		-
+			message: '#^Parameter \#1 \$abstract of method Phaseolies\\Application\:\:make\(\) expects class\-string\<auth\>, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Phaseolies/Application.php
+
+		-
+			message: '#^Property Phaseolies\\Application\:\:\$cachedConfig \(null\) does not accept true\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: src/Phaseolies/Application.php
+
+		-
+			message: '#^Call to an undefined method Phaseolies\\Support\\Router\:\:handle\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Phaseolies/ApplicationBuilder.php
+
+		-
+			message: '#^PHPDoc tag @var for property Phaseolies\\ApplicationBuilder\:\:\$request contains generic type Phaseolies\\Http\\Request\<string\> but class Phaseolies\\Http\\Request is not generic\.$#'
+			identifier: generics.notGeneric
+			count: 1
+			path: src/Phaseolies/ApplicationBuilder.php
+
+		-
+			message: '#^Parameter \#1 \$abstract of method Phaseolies\\Application\:\:make\(\) expects class\-string\<request\>, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Phaseolies/ApplicationBuilder.php
+
+		-
+			message: '#^Parameter \#1 \$abstract of method Phaseolies\\Application\:\:make\(\) expects class\-string\<response\>, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Phaseolies/ApplicationBuilder.php
+
+		-
+			message: '#^Access to an undefined property Phaseolies\\Database\\Entity\\Model\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 5
+			path: src/Phaseolies/Auth/Security/Authenticate.php
+
+		-
+			message: '#^Access to an undefined property Phaseolies\\Database\\Entity\\Model\:\:\$remember_token\.$#'
+			identifier: property.notFound
+			count: 2
+			path: src/Phaseolies/Auth/Security/Authenticate.php
+
+		-
+			message: '#^Access to an undefined property Phaseolies\\Database\\Entity\\Model\:\:\$two_factor_recovery_codes\.$#'
+			identifier: property.notFound
+			count: 4
+			path: src/Phaseolies/Auth/Security/Authenticate.php
+
+		-
+			message: '#^Access to an undefined property Phaseolies\\Database\\Entity\\Model\:\:\$two_factor_secret\.$#'
+			identifier: property.notFound
+			count: 3
+			path: src/Phaseolies/Auth/Security/Authenticate.php
+
+		-
+			message: '#^Access to undefined constant chillerlan\\QRCode\\QRCode\:\:ECC_M\.$#'
+			identifier: classConstant.notFound
+			count: 1
+			path: src/Phaseolies/Auth/Security/Authenticate.php
+
+		-
+			message: '#^Access to undefined constant chillerlan\\QRCode\\QRCode\:\:OUTPUT_MARKUP_SVG\.$#'
+			identifier: classConstant.notFound
+			count: 1
+			path: src/Phaseolies/Auth/Security/Authenticate.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Database\\Entity\\Model\:\:where\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Auth/Security/Authenticate.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Crypt\:\:decrypt\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 3
+			path: src/Phaseolies/Auth/Security/Authenticate.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Crypt\:\:encrypt\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 5
+			path: src/Phaseolies/Auth/Security/Authenticate.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Hash\:\:check\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 3
+			path: src/Phaseolies/Auth/Security/Authenticate.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Hash\:\:make\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 2
+			path: src/Phaseolies/Auth/Security/Authenticate.php
+
+		-
+			message: '#^Class Doppar\\Flarion\\ApiAuthenticate not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Phaseolies/Auth/Security/Authenticate.php
+
+		-
+			message: '#^PHPDoc tag @param references unknown parameter\: \$size$#'
+			identifier: parameter.notFound
+			count: 1
+			path: src/Phaseolies/Auth/Security/Authenticate.php
+
+		-
+			message: '#^Ternary operator condition is always true\.$#'
+			identifier: ternary.alwaysTrue
+			count: 1
+			path: src/Phaseolies/Auth/Security/Authenticate.php
+
+		-
+			message: '#^Using nullsafe property access "\?\-\>id" on left side of \?\? is unnecessary\. Use \-\> instead\.$#'
+			identifier: nullsafe.neverNull
+			count: 1
+			path: src/Phaseolies/Auth/Security/Authenticate.php
+
+		-
+			message: '#^Using nullsafe property access on non\-nullable type Phaseolies\\Database\\Entity\\Model\. Use \-\> instead\.$#'
+			identifier: nullsafe.neverNull
+			count: 1
+			path: src/Phaseolies/Auth/Security/Authenticate.php
+
+		-
+			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Phaseolies/Cache/CacheStore.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$owner with type string\|null is not subtype of native type string\.$#'
+			identifier: parameter.phpDocType
+			count: 1
+			path: src/Phaseolies/Cache/CacheStore.php
+
+		-
+			message: '#^Parameter \#3 \$ttl of method Phaseolies\\Cache\\CacheStore\:\:set\(\) expects null, int\|Phaseolies\\Cache\\DateInterval given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Phaseolies/Cache/CacheStore.php
+
+		-
+			message: '#^Parameter \$ttl of method Phaseolies\\Cache\\CacheStore\:\:stash\(\) has invalid type Phaseolies\\Cache\\DateInterval\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Phaseolies/Cache/CacheStore.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between null and null will always evaluate to false\.$#'
+			identifier: notIdentical.alwaysFalse
+			count: 1
+			path: src/Phaseolies/Cache/CacheStore.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Pool\:\:call\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Console/Commands/AppBoostCommand.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Cache\:\:clear\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Console/Commands/ClearCacheCommand.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Route\:\:clearRouteCache\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Console/Commands/ClearRouteCacheCommand.php
+
+		-
+			message: '#^Call to method getCommands\(\) on an unknown class App\\Schedule\\Schedule\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Phaseolies/Console/Commands/Cron/CronListCommand.php
+
+		-
+			message: '#^Call to method schedule\(\) on an unknown class App\\Schedule\\Schedule\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Phaseolies/Console/Commands/Cron/CronListCommand.php
+
+		-
+			message: '#^Instantiated class App\\Schedule\\Schedule not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Phaseolies/Console/Commands/Cron/CronListCommand.php
+
+		-
+			message: '#^Call to method getCommands\(\) on an unknown class App\\Schedule\\Schedule\.$#'
+			identifier: class.notFound
+			count: 2
+			path: src/Phaseolies/Console/Commands/Cron/CronRunCommand.php
+
+		-
+			message: '#^Call to method schedule\(\) on an unknown class App\\Schedule\\Schedule\.$#'
+			identifier: class.notFound
+			count: 2
+			path: src/Phaseolies/Console/Commands/Cron/CronRunCommand.php
+
+		-
+			message: '#^Instantiated class App\\Schedule\\Schedule not found\.$#'
+			identifier: class.notFound
+			count: 2
+			path: src/Phaseolies/Console/Commands/Cron/CronRunCommand.php
+
+		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: src/Phaseolies/Console/Commands/KeyGenerateCommand.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Hash\:\:make\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Console/Commands/MakePasswordCommand.php
+
+		-
+			message: '#^Method Phaseolies\\Database\\Migration\\MigrationCreator\:\:create\(\) invoked with 7 parameters, 2\-4 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: src/Phaseolies/Console/Commands/Migrations/AddColumnMigrationCommand.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(string \\\$className\)\: Unexpected token "\\\\\$className", expected variable at offset 82 on line 4$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Console/Commands/Migrations/CreateSeedCommand.php
+
+		-
+			message: '#^Call to method run\(\) on an unknown class Database\\Seeders\\DatabaseSeeder\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Phaseolies/Console/Commands/Migrations/DBSeedCommand.php
+
+		-
+			message: '#^Instantiated class Database\\Seeders\\DatabaseSeeder not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Phaseolies/Console/Commands/Migrations/DBSeedCommand.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\DB\:\:connection\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Console/Commands/Migrations/MigrateRefreshCommand.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Schema\:\:connection\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 2
+			path: src/Phaseolies/Console/Commands/Migrations/MigrateRefreshCommand.php
+
+		-
+			message: '#^Using nullsafe property access "\?\-\>trackActor" on left side of \?\? is unnecessary\. Use \-\> instead\.$#'
+			identifier: nullsafe.neverNull
+			count: 1
+			path: src/Phaseolies/Console/Commands/Migrations/MigrateTemporalCommand.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Route\:\:cacheRoutes\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Console/Commands/RouteCacheCommand.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Pool\:\:call\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Console/Commands/RouteListCommand.php
+
+		-
+			message: '#^Call to function is_int\(\) with int\<min, \-1\>\|int\<1, max\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Phaseolies/Console/Commands/Server/ServerStartCommand.php
+
+		-
+			message: '#^Parameter \#1 \$port of method Phaseolies\\Console\\Commands\\Server\\ServerStartCommand\:\:isPortOk\(\) expects int\|null, array\|string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Phaseolies/Console/Commands/Server/ServerStartCommand.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(string string\)\: Unexpected token "string", expected variable at offset 113 on line 5$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Console/Console.php
+
+		-
+			message: '#^Call to an undefined method Symfony\\Component\\Console\\Helper\\HelperInterface\:\:ask\(\)\.$#'
+			identifier: method.notFound
+			count: 5
+			path: src/Phaseolies/Console/Schedule/Command.php
+
+		-
+			message: '#^Call to an undefined method Symfony\\Component\\Console\\Question\\ChoiceQuestion\:\:setDefault\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Phaseolies/Console/Schedule/Command.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Log\:\:error\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Console/Schedule/Command.php
+
+		-
+			message: '#^Offset 1 on array\{0\: non\-falsy\-string, 1\: string, 2\: non\-empty\-string, 3\?\: string\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: src/Phaseolies/Console/Schedule/Command.php
+
+		-
+			message: '#^Trait Phaseolies\\Console\\Schedule\\InteractsWithSchedule is used zero times and is not analysed\.$#'
+			identifier: trait.unused
+			count: 1
+			path: src/Phaseolies/Console/Schedule/InteractsWithSchedule.php
+
+		-
+			message: '#^Parameter \#3 \$env of class Symfony\\Component\\Process\\Process constructor expects array\<string, string\|Stringable\|false\>\|null, non\-empty\-array\<mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Phaseolies/Console/Schedule/SchedulePool.php
+
+		-
+			message: '#^Function now invoked with 1 parameter, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: src/Phaseolies/Console/Schedule/ScheduledCommand.php
+
+		-
+			message: '#^Left side of && is always true\.$#'
+			identifier: booleanAnd.leftAlwaysTrue
+			count: 1
+			path: src/Phaseolies/Console/Schedule/ScheduledCommand.php
+
+		-
+			message: '#^Method Phaseolies\\Console\\Schedule\\ScheduledCommand\:\:getRateLimit\(\) should return string\|null but returns int\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Phaseolies/Console/Schedule/ScheduledCommand.php
+
+		-
+			message: '#^Parameter \#1 \$hour of method Carbon\\Traits\\Date\:\:setTime\(\) expects int, string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/Phaseolies/Console/Schedule/ScheduledCommand.php
+
+		-
+			message: '#^Parameter \#2 \$minute of method Carbon\\Traits\\Date\:\:setTime\(\) expects int, string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/Phaseolies/Console/Schedule/ScheduledCommand.php
+
+		-
+			message: '#^Parameter \#2 \$string of function explode expects string, int\<min, \-1\>\|int\<1, max\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Phaseolies/Console/Schedule/ScheduledCommand.php
+
+		-
+			message: '#^Property Phaseolies\\Console\\Schedule\\ScheduledCommand\:\:\$additionalConditions \(array\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: src/Phaseolies/Console/Schedule/ScheduledCommand.php
+
+		-
+			message: '#^Property Phaseolies\\Console\\Schedule\\ScheduledCommand\:\:\$rateLimit \(int\|null\) does not accept string\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: src/Phaseolies/Console/Schedule/ScheduledCommand.php
+
+		-
+			message: '#^Property Phaseolies\\Console\\Schedule\\ScheduledCommand\:\:\$rateLimit \(int\|null\) is never assigned int so it can be removed from the property type\.$#'
+			identifier: property.unusedType
+			count: 1
+			path: src/Phaseolies/Console/Schedule/ScheduledCommand.php
+
+		-
+			message: '#^Trait Phaseolies\\DI\\Concerns\\EnforcesImmutability is used zero times and is not analysed\.$#'
+			identifier: trait.unused
+			count: 1
+			path: src/Phaseolies/DI/Concerns/EnforcesImmutability.php
+
+		-
+			message: '#^Call to an undefined method ReflectionType\:\:getName\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Phaseolies/DI/Container.php
+
+		-
+			message: '#^Call to an undefined method ReflectionType\:\:isBuiltin\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Phaseolies/DI/Container.php
+
+		-
+			message: '#^Call to function is_callable\(\) with callable\(\)\: mixed will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Phaseolies/DI/Container.php
+
+		-
+			message: '#^Call to function is_object\(\) with \*NEVER\* will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Phaseolies/DI/Container.php
+
+		-
+			message: '#^Right side of && is always false\.$#'
+			identifier: booleanAnd.rightAlwaysFalse
+			count: 1
+			path: src/Phaseolies/DI/Container.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between mixed and null will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 2
+			path: src/Phaseolies/DI/Container.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: src/Phaseolies/DI/Container.php
+
+		-
+			message: '#^Access to an undefined property Phaseolies\\Database\\Database\:\:\$conditions\.$#'
+			identifier: property.notFound
+			count: 1
+			path: src/Phaseolies/Database/Database.php
+
+		-
+			message: '#^Access to an undefined property Phaseolies\\Database\\Database\:\:\$pdo\.$#'
+			identifier: property.notFound
+			count: 3
+			path: src/Phaseolies/Database/Database.php
+
+		-
+			message: '#^Access to an undefined property Phaseolies\\Database\\Database\:\:\$table\.$#'
+			identifier: property.notFound
+			count: 7
+			path: src/Phaseolies/Database/Database.php
+
+		-
+			message: '#^Dead catch \- Throwable is never thrown in the try block\.$#'
+			identifier: catch.neverThrown
+			count: 1
+			path: src/Phaseolies/Database/Database.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: src/Phaseolies/Database/Database.php
+
+		-
+			message: '#^Variable \$stmt in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: src/Phaseolies/Database/Database.php
+
+		-
+			message: '#^PHPDoc tag @param references unknown parameter\: \$name$#'
+			identifier: parameter.notFound
+			count: 1
+			path: src/Phaseolies/Database/Drivers/SQLiteDriver.php
+
+		-
+			message: '#^Access to an undefined property \$this\(Phaseolies\\Database\\Entity\\Builder\)\:\:\$originalAttributes\.$#'
+			identifier: property.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Access to an undefined property \$this\(Phaseolies\\Database\\Entity\\Builder\)\:\:\$primaryKey\.$#'
+			identifier: property.notFound
+			count: 2
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Access to an undefined property \$this\(Phaseolies\\Database\\Entity\\Builder\)\:\:\$timeStamps\.$#'
+			identifier: property.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Access to an undefined property Phaseolies\\Database\\Entity\\Builder\:\:\$attributes\.$#'
+			identifier: property.notFound
+			count: 3
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Access to an undefined property Phaseolies\\Database\\Entity\\Builder\:\:\$connection\.$#'
+			identifier: property.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Access to an undefined property Phaseolies\\Database\\Entity\\Builder\:\:\$creatable\.$#'
+			identifier: property.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Access to an undefined property Phaseolies\\Database\\Entity\\Builder\:\:\$originalAttributes\.$#'
+			identifier: property.notFound
+			count: 3
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Access to an undefined property Phaseolies\\Database\\Entity\\Builder\:\:\$pageSize\.$#'
+			identifier: property.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Access to an undefined property Phaseolies\\Database\\Entity\\Builder\:\:\$primaryKey\.$#'
+			identifier: property.notFound
+			count: 4
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Access to an undefined property Phaseolies\\Database\\Entity\\Builder\:\:\$relations\.$#'
+			identifier: property.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Access to an undefined property Phaseolies\\Database\\Entity\\Builder\:\:\$timeStamps\.$#'
+			identifier: property.notFound
+			count: 2
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Call to an undefined method \$this\(Phaseolies\\Database\\Entity\\Builder\)\:\:fireAfterHooks\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Call to an undefined method \$this\(Phaseolies\\Database\\Entity\\Builder\)\:\:fireBeforeHooks\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Call to an undefined method \$this\(Phaseolies\\Database\\Entity\\Builder\)\:\:firePropertyWatches\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Call to an undefined method \$this\(Phaseolies\\Database\\Entity\\Builder\)\:\:newQuery\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Call to an undefined method \$this\(Phaseolies\\Database\\Entity\\Builder\)\:\:pruneNonColumnDirtyAttributes\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Call to an undefined method Phaseolies\\Database\\Entity\\Builder\:\:fill\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Call to an undefined method Phaseolies\\Database\\Entity\\Builder\:\:fireAfterHooks\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Call to an undefined method Phaseolies\\Database\\Entity\\Builder\:\:fireBeforeHooks\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Call to an undefined method Phaseolies\\Database\\Entity\\Builder\:\:getTable\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Call to an undefined method Phaseolies\\Database\\Entity\\Builder\:\:newQuery\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Call to an undefined method Phaseolies\\Database\\Entity\\Builder\:\:pruneNonColumnAttributes\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Call to an undefined method Phaseolies\\Database\\Entity\\Builder\:\:setRelation\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Call to an undefined method Phaseolies\\Database\\Entity\\Builder\:\:toArray\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\URL\:\:current\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 2
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 2
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Call to function is_callable\(\) with null will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 2
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Call to function is_int\(\) with int will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Call to function unset\(\) contains undefined variable \$chunkQuery\.$#'
+			identifier: unset.variable
+			count: 2
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Call to function unset\(\) contains undefined variable \$results\.$#'
+			identifier: unset.variable
+			count: 2
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^If condition is always false\.$#'
+			identifier: if.alwaysFalse
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Instanceof between \$this\(Phaseolies\\Database\\Entity\\Builder\) and Phaseolies\\Support\\Collection will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Method Phaseolies\\Database\\Entity\\Builder\:\:absent\(\) invoked with 2 parameters, 1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Method Phaseolies\\Database\\Entity\\Builder\:\:createFromModel\(\) should return static\(Phaseolies\\Database\\Entity\\Builder\) but returns Phaseolies\\Database\\Entity\\Model\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(int chunkSize\)\: Unexpected token "chunkSize", expected variable at offset 89 on line 4$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^PHPDoc tag @param references unknown parameter\: \$boolean$#'
+			identifier: parameter.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^PHPDoc tag @param references unknown parameter\: \$page$#'
+			identifier: parameter.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Parameter \#1 \.\.\.\$arrays of function array_merge expects array, null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Parameter \#2 \$type of method Phaseolies\\Database\\Entity\\Builder\:\:formatDateTime\(\) expects string, true given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Static call to instance method Phaseolies\\Database\\Entity\\Builder\:\:create\(\)\.$#'
+			identifier: method.staticCall
+			count: 3
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between mixed and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 2
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Undefined variable\: \$inspectQuery$#'
+			identifier: variable.undefined
+			count: 4
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 6
+			path: src/Phaseolies/Database/Entity/Builder.php
+
+		-
+			message: '#^Offset ''when'' on array\{handler\: \(callable\(\)\: mixed\)\|string, when\: bool\|\(callable\(\)\: mixed\)\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: src/Phaseolies/Database/Entity/Hooks/HookHandler.php
+
+		-
+			message: '#^Access to an undefined property Phaseolies\\Database\\Entity\\Model\:\:\$__action\.$#'
+			identifier: property.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Model.php
+
+		-
+			message: '#^Access to an undefined property Phaseolies\\Database\\Entity\\Model\:\:\$__actor\.$#'
+			identifier: property.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Model.php
+
+		-
+			message: '#^Access to an undefined property Phaseolies\\Database\\Entity\\Model\:\:\$__changed_cols\.$#'
+			identifier: property.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Model.php
+
+		-
+			message: '#^Access to an undefined property Phaseolies\\Database\\Entity\\Model\:\:\$__history_id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Model.php
+
+		-
+			message: '#^Access to an undefined property Phaseolies\\Database\\Entity\\Model\:\:\$__valid_from\.$#'
+			identifier: property.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Model.php
+
+		-
+			message: '#^Access to an undefined property Phaseolies\\Database\\Entity\\Model\:\:\$modelClass\.$#'
+			identifier: property.notFound
+			count: 2
+			path: src/Phaseolies/Database/Entity/Model.php
+
+		-
+			message: '#^Offset ''key'' does not exist on string\.$#'
+			identifier: offsetAccess.notFound
+			count: 4
+			path: src/Phaseolies/Database/Entity/Model.php
+
+		-
+			message: '#^Offset ''method'' does not exist on string\.$#'
+			identifier: offsetAccess.notFound
+			count: 5
+			path: src/Phaseolies/Database/Entity/Model.php
+
+		-
+			message: '#^Property Phaseolies\\Database\\Entity\\Model\:\:\$lastLocalKey \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: src/Phaseolies/Database/Entity/Model.php
+
+		-
+			message: '#^Property Phaseolies\\Database\\Entity\\Model\:\:\$table \(string\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 2
+			path: src/Phaseolies/Database/Entity/Model.php
+
+		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: src/Phaseolies/Database/Entity/Model.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 11
+			path: src/Phaseolies/Database/Entity/Model.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\URL\:\:current\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 2
+			path: src/Phaseolies/Database/Entity/Query/Builder.php
+
+		-
+			message: '#^Call to function is_int\(\) with int will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Phaseolies/Database/Entity/Query/Builder.php
+
+		-
+			message: '#^PHPDoc tag @param references unknown parameter\: \$boolean$#'
+			identifier: parameter.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Query/Builder.php
+
+		-
+			message: '#^PHPDoc tag @param references unknown parameter\: \$modelClass$#'
+			identifier: parameter.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Query/Builder.php
+
+		-
+			message: '#^PHPDoc tag @param references unknown parameter\: \$page$#'
+			identifier: parameter.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Query/Builder.php
+
+		-
+			message: '#^PHPDoc tag @param references unknown parameter\: \$rowPerPage$#'
+			identifier: parameter.notFound
+			count: 1
+			path: src/Phaseolies/Database/Entity/Query/Builder.php
+
+		-
+			message: '#^Parameter \#2 \$type of method Phaseolies\\Database\\Entity\\Query\\Builder\:\:formatDateTime\(\) expects string, true given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/Phaseolies/Database/Entity/Query/Builder.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between mixed and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 2
+			path: src/Phaseolies/Database/Entity/Query/Builder.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: src/Phaseolies/Database/Entity/Query/Builder.php
+
+		-
+			message: '#^Call to function is_bool\(\) with bool will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Phaseolies/Database/Entity/Watches/WatchesHandler.php
+
+		-
+			message: '#^Call to function is_null\(\) with mixed will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: src/Phaseolies/Database/Migration/ColumnDefinition.php
+
+		-
+			message: '#^Variable \$keys in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: src/Phaseolies/Database/Migration/Grammars/SQLiteGrammar.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\DB\:\:connection\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 4
+			path: src/Phaseolies/Database/Migration/MigrationRepository.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Schema\:\:connection\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Database/Migration/MigrationRepository.php
+
+		-
+			message: '#^Variable \$connection on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.variable
+			count: 1
+			path: src/Phaseolies/Database/Migration/Migrator.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\DB\:\:connection\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 6
+			path: src/Phaseolies/Database/Migration/Schema.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: src/Phaseolies/Database/Migration/Schema.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(array\)\: Unexpected token "\\n     ", expected variable at offset 98 on line 4$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Database/Procedure/ProcedureResult.php
+
+		-
+			message: '#^Method Phaseolies\\Database\\Temporal\\TemporalManager\:\:resolveActor\(\) never returns int so it can be removed from the return type\.$#'
+			identifier: return.unusedType
+			count: 1
+			path: src/Phaseolies/Database/Temporal/TemporalManager.php
+
+		-
+			message: '#^Using nullsafe property access "\?\-\>suffix" on left side of \?\? is unnecessary\. Use \-\> instead\.$#'
+			identifier: nullsafe.neverNull
+			count: 1
+			path: src/Phaseolies/Database/Temporal/TemporalManager.php
+
+		-
+			message: '#^Class App\\Http\\Exceptions\\BeforeExceptionHandler not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Phaseolies/Error/ErrorHandler.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(int\)\: Unexpected token "\\n     \* ", expected variable at offset 98 on line 5$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Error/Handlers/CliErrorHandler.php
+
+		-
+			message: '#^PHPDoc tag @return with type void is incompatible with native type string\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: src/Phaseolies/Error/Handlers/CliErrorHandler.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 2
+			path: src/Phaseolies/Error/Traces/Frame.php
+
+		-
+			message: '#^Access to an undefined property Phaseolies\\Database\\Entity\\Model\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: src/Phaseolies/Error/WebErrorRenderer.php
+
+		-
+			message: '#^Array has 2 duplicate keys with value ''request_body'' \(''request_body'', ''request_body''\)\.$#'
+			identifier: array.duplicateKey
+			count: 1
+			path: src/Phaseolies/Error/WebErrorRenderer.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Route\:\:currentRouteAction\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Error/WebErrorRenderer.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Route\:\:currentRouteName\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Error/WebErrorRenderer.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Route\:\:getCurrentMiddlewareNames\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Error/WebErrorRenderer.php
+
+		-
+			message: '#^Parameter \#1 \$content of function response expects null, string given\.$#'
+			identifier: argument.type
+			count: 3
+			path: src/Phaseolies/Error/WebErrorRenderer.php
+
+		-
+			message: '#^Using nullsafe method call on non\-nullable type Phaseolies\\Auth\\ActorManager\|Phaseolies\\Auth\\Security\\Authenticate\. Use \-\> instead\.$#'
+			identifier: nullsafe.neverNull
+			count: 1
+			path: src/Phaseolies/Error/WebErrorRenderer.php
+
+		-
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
+			count: 1
+			path: src/Phaseolies/Facade/BaseFacade.php
+
+		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: src/Phaseolies/Facade/BaseFacade.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Crypt\:\:decrypt\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Helpers/helpers.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Crypt\:\:encrypt\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Helpers/helpers.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Log\:\:alert\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Helpers/helpers.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Log\:\:critical\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Helpers/helpers.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Log\:\:debug\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Helpers/helpers.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Log\:\:emergency\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Helpers/helpers.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Log\:\:error\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Helpers/helpers.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Log\:\:info\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Helpers/helpers.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Log\:\:notice\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Helpers/helpers.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Log\:\:warning\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Helpers/helpers.php
+
+		-
+			message: '#^Call to static method create\(\) on an unknown class Faker\\Factory\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Phaseolies/Helpers/helpers.php
+
+		-
+			message: '#^Condition "null is null" in conditional return type is always true\.$#'
+			identifier: conditionalType.alwaysTrue
+			count: 1
+			path: src/Phaseolies/Helpers/helpers.php
+
+		-
+			message: '#^Function __\(\) never returns array so it can be removed from the return type\.$#'
+			identifier: return.unusedType
+			count: 1
+			path: src/Phaseolies/Helpers/helpers.php
+
+		-
+			message: '#^Function fake\(\) has invalid return type Faker\\Generator\.$#'
+			identifier: class.notFound
+			count: 2
+			path: src/Phaseolies/Helpers/helpers.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(int\)\: Unexpected token "\\n     \* ", expected variable at offset 108 on line 4$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Helpers/helpers.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(string\)\: Unexpected token "\\n     \* ", expected variable at offset 86 on line 4$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Helpers/helpers.php
+
+		-
+			message: '#^Variable \$content on left side of \?\? always exists and is always null\.$#'
+			identifier: nullCoalesce.variable
+			count: 1
+			path: src/Phaseolies/Helpers/helpers.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$callback with type string is incompatible with native type Closure\.$#'
+			identifier: parameter.phpDocType
+			count: 1
+			path: src/Phaseolies/Http/Controllers/Controller.php
+
+		-
+			message: '#^Property Phaseolies\\Http\\Controllers\\Controller\:\:\$soloCounter \(int\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: src/Phaseolies/Http/Controllers/Controller.php
+
+		-
+			message: '#^Ternary operator condition is always true\.$#'
+			identifier: ternary.alwaysTrue
+			count: 1
+			path: src/Phaseolies/Http/Controllers/Controller.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: src/Phaseolies/Http/Exceptions/HttpException.php
+
+		-
+			message: '#^Method Phaseolies\\Http\\Exceptions\\StreamedResponseException\:\:render\(\) has invalid return type Illuminate\\Http\\Response\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Phaseolies/Http/Exceptions/StreamedResponseException.php
+
+		-
+			message: '#^Method Phaseolies\\Http\\Exceptions\\StreamedResponseException\:\:render\(\) should return Illuminate\\Http\\Response but returns Phaseolies\\Http\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Phaseolies/Http/Exceptions/StreamedResponseException.php
+
+		-
+			message: '#^Method Phaseolies\\Http\\HeaderBag\:\:getIterator\(\) should return ArrayIterator\<string, list\<string\|null\>\> but returns ArrayIterator\<string, list\<string\|null\>\>\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Phaseolies/Http/HeaderBag.php
+
+		-
+			message: '#^Instanceof between array\|null and Closure will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
+			count: 1
+			path: src/Phaseolies/Http/ParameterBag.php
+
+		-
+			message: '#^Argument of an invalid type Phaseolies\\Http\\InputBag supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: src/Phaseolies/Http/Request.php
+
+		-
+			message: '#^Call to an undefined method ReflectionType\:\:getName\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Phaseolies/Http/Request.php
+
+		-
+			message: '#^Call to an undefined method ReflectionType\:\:isBuiltin\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Phaseolies/Http/Request.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\App\:\:setLocale\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Http/Request.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Str\:\:contains\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 2
+			path: src/Phaseolies/Http/Request.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Str\:\:startsWith\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Http/Request.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Str\:\:substr\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Http/Request.php
+
+		-
+			message: '#^Method Phaseolies\\Http\\Request\:\:header\(\) invoked with 2 parameters, 1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: src/Phaseolies/Http/Request.php
+
+		-
+			message: '#^Method Phaseolies\\Http\\Request\:\:headers\(\) should return array\<string, string\> but returns array\<string, list\<string\|null\>\>\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Phaseolies/Http/Request.php
+
+		-
+			message: '#^Method Phaseolies\\Http\\Request\:\:prefers\(\) should return string\|null but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: src/Phaseolies/Http/Request.php
+
+		-
+			message: '#^Non\-static access to static property Phaseolies\\Http\\Request\:\:\$trustedHeaderSet\.$#'
+			identifier: staticProperty.nonStaticAccess
+			count: 5
+			path: src/Phaseolies/Http/Request.php
+
+		-
+			message: '#^Non\-static access to static property Phaseolies\\Http\\Request\:\:\$trustedProxies\.$#'
+			identifier: staticProperty.nonStaticAccess
+			count: 1
+			path: src/Phaseolies/Http/Request.php
+
+		-
+			message: '#^PHPDoc tag @return has invalid value \(string\|null\.\)\: Unexpected token "\.", expected TOKEN_HORIZONTAL_WS at offset 108 on line 5$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Http/Request.php
+
+		-
+			message: '#^PHPDoc tag @return with type array\|Phaseolies\\Http\\Response\|null is not subtype of native type array\|Phaseolies\\Http\\Response\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: src/Phaseolies/Http/Request.php
+
+		-
+			message: '#^PHPDoc tag @throws with type Phaseolies\\Http\\SuspiciousOperationException is not subtype of Throwable$#'
+			identifier: throws.notThrowable
+			count: 1
+			path: src/Phaseolies/Http/Request.php
+
+		-
+			message: '#^Property Phaseolies\\Http\\Request\:\:\$errors \(array\<string, mixed\>\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: src/Phaseolies/Http/Request.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between resource\|string and false will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 3
+			path: src/Phaseolies/Http/Request.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between null and string will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 2
+			path: src/Phaseolies/Http/Request.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between resource\|string and false will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: src/Phaseolies/Http/Request.php
+
+		-
+			message: '#^Expression on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.expr
+			count: 2
+			path: src/Phaseolies/Http/Response.php
+
+		-
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
+			count: 1
+			path: src/Phaseolies/Http/Response.php
+
+		-
+			message: '#^Instanceof between array\<string, string\> and Phaseolies\\Http\\HeaderBag will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
+			count: 1
+			path: src/Phaseolies/Http/Response.php
+
+		-
+			message: '#^Method Phaseolies\\Http\\Request\:\:isHead\(\) invoked with 1 parameter, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: src/Phaseolies/Http/Response.php
+
+		-
+			message: '#^PHPDoc tag @return with type Phaseolies\\Http\\Response is not subtype of native type static\(Phaseolies\\Http\\Response\)\.$#'
+			identifier: return.phpDocType
+			count: 4
+			path: src/Phaseolies/Http/Response.php
+
+		-
+			message: '#^PHPDoc tag @return with type void is incompatible with native type static\(Phaseolies\\Http\\Response\)\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: src/Phaseolies/Http/Response.php
+
+		-
+			message: '#^Parameter \#2 \$datetime of static method DateTimeImmutable\:\:createFromFormat\(\) expects string, int\<\-172799, max\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Phaseolies/Http/Response.php
+
+		-
+			message: '#^Parameter \#2 \$value of method Phaseolies\\Http\\HeaderBag\:\:addCacheControlDirective\(\) expects bool\|string, int given\.$#'
+			identifier: argument.type
+			count: 4
+			path: src/Phaseolies/Http/Response.php
+
+		-
+			message: '#^Parameter \#2 \$values of method Phaseolies\\Http\\Response\\ResponseHeaderBag\:\:set\(\) expects array\<string\>\|string\|null, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Phaseolies/Http/Response.php
+
+		-
+			message: '#^Parameter \#2 \$values of method Phaseolies\\Http\\Response\\ResponseHeaderBag\:\:set\(\) expects array\<string\>\|string\|null, int\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Phaseolies/Http/Response.php
+
+		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: src/Phaseolies/Http/Response.php
+
+		-
+			message: '#^Method Phaseolies\\Http\\Response\\BaseJsonResponse\:\:update\(\) should return \$this\(Phaseolies\\Http\\Response\\BaseJsonResponse\) but returns static\(Phaseolies\\Http\\Response\\BaseJsonResponse\)\.$#'
+			identifier: return.type
+			count: 2
+			path: src/Phaseolies/Http/Response/BaseJsonResponse.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: src/Phaseolies/Http/Response/BaseJsonResponse.php
+
+		-
+			message: '#^Call to function in_array\(\) with arguments ''lax''\|''none''\|''strict''\|null, array\{''lax'', ''strict'', ''none'', null\} and true will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Phaseolies/Http/Response/Cookie.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: src/Phaseolies/Http/Response/Cookie.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Str\:\:snake\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Http/Response/RedirectResponse.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Str\:\:startsWith\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Http/Response/RedirectResponse.php
+
+		-
+			message: '#^PHPDoc tag @return with type Phaseolies\\Http\\Response is not subtype of native type Phaseolies\\Http\\Response\\RedirectResponse\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: src/Phaseolies/Http/Response/RedirectResponse.php
+
+		-
+			message: '#^Expression on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.expr
+			count: 1
+			path: src/Phaseolies/Http/Response/ResponseHeaderBag.php
+
+		-
+			message: '#^PHPDoc tag @param references unknown parameter\: \$partitioned$#'
+			identifier: parameter.notFound
+			count: 1
+			path: src/Phaseolies/Http/Response/ResponseHeaderBag.php
+
+		-
+			message: '#^Method Phaseolies\\Http\\Request\:\:isGet\(\) invoked with 1 parameter, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: src/Phaseolies/Http/Response/Stream/BinaryFileResponse.php
+
+		-
+			message: '#^Method Phaseolies\\Http\\Request\:\:isHead\(\) invoked with 1 parameter, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: src/Phaseolies/Http/Response/Stream/BinaryFileResponse.php
+
+		-
+			message: '#^Parameter \#2 \$datetime of static method DateTimeImmutable\:\:createFromFormat\(\) expects string, int\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Phaseolies/Http/Response/Stream/BinaryFileResponse.php
+
+		-
+			message: '#^Parameter \#2 \$values of method Phaseolies\\Http\\Response\\ResponseHeaderBag\:\:set\(\) expects array\<string\>\|string\|null, int given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/Phaseolies/Http/Response/Stream/BinaryFileResponse.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between false and int will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: src/Phaseolies/Http/Response/Stream/BinaryFileResponse.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between false and string will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: src/Phaseolies/Http/Response/Stream/BinaryFileResponse.php
+
+		-
+			message: '#^Instanceof between mixed and ArrayObject will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
+			count: 1
+			path: src/Phaseolies/Http/ResponseFactory.php
+
+		-
+			message: '#^Instanceof between mixed and JsonSerializable will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
+			count: 1
+			path: src/Phaseolies/Http/ResponseFactory.php
+
+		-
+			message: '#^Instanceof between mixed and Phaseolies\\Database\\Entity\\Builder will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
+			count: 1
+			path: src/Phaseolies/Http/ResponseFactory.php
+
+		-
+			message: '#^Instanceof between mixed and Phaseolies\\Database\\Entity\\Model will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
+			count: 1
+			path: src/Phaseolies/Http/ResponseFactory.php
+
+		-
+			message: '#^Instanceof between mixed and Phaseolies\\Support\\Collection will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
+			count: 1
+			path: src/Phaseolies/Http/ResponseFactory.php
+
+		-
+			message: '#^Instanceof between mixed and stdClass will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
+			count: 1
+			path: src/Phaseolies/Http/ResponseFactory.php
+
+		-
+			message: '#^Trait Phaseolies\\Http\\Support\\InteractsWithTrustedProxies is used zero times and is not analysed\.$#'
+			identifier: trait.unused
+			count: 1
+			path: src/Phaseolies/Http/Support/InteractsWithTrustedProxies.php
+
+		-
+			message: '#^Trait Phaseolies\\Http\\Support\\InteractsWithVerifyTwoFactorUser is used zero times and is not analysed\.$#'
+			identifier: trait.unused
+			count: 1
+			path: src/Phaseolies/Http/Support/InteractsWithVerifyTwoFactorUser.php
+
+		-
+			message: '#^Parameter \#1 \$content of function response expects null, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Phaseolies/Http/Support/RequestAbortion.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: src/Phaseolies/Http/Validation/Bind.php
+
+		-
+			message: '#^Call to an undefined method Phaseolies\\Http\\Validation\\FormRequest\:\:sanitize\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Phaseolies/Http/Validation/FormRequest.php
+
+		-
+			message: '#^PHPDoc tag @throws with type Phaseolies\\Http\\Validation\\HttpResponseException is not subtype of Throwable$#'
+			identifier: throws.notThrowable
+			count: 1
+			path: src/Phaseolies/Http/Validation/FormRequest.php
+
+		-
+			message: '#^Call to method getIO\(\) on an unknown class Composer\\Script\\Event\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Phaseolies/Installer.php
+
+		-
+			message: '#^Parameter \$event of method Phaseolies\\Installer\:\:postCreateProject\(\) has invalid type Composer\\Script\\Event\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Phaseolies/Installer.php
+
+		-
+			message: '#^PHPDoc tag @param references unknown parameter\: \$channel$#'
+			identifier: parameter.notFound
+			count: 1
+			path: src/Phaseolies/Logger/Contracts/AbstractHandler.php
+
+		-
+			message: '#^Method Phaseolies\\Middleware\\CacheHeaders\:\:__invoke\(\) has invalid return type Phaseolies\\Middleware\\Phaseolies\\Http\\Response\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Phaseolies/Middleware/CacheHeaders.php
+
+		-
+			message: '#^Method Phaseolies\\Middleware\\CacheHeaders\:\:__invoke\(\) should return Phaseolies\\Http\\Response but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Phaseolies/Middleware/CacheHeaders.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(\\Closure\(\\Phaseolies\\Http\\Request\) \$next\)\: Unexpected token "\(", expected variable at offset 124 on line 5$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Middleware/CacheHeaders.php
+
+		-
+			message: '#^PHPDoc tag @return with type Phaseolies\\Middleware\\Phaseolies\\Http\\Response is not subtype of native type Phaseolies\\Http\\Response\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: src/Phaseolies/Middleware/CacheHeaders.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between string\|null and false will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: src/Phaseolies/Middleware/CacheHeaders.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Str\:\:toUpper\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Middleware/CsrfTokenMiddleware.php
+
+		-
+			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
+			identifier: catch.neverThrown
+			count: 1
+			path: src/Phaseolies/Middleware/CsrfTokenMiddleware.php
+
+		-
+			message: '#^Method Phaseolies\\Middleware\\CsrfTokenMiddleware\:\:shouldAddXsrfTokenCookie\(\) invoked with 1 parameter, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: src/Phaseolies/Middleware/CsrfTokenMiddleware.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(\\Closure\(\\Phaseolies\\Http\\Request\) \$next\)\: Unexpected token "\(", expected variable at offset 128 on line 5$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Middleware/CsrfTokenMiddleware.php
+
+		-
+			message: '#^PHPDoc tag @throws with type Phaseolies\\Middleware\\HttpException is not subtype of Throwable$#'
+			identifier: throws.notThrowable
+			count: 1
+			path: src/Phaseolies/Middleware/CsrfTokenMiddleware.php
+
+		-
+			message: '#^Parameter \#1 \$string of function sha1 expects string, int\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Phaseolies/Middleware/ThrottleRequests.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Route\:\:group\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Providers/RouteServiceProvider.php
+
+		-
+			message: '#^Method Phaseolies\\Providers\\ServiceProvider\:\:pathsForProviderOrGroup\(\) should return array\|null but returns string\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Phaseolies/Providers/ServiceProvider.php
+
+		-
+			message: '#^Property Phaseolies\\Providers\\ServiceProvider\:\:\$publishGroups \(array\<string, array\<string, string\>\>\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: src/Phaseolies/Providers/ServiceProvider.php
+
+		-
+			message: '#^Property Phaseolies\\Providers\\ServiceProvider\:\:\$publishes \(array\<string, string\|null\>\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: src/Phaseolies/Providers/ServiceProvider.php
+
+		-
+			message: '#^Property Phaseolies\\Support\\Collection\:\:\$data \(array\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: src/Phaseolies/Support/Collection.php
+
+		-
+			message: '#^Property Phaseolies\\Support\\Collection\:\:\$model \(string\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 2
+			path: src/Phaseolies/Support/Collection.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 16
+			path: src/Phaseolies/Support/Collection.php
+
+		-
+			message: '#^Comparison operation "\<" between int\<80500, 80599\> and 70300 is always false\.$#'
+			identifier: smaller.alwaysFalse
+			count: 1
+			path: src/Phaseolies/Support/CookieJar.php
+
+		-
+			message: '#^PHPDoc tag @return with type void is incompatible with native type bool\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: src/Phaseolies/Support/CookieJar.php
+
+		-
+			message: '#^Variable \$cookies on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.variable
+			count: 1
+			path: src/Phaseolies/Support/CookieJar.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: array\)\: Unexpected token "\\n \* ", expected type at offset 430 on line 10$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Auth.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: array\)\: Unexpected token "\\n \* ", expected type at offset 657 on line 14$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Auth.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: bool\)\: Unexpected token "\\n \* ", expected type at offset 327 on line 7$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Auth.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: bool\)\: Unexpected token "\\n \* ", expected type at offset 477 on line 11$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Auth.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: bool\)\: Unexpected token "\\n \* ", expected type at offset 763 on line 16$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Auth.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(Model \$user\)\: bool\)\: Unexpected token "\\n \* ", expected type at offset 714 on line 15$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Auth.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(Model \$user, string \$code\)\: bool\)\: Unexpected token "\\n \* ", expected type at offset 605 on line 13$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Auth.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(string \$code\)\: bool\)\: Unexpected token "\\n \* ", expected type at offset 535 on line 12$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Auth.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(string \$qrCodeUrl\)\: string\)\: Unexpected token "\\n \*", expected type at offset 832 on line 17$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Auth.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(static id\(\)\: \?int\)\: Unexpected token "\\n \* ", expected type at offset 383 on line 9$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Auth.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(static onceUsingId\(int \$id\)\: \?User\)\: Unexpected token "\\n \* ", expected type at offset 263 on line 5$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Auth.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(static user\(\)\: \?User\)\: Unexpected token "\\n \* ", expected type at offset 295 on line 6$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Auth.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(string \$name, string \$owner\)\: AtomicLock\)\: Unexpected token "\\n \* ", expected type at offset 1405 on line 18$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Cache.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: PDO\)\: Unexpected token "\\n \* ", expected type at offset 631 on line 14$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/DB.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: array\)\: Unexpected token "\\n \* ", expected type at offset 489 on line 11$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/DB.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: int\)\: Unexpected token "\\n \* ", expected type at offset 297 on line 7$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/DB.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: int\)\: Unexpected token "\\n \* ", expected type at offset 402 on line 9$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/DB.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: void\)\: Unexpected token "\\n \* ", expected type at offset 114 on line 3$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/DB.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: void\)\: Unexpected token "\\n \* ", expected type at offset 148 on line 4$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/DB.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: void\)\: Unexpected token "\\n \* ", expected type at offset 184 on line 5$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/DB.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: void\)\: Unexpected token "\\n \*", expected type at offset 1532 on line 26$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/DB.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(Model \$model\)\: string\)\: Unexpected token "\\n \* ", expected type at offset 591 on line 13$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/DB.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(string \$table\)\: Builder\)\: Unexpected token "\\n \* ", expected type at offset 451 on line 10$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/DB.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(string \$table\)\: \\Phaseolies\\Database\\Entity\\Query\\Builder\)\: Unexpected token "\\n \* ", expected type at offset 1221 on line 21$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/DB.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(string \$table\)\: bool\)\: Unexpected token "\\n \* ", expected type at offset 541 on line 12$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/DB.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: array\)\: Unexpected token "\\n \* ", expected type at offset 2932 on line 58$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: bool\)\: Unexpected token "\\n \* ", expected type at offset 1633 on line 30$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: bool\)\: Unexpected token "\\n \* ", expected type at offset 1667 on line 31$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: bool\)\: Unexpected token "\\n \* ", expected type at offset 1708 on line 32$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: bool\)\: Unexpected token "\\n \* ", expected type at offset 1886 on line 36$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: bool\)\: Unexpected token "\\n \* ", expected type at offset 1927 on line 37$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: bool\)\: Unexpected token "\\n \* ", expected type at offset 2897 on line 57$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: bool\)\: Unexpected token "\\n \* ", expected type at offset 3103 on line 61$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: bool\)\: Unexpected token "\\n \* ", expected type at offset 3142 on line 62$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: bool\)\: Unexpected token "\\n \* ", expected type at offset 3182 on line 63$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: bool\)\: Unexpected token "\\n \* ", expected type at offset 3222 on line 64$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: bool\)\: Unexpected token "\\n \* ", expected type at offset 3253 on line 65$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: bool\)\: Unexpected token "\\n \* ", expected type at offset 3291 on line 66$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: bool\)\: Unexpected token "\\n \* ", expected type at offset 3328 on line 67$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: bool\)\: Unexpected token "\\n \* ", expected type at offset 661 on line 14$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: bool\)\: Unexpected token "\\n \* ", expected type at offset 695 on line 15$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: int\)\: Unexpected token "\\n \* ", expected type at offset 2068 on line 40$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: int\)\: Unexpected token "\\n \* ", expected type at offset 433 on line 10$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: static\)\: Unexpected token "\\n \* ", expected type at offset 1020 on line 21$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: static\)\: Unexpected token "\\n \* ", expected type at offset 1747 on line 33$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: static\)\: Unexpected token "\\n \* ", expected type at offset 1785 on line 34$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: static\)\: Unexpected token "\\n \* ", expected type at offset 2103 on line 41$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: static\)\: Unexpected token "\\n \* ", expected type at offset 2863 on line 56$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: string\)\: Unexpected token "\\n \* ", expected type at offset 1252 on line 25$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: string\)\: Unexpected token "\\n \* ", expected type at offset 804 on line 17$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\?\\DateTimeInterface \$date\)\: static\)\: Unexpected token "\\n \* ", expected type at offset 2219 on line 43$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\?string \$body\)\: static\)\: Unexpected token "\\n \* ", expected type at offset 52 on line 2$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(HttpException \$exception\)\: void\)\: Unexpected token "\\n \* ", expected type at offset 1217 on line 24$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(Request \$request\)\: bool\)\: Unexpected token "\\n \* ", expected type at offset 3067 on line 60$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(Request \$request\)\: static\)\: Unexpected token "\\n \* ", expected type at offset 856 on line 18$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\\DateTimeInterface \$date\)\: static\)\: Unexpected token "\\n \* ", expected type at offset 2036 on line 39$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(array \$headers\)\: Response\)\: Unexpected token "\\n \* ", expected type at offset 573 on line 12$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(array \$options\)\: static\)\: Unexpected token "\\n \* ", expected type at offset 2820 on line 55$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(int \$seconds\)\: static\)\: Unexpected token "\\n \* ", expected type at offset 2553 on line 50$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(int \$seconds\)\: static\)\: Unexpected token "\\n \* ", expected type at offset 2606 on line 51$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(int \$statusCode\)\: string\)\: Unexpected token "\\n \* ", expected type at offset 980 on line 20$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(int \$targetLevel, bool \$flush\)\: void\)\: Unexpected token "\\n \* ", expected type at offset 1145 on line 23$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(int \$value\)\: static\)\: Unexpected token "\\n \* ", expected type at offset 2303 on line 45$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(int \$value\)\: static\)\: Unexpected token "\\n \* ", expected type at offset 2357 on line 46$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(int \$value\)\: static\)\: Unexpected token "\\n \* ", expected type at offset 2419 on line 47$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(int \$value\)\: static\)\: Unexpected token "\\n \* ", expected type at offset 2473 on line 48$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(string \$charset\)\: static\)\: Unexpected token "\\n \* ", expected type at offset 224 on line 6$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(string \$version\)\: static\)\: Unexpected token "\\n \* ", expected type at offset 757 on line 16$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(static getBody\(\)\: \?string\)\: Unexpected token "\\n \* ", expected type at offset 89 on line 3$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(static getCharset\(\)\: \?string\)\: Unexpected token "\\n \* ", expected type at offset 264 on line 7$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(static getDate\(\)\: \?\\DateTimeImmutable\)\: Unexpected token "\\n \* ", expected type at offset 1976 on line 38$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(static getEtag\(\)\: \?string\)\: Unexpected token "\\n \* ", expected type at offset 2700 on line 53$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(static getExpires\(\)\: \?\\DateTimeImmutable\)\: Unexpected token "\\n \* ", expected type at offset 2155 on line 42$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(static getLastModified\(\)\: \?\\DateTimeImmutable\)\: Unexpected token "\\n \* ", expected type at offset 2663 on line 52$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(static getMaxAge\(\)\: \?int\)\: Unexpected token "\\n \* ", expected type at offset 2255 on line 44$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(static getTtl\(\)\: \?int\)\: Unexpected token "\\n \* ", expected type at offset 2506 on line 49$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Response.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: array\)\: Unexpected token "\\n \* ", expected type at offset 529 on line 12$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Session.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: string\)\: Unexpected token "\\n \* ", expected type at offset 563 on line 13$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Session.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: void\)\: Unexpected token "\\n \* ", expected type at offset 253 on line 6$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Session.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: void\)\: Unexpected token "\\n \* ", expected type at offset 432 on line 10$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Session.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: void\)\: Unexpected token "\\n \* ", expected type at offset 639 on line 15$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Session.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: void\)\: Unexpected token "\\n \* ", expected type at offset 801 on line 19$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Session.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: void\)\: Unexpected token "\\n \*", expected type at offset 843 on line 20$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Session.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(string \$id\)\: void\)\: Unexpected token "\\n \* ", expected type at offset 605 on line 14$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Session.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(string \$key\)\: bool\)\: Unexpected token "\\n \* ", expected type at offset 356 on line 8$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Session.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(string \$key\)\: void\)\: Unexpected token "\\n \* ", expected type at offset 400 on line 9$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Session.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(static token\(\)\: \?string\)\: Unexpected token "\\n \* ", expected type at offset 674 on line 16$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Facades/Session.php
+
+		-
+			message: '#^Call to an undefined static method Phaseolies\\Support\\Facades\\Storage\:\:getDiskPath\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Phaseolies/Support/File.php
+
+		-
+			message: '#^Call to function is_null\(\) with string will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: src/Phaseolies/Support/File.php
+
+		-
+			message: '#^Method Phaseolies\\Support\\File\:\:generateUniqueName\(\) invoked with 1 parameter, 0 required\.$#'
+			identifier: arguments.count
+			count: 2
+			path: src/Phaseolies/Support/File.php
+
+		-
+			message: '#^PHPDoc tag @method for method Phaseolies\\Support\\Lens\:\:flat\(\) parameter \#2 \$depth default value contains unresolvable type\.$#'
+			identifier: methodTag.unresolvableType
+			count: 1
+			path: src/Phaseolies/Support/Lens.php
+
+		-
+			message: '#^Unsafe call to private method Phaseolies\\Support\\Lens\:\:make\(\) through static\:\:\.$#'
+			identifier: staticClassAccess.privateMethod
+			count: 1
+			path: src/Phaseolies/Support/Lens.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: src/Phaseolies/Support/Lens.php
+
+		-
+			message: '#^Property Phaseolies\\Support\\Mail\\Driver\\MailMailDriver\:\:\$config is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: src/Phaseolies/Support/Mail/Driver/MailMailDriver.php
+
+		-
+			message: '#^Property Phaseolies\\Support\\Mail\\Driver\\QmailMailDriver\:\:\$config is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: src/Phaseolies/Support/Mail/Driver/QmailMailDriver.php
+
+		-
+			message: '#^Access to an undefined property Phaseolies\\Database\\Entity\\Model\:\:\$email\.$#'
+			identifier: property.notFound
+			count: 1
+			path: src/Phaseolies/Support/Mail/MailService.php
+
+		-
+			message: '#^Call to an undefined method Phaseolies\\Support\\Mail\\Mailable\:\:attachment\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Phaseolies/Support/Mail/MailService.php
+
+		-
+			message: '#^Call to an undefined method Phaseolies\\Support\\Mail\\Mailable\:\:subject\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Phaseolies/Support/Mail/MailService.php
+
+		-
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 2
+			path: src/Phaseolies/Support/Mail/MailService.php
+
+		-
+			message: '#^Class Phaseolies\\Support\\Mail\\MailService constructor invoked with 1 parameter, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: src/Phaseolies/Support/Mail/MailService.php
+
+		-
+			message: '#^Call to an undefined method Phaseolies\\Support\\Mail\\Mailable\:\:content\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: src/Phaseolies/Support/Mail/Mailable/View.php
+
+		-
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Phaseolies/Support/Mail/Mailable/View.php
+
+		-
+			message: '#^Using nullsafe property access "\?\-\>view" in empty\(\) is unnecessary\. Use \-\> instead\.$#'
+			identifier: nullsafe.neverNull
+			count: 1
+			path: src/Phaseolies/Support/Mail/Mailable/View.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: src/Phaseolies/Support/Presenter/Presenter.php
+
+		-
+			message: '#^Access to an undefined property Phaseolies\\Support\\Router\:\:\$routeMiddleware\.$#'
+			identifier: property.notFound
+			count: 2
+			path: src/Phaseolies/Support/Router.php
+
+		-
+			message: '#^Call to an undefined method \$this\(Phaseolies\\Support\\Router\)\:\:applyMiddleware\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Phaseolies/Support/Router.php
+
+		-
+			message: '#^Call to an undefined method Phaseolies\\Support\\Router\:\:handle\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Phaseolies/Support/Router.php
+
+		-
+			message: '#^Call to an undefined method ReflectionType\:\:getName\(\)\.$#'
+			identifier: method.notFound
+			count: 4
+			path: src/Phaseolies/Support/Router.php
+
+		-
+			message: '#^Call to an undefined method ReflectionType\:\:isBuiltin\(\)\.$#'
+			identifier: method.notFound
+			count: 4
+			path: src/Phaseolies/Support/Router.php
+
+		-
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 2
+			path: src/Phaseolies/Support/Router.php
+
+		-
+			message: '#^Call to function is_string\(\) with \*NEVER\* will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Phaseolies/Support/Router.php
+
+		-
+			message: '#^Cannot call method bindTo\(\) on request\|string\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/Phaseolies/Support/Router.php
+
+		-
+			message: '#^Class App\\Http\\Controllers\\Controller not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Phaseolies/Support/Router.php
+
+		-
+			message: '#^Instanceof between \*NEVER\* and Closure will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
+			count: 1
+			path: src/Phaseolies/Support/Router.php
+
+		-
+			message: '#^Instanceof between mixed and ArrayObject will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
+			count: 1
+			path: src/Phaseolies/Support/Router.php
+
+		-
+			message: '#^Instanceof between mixed and JsonSerializable will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
+			count: 1
+			path: src/Phaseolies/Support/Router.php
+
+		-
+			message: '#^Instanceof between mixed and Phaseolies\\Database\\Entity\\Builder will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
+			count: 1
+			path: src/Phaseolies/Support/Router.php
+
+		-
+			message: '#^Instanceof between mixed and Phaseolies\\Database\\Entity\\Model will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
+			count: 1
+			path: src/Phaseolies/Support/Router.php
+
+		-
+			message: '#^Instanceof between mixed and Ramsey\\Collection\\Collection will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
+			count: 1
+			path: src/Phaseolies/Support/Router.php
+
+		-
+			message: '#^Instanceof between mixed and stdClass will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
+			count: 1
+			path: src/Phaseolies/Support/Router.php
+
+		-
+			message: '#^Method Phaseolies\\Support\\Router\:\:middleware\(\) has invalid return type Phaseolies\\Support\\Route\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Phaseolies/Support/Router.php
+
+		-
+			message: '#^Offset 0 on non\-empty\-list\<mixed\>&callable\(string\)\: void on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: src/Phaseolies/Support/Router.php
+
+		-
+			message: '#^PHPDoc tag @param references unknown parameter\: \$key$#'
+			identifier: parameter.notFound
+			count: 1
+			path: src/Phaseolies/Support/Router.php
+
+		-
+			message: '#^PHPDoc tag @return with type Phaseolies\\Support\\Route is not subtype of native type Phaseolies\\Support\\Router\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: src/Phaseolies/Support/Router.php
+
+		-
+			message: '#^Parameter \#1 \$abstract of method Phaseolies\\Application\:\:make\(\) expects class\-string\<request\>, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Phaseolies/Support/Router.php
+
+		-
+			message: '#^Property Phaseolies\\Utilities\\Attributes\\BindPayload\:\:\$strict \(bool\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: src/Phaseolies/Support/Router.php
+
+		-
+			message: '#^Property Phaseolies\\Utilities\\Attributes\\Route\:\:\$middleware \(array\) on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.property
+			count: 1
+			path: src/Phaseolies/Support/Router.php
+
+		-
+			message: '#^Variable \$attributes on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.variable
+			count: 2
+			path: src/Phaseolies/Support/Router.php
+
+		-
+			message: '#^PHPDoc tag @param references unknown parameter\: \$data$#'
+			identifier: parameter.notFound
+			count: 1
+			path: src/Phaseolies/Support/Session.php
+
+		-
+			message: '#^Call to function is_null\(\) with string will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: src/Phaseolies/Support/Storage/FileSystem.php
+
+		-
+			message: '#^PHPDoc tag @method for method Phaseolies\\Support\\Storage\\StorageFileService\:\:store\(\) parameter \#2 \$file contains unknown class Phaseolies\\Support\\Storage\\File\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Phaseolies/Support/Storage/StorageFileService.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(\)\: string\)\: Unexpected token "\\n \* ", expected type at offset 130 on line 3$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Storage/StorageFileService.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(\(string\|array \$path\)\: bool\)\: Unexpected token "\\n \* ", expected type at offset 259 on line 6$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Storage/StorageFileService.php
+
+		-
+			message: '#^PHPDoc tag @method has invalid value \(static get\(string \$path\)\: \?string\)\: Unexpected token "\\n \* ", expected type at offset 175 on line 4$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/Storage/StorageFileService.php
+
+		-
+			message: '#^Instanceof between Iterator and Traversable will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: src/Phaseolies/Support/StreamCollection.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 1
+			path: src/Phaseolies/Support/StreamCollection.php
+
+		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: src/Phaseolies/Support/StreamCollection.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 10
+			path: src/Phaseolies/Support/StreamCollection.php
+
+		-
+			message: '#^Offset 0 on array\{list\<string\>\} on left side of \?\? always exists and is not nullable\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: src/Phaseolies/Support/StringService.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(string\)\: Unexpected token "\\n     ", expected variable at offset 219 on line 7$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Phaseolies/Support/StringService.php
+
+		-
+			message: '#^Expression on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.expr
+			count: 1
+			path: src/Phaseolies/Support/UrlGenerator.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between mixed and null will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 2
+			path: src/Phaseolies/Support/Validation/Sanitizer.php
+
+		-
+			message: '#^Call to an undefined method Phaseolies\\Support\\View\\View\:\:prepare\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Phaseolies/Support/View/View.php
+
+		-
+			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Phaseolies/Support/View/View.php
+
+		-
+			message: '#^PHPDoc tag @param references unknown parameter\: \$view$#'
+			identifier: parameter.notFound
+			count: 1
+			path: src/Phaseolies/Support/View/View.php
+
+		-
+			message: '#^Variable \$message might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/Phaseolies/Support/View/errors/401.odo.php
+
+		-
+			message: '#^Variable \$message might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/Phaseolies/Support/View/errors/403.odo.php
+
+		-
+			message: '#^Variable \$message might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/Phaseolies/Support/View/errors/404.odo.php
+
+		-
+			message: '#^Variable \$message might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/Phaseolies/Support/View/errors/429.odo.php
+
+		-
+			message: '#^Variable \$message might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/Phaseolies/Support/View/errors/500.odo.php
+
+		-
+			message: '#^Call to function is_string\(\) with array will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: src/Phaseolies/Utilities/Attributes/Route.php
+
+		-
+			message: '#^PHPDoc tag @param references unknown parameter\: \$v4Bytes$#'
+			identifier: parameter.notFound
+			count: 1
+			path: src/Phaseolies/Utilities/IpUtils.php
+
+		-
+			message: '#^PHPDoc tag @param references unknown parameter\: \$v6Bytes$#'
+			identifier: parameter.notFound
+			count: 1
+			path: src/Phaseolies/Utilities/IpUtils.php
+
+		-
+			message: '#^PHPDoc tag @return with type string\|null is incompatible with native type array\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: src/Phaseolies/Utilities/Paginator.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between 1 and 1 will always evaluate to true\.$#'
+			identifier: identical.alwaysTrue
+			count: 1
+			path: src/Phaseolies/Utilities/Paginator.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,11 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: 5
+    paths:
+        - src
+    scanFiles:
+        - .phpstan/stubs/AppHttpKernel.php
+    tmpDir: .phpstan.cache
+    reportUnmatchedIgnoredErrors: false

--- a/src/Phaseolies/Application.php
+++ b/src/Phaseolies/Application.php
@@ -239,7 +239,7 @@ class Application extends Container
      */
     public function langPath($path = ''): string
     {
-        return $this->getPath($this->buildPathFragment('lang', $path));
+        return $this->getPath($this->buildPathFragment('templates/lang', $path));
     }
 
     /**
@@ -486,7 +486,7 @@ class Application extends Container
      */
     public function resourcesPath($path = ''): string
     {
-        return $this->resourcesPath = $this->getPath($this->buildPathFragment('resources', $path));
+        return $this->resourcesPath = $this->getPath($this->buildPathFragment('templates', $path));
     }
 
     /**
@@ -497,7 +497,7 @@ class Application extends Container
      */
     public function clientPath($path = ''): string
     {
-        return $this->clientPath = $this->getPath($this->buildPathFragment('resources/client', $path));
+        return $this->clientPath = $this->getPath($this->buildPathFragment('templates/client', $path));
     }
 
     /**
@@ -508,7 +508,7 @@ class Application extends Container
      */
     public function bootstrapPath($path = ''): string
     {
-        return $this->bootstrapPath = $this->getPath($this->buildPathFragment('bootstrap', $path));
+        return $this->bootstrapPath = $this->getPath($this->buildPathFragment('runtime', $path));
     }
 
     /**
@@ -519,7 +519,7 @@ class Application extends Container
      */
     public function databasePath($path = ''): string
     {
-        return $this->databasePath = $this->getPath($this->buildPathFragment('database', $path));
+        return $this->databasePath = $this->getPath($this->buildPathFragment('schema', $path));
     }
 
     /**
@@ -568,7 +568,7 @@ class Application extends Container
      */
     public function appPath(): string
     {
-        return $this->appPath = $this->basePath();
+        return $this->appPath = $this->getPath('src');
     }
 
     /**
@@ -588,7 +588,7 @@ class Application extends Container
      */
     public function configPath($path = ''): string
     {
-        return $this->configPath = $this->getPath("config/{$path}");
+        return $this->configPath = $this->getPath("runtime/config/{$path}");
     }
 
     /**

--- a/src/Phaseolies/Application.php
+++ b/src/Phaseolies/Application.php
@@ -56,7 +56,7 @@ class Application extends Container
      *
      * @var string
      */
-    protected $resourcesPath;
+    protected $templatesPath;
 
     /**
      * The path to the client-side assets directory.
@@ -84,7 +84,7 @@ class Application extends Container
      *
      * @var string
      */
-    protected $databasePath;
+    protected $schemaPath;
 
     /**
      * The path to the public directory.
@@ -454,10 +454,10 @@ class Application extends Container
         $this->configPath = $this->configPath();
         $this->appPath = $this->appPath();
         $this->bootstrapPath = $this->bootstrapPath();
-        $this->databasePath = $this->databasePath();
+        $this->schemaPath = $this->schemaPath();
         $this->publicPath = $this->publicPath();
         $this->storagePath = $this->storagePath();
-        $this->resourcesPath = $this->resourcesPath();
+        $this->templatesPath = $this->templatesPath();
         $this->clientPath = $this->clientPath();
     }
 
@@ -484,9 +484,9 @@ class Application extends Container
      * @param string $path
      * @return string
      */
-    public function resourcesPath($path = ''): string
+    public function templatesPath($path = ''): string
     {
-        return $this->resourcesPath = $this->getPath($this->buildPathFragment('templates', $path));
+        return $this->templatesPath = $this->getPath($this->buildPathFragment('templates', $path));
     }
 
     /**
@@ -517,9 +517,9 @@ class Application extends Container
      * @param string $path
      * @return string
      */
-    public function databasePath($path = ''): string
+    public function schemaPath($path = ''): string
     {
-        return $this->databasePath = $this->getPath($this->buildPathFragment('schema', $path));
+        return $this->schemaPath = $this->getPath($this->buildPathFragment('schema', $path));
     }
 
     /**
@@ -748,9 +748,9 @@ class Application extends Container
         $this->singleton('path.config', fn() => $this->configPath());
         $this->singleton('path.public', fn() => $this->publicPath());
         $this->singleton('path.storage', fn() => $this->storagePath());
-        $this->singleton('path.resources', fn() => $this->resourcesPath());
+        $this->singleton('path.resources', fn() => $this->templatesPath());
         $this->singleton('path.client', fn() => $this->clientPath());
-        $this->singleton('path.database', fn() => $this->databasePath());
+        $this->singleton('path.database', fn() => $this->schemaPath());
     }
 
     /**
@@ -781,7 +781,7 @@ class Application extends Container
             fn() =>
             new \Phaseolies\Database\Migration\Migrator(
                 new \Phaseolies\Database\Migration\MigrationRepository(),
-                database_path('migrations')
+                schema_path('migrations')
             )
         );
     }

--- a/src/Phaseolies/Application.php
+++ b/src/Phaseolies/Application.php
@@ -479,7 +479,7 @@ class Application extends Container
     }
 
     /**
-     * Gets the resources path.
+     * Gets the templates path.
      *
      * @param string $path
      * @return string
@@ -748,7 +748,7 @@ class Application extends Container
         $this->singleton('path.config', fn() => $this->configPath());
         $this->singleton('path.public', fn() => $this->publicPath());
         $this->singleton('path.storage', fn() => $this->storagePath());
-        $this->singleton('path.resources', fn() => $this->templatesPath());
+        $this->singleton('path.templates', fn() => $this->templatesPath());
         $this->singleton('path.client', fn() => $this->clientPath());
         $this->singleton('path.database', fn() => $this->schemaPath());
     }

--- a/src/Phaseolies/Config/Config.php
+++ b/src/Phaseolies/Config/Config.php
@@ -68,7 +68,7 @@ final class Config
      */
     protected static function getConfigFiles(): array
     {
-        return self::$configFiles ??= glob(base_path('config/*.php')) ?: [];
+        return self::$configFiles ??= glob(base_path('runtime/config/*.php')) ?: [];
     }
 
     /**

--- a/src/Phaseolies/Console/Command.php
+++ b/src/Phaseolies/Console/Command.php
@@ -52,7 +52,7 @@ class Command extends Console
             return 'Phaseolies\\Console\\Commands' . $relativePath;
         }, $commandFiles);
 
-        $userDefineCommandsDir = base_path('app/Schedule/Commands');
+        $userDefineCommandsDir = base_path('src/Schedule/Commands');
         if (is_dir($userDefineCommandsDir)) {
             $files = [];
             $dirIterator = new RecursiveDirectoryIterator($userDefineCommandsDir);

--- a/src/Phaseolies/Console/Commands/FrontendInstallCommand.php
+++ b/src/Phaseolies/Console/Commands/FrontendInstallCommand.php
@@ -159,8 +159,8 @@ class FrontendInstallCommand extends Command
             client_path('css/app.css') => $this->clientCss($cssStack),
             client_path('js/' . $this->bootstrapFilename($typescript)) => $this->bootstrapFile($cssStack, $typescript, $htmx),
             client_path('js/' . $this->entryFilename($framework, $typescript)) => $this->entryFile($framework, $cssStack, $typescript),
-            base_path('resources/views/layouts/app.odo.php') => $this->appLayoutView($framework, $typescript),
-            base_path('resources/views/welcome.odo.php') => $this->welcomeView($framework, $typescript),
+            base_path('templates/views/layouts/app.odo.php') => $this->appLayoutView($framework, $typescript),
+            base_path('templates/views/welcome.odo.php') => $this->welcomeView($framework, $typescript),
         ];
 
         if ($cssStack === 'tailwind') {
@@ -278,9 +278,9 @@ class FrontendInstallCommand extends Command
     protected function trackedFrontendDirectories(): array
     {
         return [
-            $this->projectPath('resources/client'),
-            $this->projectPath('resources/client/css'),
-            $this->projectPath('resources/client/js'),
+            $this->projectPath('templates/client'),
+            $this->projectPath('templates/client/css'),
+            $this->projectPath('templates/client/js'),
             $this->projectPath('public/build'),
         ];
     }
@@ -313,7 +313,7 @@ class FrontendInstallCommand extends Command
      */
     protected function entryFilePath(string $framework, bool $typescript): string
     {
-        return 'resources/client/js/' . $this->entryFilename($framework, $typescript);
+        return 'templates/client/js/' . $this->entryFilename($framework, $typescript);
     }
 
     /**

--- a/src/Phaseolies/Console/Commands/FrontendInstallCommand.php
+++ b/src/Phaseolies/Console/Commands/FrontendInstallCommand.php
@@ -129,7 +129,7 @@ class FrontendInstallCommand extends Command
                 client_path(),
                 client_path('css'),
                 client_path('js'),
-                resource_path('views/layouts'),
+                template_path('views/layouts'),
                 storage_path('framework'),
             ] as $directory
         ) {

--- a/src/Phaseolies/Console/Commands/FrontendUninstallCommand.php
+++ b/src/Phaseolies/Console/Commands/FrontendUninstallCommand.php
@@ -135,11 +135,11 @@ class FrontendUninstallCommand extends Command
             client_path('js/App.tsx'),
             client_path('js/App.vue'),
             client_path('js/App.svelte'),
-            base_path('client/css/app.css'),
-            base_path('client/js/app.js'),
-            base_path('client/js/app.ts'),
-            base_path('client/js/bootstrap.js'),
-            base_path('client/js/bootstrap.ts'),
+            base_path('templates/client/css/app.css'),
+            base_path('templates/client/js/app.js'),
+            base_path('templates/client/js/app.ts'),
+            base_path('templates/client/js/bootstrap.js'),
+            base_path('templates/client/js/bootstrap.ts'),
             base_path('client/js/main.js'),
             base_path('client/js/main.ts'),
             base_path('client/js/main.jsx'),
@@ -195,7 +195,7 @@ class FrontendUninstallCommand extends Command
     protected function legacyFrontendDirectories(): array
     {
         return [
-            $this->projectPath('resources/client'),
+            $this->projectPath('templates/client'),
             $this->projectPath('client'),
         ];
     }
@@ -226,7 +226,7 @@ class FrontendUninstallCommand extends Command
      */
     protected function removeLegacyViteMarkersFromLayouts(): int
     {
-        $viewsPath = base_path('resources/views');
+        $viewsPath = base_path('templates/views');
 
         if (!is_dir($viewsPath)) {
             return 0;
@@ -357,7 +357,7 @@ class FrontendUninstallCommand extends Command
             && str_contains($contents, "storage/framework/vite.hot")
             && str_contains($contents, "outDir: 'public/build'")
             && (
-                str_contains($contents, "path.resolve(__dirname, 'resources/client')")
+                str_contains($contents, "path.resolve(__dirname, 'templates/client')")
                 || str_contains($contents, "path.resolve(__dirname, 'client')")
             );
     }
@@ -378,13 +378,13 @@ class FrontendUninstallCommand extends Command
 
         return ($decoded['compilerOptions']['moduleResolution'] ?? null) === 'Bundler'
             && ($decoded['compilerOptions']['baseUrl'] ?? null) === '.'
-            && in_array(($decoded['compilerOptions']['paths']['@/*'][0] ?? null), ['resources/client/js/*', 'client/js/*'], true)
+            && in_array(($decoded['compilerOptions']['paths']['@/*'][0] ?? null), ['templates/client/js/*', 'client/js/*'], true)
             && (
-                in_array('resources/client/**/*.ts', $decoded['include'] ?? [], true)
+                in_array('templates/client/**/*.ts', $decoded['include'] ?? [], true)
                 || in_array('client/**/*.ts', $decoded['include'] ?? [], true)
             )
             && (
-                in_array('resources/client/**/*.tsx', $decoded['include'] ?? [], true)
+                in_array('templates/client/**/*.tsx', $decoded['include'] ?? [], true)
                 || in_array('client/**/*.tsx', $decoded['include'] ?? [], true)
             );
     }

--- a/src/Phaseolies/Console/Commands/MakeAuthCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeAuthCommand.php
@@ -57,9 +57,9 @@ class MakeAuthCommand extends Command
     protected function createDirectories(): void
     {
         $paths = [
-            base_path('app/Http/Controllers/Auth/'),
-            base_path('resources/views/auth/'),
-            base_path('resources/views/layouts/'),
+            base_path('src/Http/Controllers/Auth/'),
+            base_path('templates/views/auth/'),
+            base_path('templates/views/layouts/'),
         ];
 
         foreach ($paths as $path) {
@@ -75,27 +75,27 @@ class MakeAuthCommand extends Command
     protected function generateControllers(): void
     {
         $this->createFile(
-            base_path('app/Http/Controllers/Auth/LoginController.php'),
+            base_path('src/Http/Controllers/Auth/LoginController.php'),
             $this->getStubContent('LoginController.stub')
         );
 
         $this->createFile(
-            base_path('app/Http/Controllers/Auth/RegisterController.php'),
+            base_path('src/Http/Controllers/Auth/RegisterController.php'),
             $this->getStubContent('RegisterController.stub')
         );
 
         $this->createFile(
-            base_path('app/Http/Controllers/Auth/TwoFactorAuthController.php'),
+            base_path('src/Http/Controllers/Auth/TwoFactorAuthController.php'),
             $this->getStubContent('TwoFactorAuthController.stub')
         );
 
         $this->createFile(
-            base_path('app/Http/Controllers/HomeController.php'),
+            base_path('src/Http/Controllers/HomeController.php'),
             $this->getStubContent('HomeController.stub')
         );
 
         $this->createFile(
-            base_path('app/Http/Controllers/ProfileController.php'),
+            base_path('src/Http/Controllers/ProfileController.php'),
             $this->getStubContent('ProfileController.stub')
         );
     }
@@ -115,7 +115,7 @@ class MakeAuthCommand extends Command
         ];
 
         foreach ($views as $destination => $stubFile) {
-            $destinationPath = base_path('resources/views/' . $destination);
+            $destinationPath = base_path('templates/views/' . $destination);
             $content = $this->getStubContent($stubFile);
             $this->createFile($destinationPath, $content);
         }
@@ -126,7 +126,7 @@ class MakeAuthCommand extends Command
      */
     protected function appendRoutes(): void
     {
-        $routesPath = base_path('routes/web.php');
+        $routesPath = base_path('runtime/routes/web.php');
 
         if (!file_exists($routesPath)) {
             throw new RuntimeException('Routes file not found: ' . $routesPath);
@@ -167,17 +167,17 @@ class MakeAuthCommand extends Command
     protected function authFilesExist(): bool
     {
         $filesToCheck = [
-            base_path('app/Http/Controllers/Auth/LoginController.php'),
-            base_path('app/Http/Controllers/Auth/RegisterController.php'),
-            base_path('app/Http/Controllers/Auth/TwoFactorAuthController.php'),
-            base_path('app/Http/Controllers/HomeController.php'),
-            base_path('app/Http/Controllers/ProfileController.php'),
-            base_path('resources/views/auth/login.odo.php'),
-            base_path('resources/views/auth/2fa.odo.php'),
-            base_path('resources/views/auth/register.odo.php'),
-            base_path('resources/views/layouts/app.odo.php'),
-            base_path('resources/views/home.odo.php'),
-            base_path('resources/views/profile.odo.php'),
+            base_path('src/Http/Controllers/Auth/LoginController.php'),
+            base_path('src/Http/Controllers/Auth/RegisterController.php'),
+            base_path('src/Http/Controllers/Auth/TwoFactorAuthController.php'),
+            base_path('src/Http/Controllers/HomeController.php'),
+            base_path('src/Http/Controllers/ProfileController.php'),
+            base_path('templates/views/auth/login.odo.php'),
+            base_path('templates/views/auth/2fa.odo.php'),
+            base_path('templates/views/auth/register.odo.php'),
+            base_path('templates/views/layouts/app.odo.php'),
+            base_path('templates/views/home.odo.php'),
+            base_path('templates/views/profile.odo.php'),
         ];
 
         foreach ($filesToCheck as $file) {
@@ -196,19 +196,19 @@ class MakeAuthCommand extends Command
     {
         $files = [
             'Controllers' => [
-                base_path('app/Http/Controllers/Auth/LoginController.php'),
-                base_path('app/Http/Controllers/Auth/RegisterController.php'),
-                base_path('app/Http/Controllers/Auth/TwoFactorAuthController.php'),
-                base_path('app/Http/Controllers/HomeController.php'),
-                base_path('app/Http/Controllers/ProfileController.php'),
+                base_path('src/Http/Controllers/Auth/LoginController.php'),
+                base_path('src/Http/Controllers/Auth/RegisterController.php'),
+                base_path('src/Http/Controllers/Auth/TwoFactorAuthController.php'),
+                base_path('src/Http/Controllers/HomeController.php'),
+                base_path('src/Http/Controllers/ProfileController.php'),
             ],
             'Views' => [
-                base_path('resources/views/auth/login.odo.php'),
-                base_path('resources/views/auth/register.odo.php'),
-                base_path('resources/views/auth/2fa.odo.php'),
-                base_path('resources/views/layouts/app.odo.php'),
-                base_path('resources/views/home.odo.php'),
-                base_path('resources/views/profile.odo.php'),
+                base_path('templates/views/auth/login.odo.php'),
+                base_path('templates/views/auth/register.odo.php'),
+                base_path('templates/views/auth/2fa.odo.php'),
+                base_path('templates/views/layouts/app.odo.php'),
+                base_path('templates/views/home.odo.php'),
+                base_path('templates/views/profile.odo.php'),
             ]
         ];
 

--- a/src/Phaseolies/Console/Commands/MakeAuthorizerCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeAuthorizerCommand.php
@@ -32,7 +32,7 @@ class MakeAuthorizerCommand extends Command
             $model = $this->option('model') ?? $this->option('m');
 
             $namespace = 'App\\Authorizers' . (count($parts) > 0 ? '\\' . implode('\\', $parts) : '');
-            $filePath = $this->generatedFilePath('app/Authorizers', $name);
+            $filePath = $this->generatedFilePath('src/Authorizers', $name);
 
             if (file_exists($filePath)) {
                 $this->displayError('Authorizer already exists at:');

--- a/src/Phaseolies/Console/Commands/MakeConsoleCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeConsoleCommand.php
@@ -30,7 +30,7 @@ class MakeConsoleCommand extends Command
         return $this->executeWithTiming(function() {
             [$name, $parts, $className] = $this->splitGeneratedName((string) $this->argument('name'));
             $namespace = 'App\\Schedule\\Commands' . (count($parts) > 0 ? '\\' . implode('\\', $parts) : '');
-            $filePath = $this->generatedFilePath('app/Schedule/Commands', $name);
+            $filePath = $this->generatedFilePath('src/Schedule/Commands', $name);
 
             if (file_exists($filePath)) {
                 $this->displayError('Command already exists at:');

--- a/src/Phaseolies/Console/Commands/MakeControllerCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeControllerCommand.php
@@ -129,7 +129,7 @@ class MakeControllerCommand extends Command
         string $routeName
     ): string {
         $baseNamespace = 'App\\Http\\Controllers';
-        $basePath = 'app/Http/Controllers/';
+        $basePath = 'src/Http/Controllers/';
 
         // Normalize route view name
         $routeView = str_replace(['\\', '/'], '.', $routeName);
@@ -201,7 +201,7 @@ class MakeControllerCommand extends Command
         $namespace = $baseNamespace . (count($parts) > 0 ? '\\' . implode('\\', $parts) : '');
 
         $filePath = $this->generatedFilePath(
-            'app/Http/Controllers' . ($isApi ? '/API' : ''),
+            'src/Http/Controllers' . ($isApi ? '/API' : ''),
             $name
         );
 
@@ -236,7 +236,7 @@ class MakeControllerCommand extends Command
         $layoutDir = base_path(str_replace(
             ['/', '\\'],
             DIRECTORY_SEPARATOR,
-            'resources/views/' . $this->normalizeGeneratedName($routeName)
+            'templates/views/' . $this->normalizeGeneratedName($routeName)
         ));
         $this->createDirIfMissing($layoutDir);
         $layoutPath = $layoutDir . '/default.odo.php';

--- a/src/Phaseolies/Console/Commands/MakeHookCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeHookCommand.php
@@ -30,7 +30,7 @@ class MakeHookCommand extends Command
         return $this->executeWithTiming(function() {
             [$name, $parts, $className] = $this->splitGeneratedName((string) $this->argument('name'));
             $namespace = 'App\\Hooks' . (count($parts) > 0 ? '\\' . implode('\\', $parts) : '');
-            $filePath = $this->generatedFilePath('app/Hooks', $name);
+            $filePath = $this->generatedFilePath('src/Hooks', $name);
 
             // Check if hook already exists
             if (file_exists($filePath)) {

--- a/src/Phaseolies/Console/Commands/MakeMailCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeMailCommand.php
@@ -36,7 +36,7 @@ class MakeMailCommand extends Command
             }
 
             $namespace = 'App\\Mail' . (count($parts) > 0 ? '\\' . implode('\\', $parts) : '');
-            $filePath = $this->generatedFilePath('app/Mail', $name);
+            $filePath = $this->generatedFilePath('src/Mail', $name);
 
             // Check if Mailable already exists
             if (file_exists($filePath)) {

--- a/src/Phaseolies/Console/Commands/MakeMiddlewareCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeMiddlewareCommand.php
@@ -30,7 +30,7 @@ class MakeMiddlewareCommand extends Command
         return $this->executeWithTiming(function() {
             [$name, $parts, $className] = $this->splitGeneratedName((string) $this->argument('name'));
             $namespace = 'App\\Http\\Middleware' . (count($parts) > 0 ? '\\' . implode('\\', $parts) : '');
-            $filePath = $this->generatedFilePath('app/Http/Middleware', $name);
+            $filePath = $this->generatedFilePath('src/Http/Middleware', $name);
 
             // Check if middleware already exists
             if (file_exists($filePath)) {

--- a/src/Phaseolies/Console/Commands/MakeModelCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeModelCommand.php
@@ -51,7 +51,7 @@ class MakeModelCommand extends Command
             [$name, $parts, $className] = $this->splitGeneratedName((string) $this->argument('name'));
             $withMigration = $this->option('m');
             $namespace = 'App\\Models' . (count($parts) > 0 ? '\\' . implode('\\', $parts) : '');
-            $filePath = $this->generatedFilePath('app/Models', $name);
+            $filePath = $this->generatedFilePath('src/Models', $name);
 
             // Check if model already exists
             if (file_exists($filePath)) {
@@ -129,6 +129,6 @@ EOT;
      */
     protected function getMigrationPath(): string
     {
-        return base_path('database/migrations');
+        return base_path('schema/migrations');
     }
 }

--- a/src/Phaseolies/Console/Commands/MakeProviderCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeProviderCommand.php
@@ -30,7 +30,7 @@ class MakeProviderCommand extends Command
         return $this->executeWithTiming(function () {
             [$name, $parts, $className] = $this->splitGeneratedName((string) $this->argument('name'));
             $namespace = 'App\\Providers' . (count($parts) > 0 ? '\\' . implode('\\', $parts) : '');
-            $filePath = $this->generatedFilePath('app/Providers', $name);
+            $filePath = $this->generatedFilePath('src/Providers', $name);
 
             // Check if provider already exists
             if (file_exists($filePath)) {

--- a/src/Phaseolies/Console/Commands/MakeRequestCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeRequestCommand.php
@@ -36,7 +36,7 @@ class MakeRequestCommand extends Command
             }
 
             $namespace = 'App\\Http\\Validations' . (count($parts) > 0 ? '\\' . implode('\\', $parts) : '');
-            $filePath = $this->generatedFilePath('app/Http/Validations', $name);
+            $filePath = $this->generatedFilePath('src/Http/Validations', $name);
 
             // Check if request already exists
             if (file_exists($filePath)) {

--- a/src/Phaseolies/Console/Commands/MakeRuleCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeRuleCommand.php
@@ -30,7 +30,7 @@ class MakeRuleCommand extends Command
         return $this->executeWithTiming(function () {
             [$name, $parts, $className] = $this->splitGeneratedName((string) $this->argument('name'));
             $namespace = 'App\\Http\\Validations\\Rules' . (count($parts) > 0 ? '\\' . implode('\\', $parts) : '');
-            $filePath = $this->generatedFilePath('app/Http/Validations/Rules', $name);
+            $filePath = $this->generatedFilePath('src/Http/Validations/Rules', $name);
 
             // Check if rule already exists
             if (file_exists($filePath)) {

--- a/src/Phaseolies/Console/Commands/MakeWatcherCommand.php
+++ b/src/Phaseolies/Console/Commands/MakeWatcherCommand.php
@@ -30,7 +30,7 @@ class MakeWatcherCommand extends Command
         return $this->executeWithTiming(function () {
             [$name, $parts, $className] = $this->splitGeneratedName((string) $this->argument('name'));
             $namespace = 'App\\Watchers' . (count($parts) > 0 ? '\\' . implode('\\', $parts) : '');
-            $filePath  = $this->generatedFilePath('app/Watchers', $name);
+            $filePath  = $this->generatedFilePath('src/Watchers', $name);
 
             if (file_exists($filePath)) {
                 $this->displayError('Watcher already exists at:');

--- a/src/Phaseolies/Console/Commands/Migrations/AddColumnMigrationCommand.php
+++ b/src/Phaseolies/Console/Commands/Migrations/AddColumnMigrationCommand.php
@@ -76,6 +76,6 @@ class AddColumnMigrationCommand extends Command
      */
     protected function getMigrationPath(): string
     {
-        return base_path('database/migrations');
+        return base_path('schema/migrations');
     }
 }

--- a/src/Phaseolies/Console/Commands/Migrations/CreateMigrationCommand.php
+++ b/src/Phaseolies/Console/Commands/Migrations/CreateMigrationCommand.php
@@ -78,6 +78,6 @@ class CreateMigrationCommand extends Command
      */
     protected function getMigrationPath(): string
     {
-        return base_path('database/migrations');
+        return base_path('schema/migrations');
     }
 }

--- a/src/Phaseolies/Console/Commands/Migrations/CreateSeedCommand.php
+++ b/src/Phaseolies/Console/Commands/Migrations/CreateSeedCommand.php
@@ -29,7 +29,7 @@ class CreateSeedCommand extends Command
     {
         return $this->executeWithTiming(function() {
             $name = $this->argument('name');
-            $filePath = base_path('database/seeders/' . $name . '.php');
+            $filePath = base_path('schema/seeders/' . $name . '.php');
 
             if (file_exists($filePath)) {
                 $this->displayError('Seed file already exists!');

--- a/src/Phaseolies/Console/Commands/Migrations/MigrateTemporalCommand.php
+++ b/src/Phaseolies/Console/Commands/Migrations/MigrateTemporalCommand.php
@@ -37,7 +37,7 @@ class MigrateTemporalCommand extends Command
         return $this->executeWithTiming(function () {
             $connection = $this->option('connection') ?: null;
             $dryRun     = (bool) $this->option('show');
-            $modelsPath = $this->option('path') ?: base_path('app/Models');
+            $modelsPath = $this->option('path') ?: base_path('src/Models');
 
             $connectionLabel = $connection ?: 'per-model';
 

--- a/src/Phaseolies/Console/Commands/PaginationPublishCommand.php
+++ b/src/Phaseolies/Console/Commands/PaginationPublishCommand.php
@@ -27,8 +27,8 @@ class PaginationPublishCommand extends Command
      */
     public function handle(): int
     {
-        return $this->executeWithTiming(function() {
-            $paginationPath = resource_path('views/vendor/pagination');
+        return $this->executeWithTiming(function () {
+            $paginationPath = template_path('views/vendor/pagination');
 
             if (!is_dir($paginationPath)) {
                 if (!mkdir($paginationPath, 0755, true)) {

--- a/src/Phaseolies/Console/Commands/PaginationPublishCommand.php
+++ b/src/Phaseolies/Console/Commands/PaginationPublishCommand.php
@@ -18,7 +18,7 @@ class PaginationPublishCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Publish pagination views to resources/views/vendor/pagination';
+    protected $description = 'Publish pagination views to templates/views/vendor/pagination';
 
     /**
      * Execute the console command.

--- a/src/Phaseolies/Console/Commands/Presenter/BundleCommand.php
+++ b/src/Phaseolies/Console/Commands/Presenter/BundleCommand.php
@@ -30,7 +30,7 @@ class BundleCommand extends Command
         return $this->executeWithTiming(function () {
             [$name, $parts, $className] = $this->splitGeneratedName((string) $this->argument('name'));
             $namespace = 'App\\Http\\Presenters' . (count($parts) > 0 ? '\\' . implode('\\', $parts) : '');
-            $filePath = $this->generatedFilePath('app/Http/Presenters', $name);
+            $filePath = $this->generatedFilePath('src/Http/Presenters', $name);
 
             if (file_exists($filePath)) {
                 $this->displayError('Bundle class already exists at:');

--- a/src/Phaseolies/Console/Commands/Presenter/PresenterCommand.php
+++ b/src/Phaseolies/Console/Commands/Presenter/PresenterCommand.php
@@ -30,7 +30,7 @@ class PresenterCommand extends Command
         return $this->executeWithTiming(function () {
             [$name, $parts, $className] = $this->splitGeneratedName((string) $this->argument('name'));
             $namespace = 'App\\Http\\Presenters' . (count($parts) > 0 ? '\\' . implode('\\', $parts) : '');
-            $filePath = $this->generatedFilePath('app/Http/Presenters', $name);
+            $filePath = $this->generatedFilePath('src/Http/Presenters', $name);
 
             if (file_exists($filePath)) {
                 $this->displayError('Presenters already exists at:');

--- a/src/Phaseolies/Console/Commands/ViewCacheCommand.php
+++ b/src/Phaseolies/Console/Commands/ViewCacheCommand.php
@@ -37,7 +37,7 @@ class ViewCacheCommand extends Command
     public function handle(): int
     {
         return $this->executeWithTiming(function() {
-            $viewPath = base_path('resources/views');
+            $viewPath = base_path('templates/views');
             $cachePath = base_path('storage/framework/views');
 
             // Validate directories
@@ -77,7 +77,7 @@ class ViewCacheCommand extends Command
         $results = ['success' => [], 'failed' => []];
 
         foreach ($viewFiles as $file) {
-            $relativePath = $this->relativePath($file, base_path('resources/views'));
+            $relativePath = $this->relativePath($file, base_path('templates/views'));
             $viewName = str_replace(['/', '.odo.php'], ['.', ''], $relativePath);
 
             try {

--- a/src/Phaseolies/Console/Commands/stubs/controller/layouts/complete.stub
+++ b/src/Phaseolies/Console/Commands/stubs/controller/layouts/complete.stub
@@ -20,7 +20,7 @@
                 <p>The following files were created for you:</p>
                 <ul>
                     <li>Controller: <code>[[ $controllerPath ]]</code></li>
-                    <li>View: <code>resources/views/[[ $routeName ]]/default.odo.php</code></li>
+                    <li>View: <code>templates/views/[[ $routeName ]]/default.odo.php</code></li>
                 </ul>
             </div>
 

--- a/src/Phaseolies/Console/Commands/stubs/frontend/configs/tsconfig.stub
+++ b/src/Phaseolies/Console/Commands/stubs/frontend/configs/tsconfig.stub
@@ -12,8 +12,8 @@
 {{ jsxOption }}
         "baseUrl": ".",
         "paths": {
-            "@/*": ["resources/client/js/*"]
+            "@/*": ["templates/client/js/*"]
         }
     },
-    "include": ["resources/client/**/*.ts", "resources/client/**/*.tsx", "resources/client/**/*.vue", "resources/client/**/*.svelte"]
+    "include": ["templates/client/**/*.ts", "templates/client/**/*.tsx", "templates/client/**/*.vue", "templates/client/**/*.svelte"]
 }

--- a/src/Phaseolies/Console/Commands/stubs/frontend/configs/vite.stub
+++ b/src/Phaseolies/Console/Commands/stubs/frontend/configs/vite.stub
@@ -46,8 +46,8 @@ export default defineConfig({
     publicDir: false,
     resolve: {
         alias: {
-            '~client': path.resolve(__dirname, 'resources/client'),
-            '@': path.resolve(__dirname, 'resources/client/js'),
+            '~client': path.resolve(__dirname, 'templates/client'),
+            '@': path.resolve(__dirname, 'templates/client/js'),
         },
     },
     server: {

--- a/src/Phaseolies/Database/Migration/Migrator.php
+++ b/src/Phaseolies/Database/Migration/Migrator.php
@@ -88,7 +88,7 @@ class Migrator
         $migrations = array_diff($fileNames, $ran);
 
         foreach ($vendorMigrations as $basename => $vendorPath) {
-            if (!file_exists(database_path('migration/' . $basename))) {
+            if (!file_exists(schema_path('migration/' . $basename))) {
                 $migrations[] = $vendorPath;
             }
 

--- a/src/Phaseolies/Database/Migration/Migrator.php
+++ b/src/Phaseolies/Database/Migration/Migrator.php
@@ -88,7 +88,7 @@ class Migrator
         $migrations = array_diff($fileNames, $ran);
 
         foreach ($vendorMigrations as $basename => $vendorPath) {
-            if (!file_exists(schema_path('migration/' . $basename))) {
+            if (!file_exists(schema_path('migrations/' . $basename))) {
                 $migrations[] = $vendorPath;
             }
 

--- a/src/Phaseolies/Database/Migration/Migrator.php
+++ b/src/Phaseolies/Database/Migration/Migrator.php
@@ -171,7 +171,7 @@ class Migrator
         /**
          * 🧠 Build a map by basename so project migrations override vendor ones
          * Example:
-         *   2025_10_11_000001_create_users_table.php → pick from database/migrations if exists
+         *   2025_10_11_000001_create_users_table.php → pick from schema/migrations if exists
          */
         $migrationMap = [];
 

--- a/src/Phaseolies/Error/WebErrorRenderer.php
+++ b/src/Phaseolies/Error/WebErrorRenderer.php
@@ -223,7 +223,7 @@ class WebErrorRenderer
     protected function resolveErrorViewPath(int $statusCode): ?string
     {
         $customPath = base_path(
-            'resources'
+            'templates'
             . DIRECTORY_SEPARATOR . 'views'
             . DIRECTORY_SEPARATOR . 'errors'
             . DIRECTORY_SEPARATOR . "{$statusCode}.odo.php"

--- a/src/Phaseolies/Helpers/helpers.php
+++ b/src/Phaseolies/Helpers/helpers.php
@@ -326,10 +326,10 @@ if (!function_exists('config')) {
      * Retrieve a configuration value by key.
      *
      * @param string $key
-     * @param string $default
+     * @param mixed $default
      * @return mixed
      */
-    function config(string|array $key, ?string $default = null): mixed
+    function config(string|array $key, mixed $default = null): mixed
     {
         if (is_array($key)) {
             foreach ($key as $k => $v) {
@@ -415,7 +415,7 @@ if (!function_exists('base_path')) {
 
         if ($basePath === null) {
             if (app()->runningInConsole()) {
-                $basePath = rtrim(getcwd(), DIRECTORY_SEPARATOR);
+            $basePath = rtrim(getcwd(), DIRECTORY_SEPARATOR);
             } elseif (defined('BASE_PATH')) {
                 $basePath = rtrim(BASE_PATH, DIRECTORY_SEPARATOR);
             } else {

--- a/src/Phaseolies/Helpers/helpers.php
+++ b/src/Phaseolies/Helpers/helpers.php
@@ -225,7 +225,7 @@ if (!function_exists('back')) {
      * @param int $status
      * @param array $headers
      * @param mixed $fallback
-     * @return \Phaseolies\Http\RedirectResponse
+     * @return \Phaseolies\Http\Response\RedirectResponse
      */
     function back($status = 302, $headers = [], $fallback = false)
     {
@@ -415,7 +415,7 @@ if (!function_exists('base_path')) {
 
         if ($basePath === null) {
             if (app()->runningInConsole()) {
-            $basePath = rtrim(getcwd(), DIRECTORY_SEPARATOR);
+                $basePath = rtrim(getcwd(), DIRECTORY_SEPARATOR);
             } elseif (defined('BASE_PATH')) {
                 $basePath = rtrim(BASE_PATH, DIRECTORY_SEPARATOR);
             } else {
@@ -728,16 +728,16 @@ if (!function_exists('public_path')) {
     }
 }
 
-if (!function_exists('resource_path')) {
+if (!function_exists('template_path')) {
     /**
-     * Get the resources path of the application.
+     * Get the template path of the application.
      *
      * @param string $path
      * @return string
      */
-    function resource_path(string $path = ''): string
+    function template_path(string $path = ''): string
     {
-        return app()->resourcesPath($path);
+        return app()->templatesPath($path);
     }
 }
 
@@ -767,16 +767,16 @@ if (!function_exists('config_path')) {
     }
 }
 
-if (!function_exists('database_path')) {
+if (!function_exists('schema_path')) {
     /**
-     * Get the database path of the application.
+     * Get the schema path of the application.
      *
      * @param string $path
      * @return string
      */
-    function database_path(string $path = ''): string
+    function schema_path(string $path = ''): string
     {
-        return app()->databasePath($path);
+        return app()->schemaPath($path);
     }
 }
 

--- a/src/Phaseolies/Http/Controllers/Controller.php
+++ b/src/Phaseolies/Http/Controllers/Controller.php
@@ -129,7 +129,7 @@ class Controller extends View
     {
         parent::__construct();
         $this->setFileExtension('.odo.php');
-        $this->setViewFolder('resources/views' . DIRECTORY_SEPARATOR);
+        $this->setViewFolder('templates/views' . DIRECTORY_SEPARATOR);
         $this->setCacheFolder('storage/framework/views' . DIRECTORY_SEPARATOR);
         $this->createCacheFolder();
         $this->setSymlinkPathFolder('storage/app/public' . DIRECTORY_SEPARATOR);
@@ -320,9 +320,9 @@ class Controller extends View
 
         $viewPath = str_replace('.', DIRECTORY_SEPARATOR, $viewName);
 
-        // First check published views in resources/views/vendor/{namespace}
+        // First check published views in templates/views/vendor/{namespace}
         // Prioritize published views over package views
-        $publishedPath = base_path('resources/views/vendor/' . $namespace);
+        $publishedPath = base_path('templates/views/vendor/' . $namespace);
         if (is_dir($publishedPath)) {
             $possiblePaths = [
                 $publishedPath . DIRECTORY_SEPARATOR . $viewPath . $this->fileExtension,

--- a/src/Phaseolies/Http/Response.php
+++ b/src/Phaseolies/Http/Response.php
@@ -662,7 +662,7 @@ class Response implements HttpStatus
      */
     protected static function renderErrorPage(int $status, string $message): void
     {
-        $customPath = base_path("resources/views/errors/{$status}.odo.php");
+        $customPath = base_path("templates/views/errors/{$status}.odo.php");
         $errorPage = base_path("vendor/doppar/framework/src/Phaseolies/Support/View/errors/{$status}.odo.php");
 
         if (file_exists($customPath)) {
@@ -734,7 +734,7 @@ class Response implements HttpStatus
 
         ob_start();
 
-        include base_path("resources/views/{$viewPath}.odo.php");
+        include base_path("templates/views/{$viewPath}.odo.php");
 
         return ob_get_clean();
     }

--- a/src/Phaseolies/Http/Support/RequestAbortion.php
+++ b/src/Phaseolies/Http/Support/RequestAbortion.php
@@ -26,7 +26,7 @@ class RequestAbortion
 
         $customPath =
             base_path(
-                'resources'
+                'templates'
                     . DIRECTORY_SEPARATOR . 'views'
                     . DIRECTORY_SEPARATOR . 'errors'
                     . DIRECTORY_SEPARATOR . "{$code}.odo.php"
@@ -99,8 +99,7 @@ class RequestAbortion
         string $message = '',
         array $headers = [],
         mixed $original = null
-    ): Response
-    {
+    ): Response {
         if (ob_get_level() > 0) {
             ob_get_clean();
         }

--- a/src/Phaseolies/Http/Support/ValidationRules.php
+++ b/src/Phaseolies/Http/Support/ValidationRules.php
@@ -569,7 +569,7 @@ trait ValidationRules
     {
         $value = $input[$fieldName] ?? '';
 
-        return $value === null || $value === '';
+        return $value === '';
     }
 
     /**
@@ -832,7 +832,7 @@ trait ValidationRules
             return empty($value);
         }
 
-        return $value === '' || $value === null;
+        return $value === '';
     }
 
     /**

--- a/src/Phaseolies/Providers/PackageServiceProvider.php
+++ b/src/Phaseolies/Providers/PackageServiceProvider.php
@@ -84,8 +84,8 @@ abstract class PackageServiceProvider extends ServiceProvider
 
         foreach ($paths as $from) {
             $publishPaths[$from] = match ($type) {
-                'migrations' => database_path('migrations/' . basename($from)),
-                'views' => resource_path('views/vendor/' . $this->packageName),
+                'migrations' => schema_path('migrations/' . basename($from)),
+                'views' => template_path('views/vendor/' . $this->packageName),
                 'lang' => lang_path('vendor/' . $this->packageName),
                 default => $from,
             };

--- a/src/Phaseolies/Providers/RouteServiceProvider.php
+++ b/src/Phaseolies/Providers/RouteServiceProvider.php
@@ -39,7 +39,7 @@ class RouteServiceProvider extends ServiceProvider
 
         $this->app->router->loadAttributeBasedRoutes();
 
-        Route::group(['prefix' => 'api'], fn() => require base_path('routes/api.php'));
+        Route::group(['prefix' => 'api'], fn() => require base_path('runtime/routes/api.php'));
 
         if ($this->app->router->shouldCacheRoutes()) {
             $this->app->router->cacheRoutes();

--- a/src/Phaseolies/Support/Facades/App.php
+++ b/src/Phaseolies/Support/Facades/App.php
@@ -5,9 +5,9 @@ namespace Phaseolies\Support\Facades;
 /**
  * @method static \Phaseolies\Application langPath($path = ''): string
  * @method static \Phaseolies\Application setBasePath(string $basePath): self
- * @method static \Phaseolies\Application resourcesPath($path = ''): string
+ * @method static \Phaseolies\Application templatesPath($path = ''): string
  * @method static \Phaseolies\Application bootstrapPath($path = ''): string
- * @method static \Phaseolies\Application databasePath($path = ''): string
+ * @method static \Phaseolies\Application schemaPath($path = ''): string
  * @method static \Phaseolies\Application publicPath($path = ''): string
  * @method static \Phaseolies\Application storagePath($path = ''): string
  * @method static \Phaseolies\Application appPath(): string

--- a/src/Phaseolies/Support/Router.php
+++ b/src/Phaseolies/Support/Router.php
@@ -1041,7 +1041,7 @@ class Router extends Kernel
     protected function loadRoutesFromFiles(): void
     {
         $routeFiles = [
-            base_path('routes/web.php')
+            base_path('runtime/routes/web.php')
         ];
 
         foreach ($routeFiles as $file) {

--- a/src/Phaseolies/Support/Router/InteractsWithDynamicControllerBinding.php
+++ b/src/Phaseolies/Support/Router/InteractsWithDynamicControllerBinding.php
@@ -151,7 +151,7 @@ trait InteractsWithDynamicControllerBinding
      */
     protected function scanDefaultControllerDirectory(): array
     {
-        $controllerPath = base_path('app/Http/Controllers');
+        $controllerPath = base_path('src/Http/Controllers');
         $controllers = [];
 
         if (!is_dir($controllerPath)) {

--- a/src/Phaseolies/Utilities/Paginator.php
+++ b/src/Phaseolies/Utilities/Paginator.php
@@ -209,7 +209,7 @@ class Paginator
      */
     public function linkWithJumps(): ?string
     {
-        if (file_exists(resource_path('views/vendor/pagination/jump.odo.php'))) {
+        if (file_exists(template_path('views/vendor/pagination/jump.odo.php'))) {
             return view('vendor.pagination.jump', ['paginator' => $this])->render();
         }
 
@@ -272,7 +272,7 @@ class Paginator
      */
     public function links(): ?string
     {
-        if (file_exists(resource_path('views/vendor/pagination/number.odo.php'))) {
+        if (file_exists(template_path('views/vendor/pagination/number.odo.php'))) {
             return view('vendor.pagination.number', ['paginator' => $this])->render();
         }
 

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -185,10 +185,10 @@ final class ApplicationTest extends TestCase
     public function testPathMethodsReturnCorrectPaths(): void
     {
         $stringService = app(StringService::class);
-        $this->assertStringEndsWith('/templates/views', $stringService->urlHarmonize($this->app->resourcesPath('views')));
+        $this->assertStringEndsWith('/templates/views', $stringService->urlHarmonize($this->app->templatesPath('views')));
         $this->assertStringEndsWith('/templates/client/js/pages', $stringService->urlHarmonize($this->app->clientPath('js\\pages')));
         $this->assertStringEndsWith('/runtime/cache', $stringService->urlHarmonize($this->app->bootstrapPath('cache')));
-        $this->assertStringEndsWith('/schema/migrations', $stringService->urlHarmonize($this->app->databasePath('migrations')));
+        $this->assertStringEndsWith('/schema/migrations', $stringService->urlHarmonize($this->app->schemaPath('migrations')));
         $this->assertStringEndsWith('/public/assets', $stringService->urlHarmonize($this->app->publicPath('assets')));
         $this->assertStringEndsWith('/storage/logs', $stringService->urlHarmonize($this->app->storagePath('logs')));
         $this->assertStringEndsWith('/runtime/config/app.php', $stringService->urlHarmonize($this->app->configPath('app.php')));

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -118,7 +118,11 @@ final class ApplicationTest extends TestCase
         ];
 
         foreach ($dirs as $dir) {
-            mkdir($this->tempBasePath . $dir, 0777, true);
+            $path = $this->tempBasePath . $dir;
+
+            if (!is_dir($path)) {
+                mkdir($path, 0777, true);
+            }
         }
 
         // Create minimal config file

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -107,14 +107,14 @@ final class ApplicationTest extends TestCase
     private function createDirectoryStructure(): void
     {
         $dirs = [
-            '/config',
-            '/bootstrap',
-            '/database/migrations',
+            '/runtime/config',
+            '/runtime',
+            '/schema/migrations',
             '/public',
             '/storage',
-            '/resources',
-            '/resources/lang',
-            '/app',
+            '/templates',
+            '/templates/lang',
+            '/src',
         ];
 
         foreach ($dirs as $dir) {
@@ -122,7 +122,7 @@ final class ApplicationTest extends TestCase
         }
 
         // Create minimal config file
-        file_put_contents($this->tempBasePath . '/config/app.php', "<?php return [
+        file_put_contents($this->tempBasePath . '/runtime/config/app.php', "<?php return [
             'env' => 'testing',
             'locale' => 'en',
             'fallback_locale' => 'en',
@@ -185,14 +185,14 @@ final class ApplicationTest extends TestCase
     public function testPathMethodsReturnCorrectPaths(): void
     {
         $stringService = app(StringService::class);
-        $this->assertStringEndsWith('/resources/views', $stringService->urlHarmonize($this->app->resourcesPath('views')));
-        $this->assertStringEndsWith('/resources/client/js/pages', $stringService->urlHarmonize($this->app->clientPath('js\\pages')));
-        $this->assertStringEndsWith('/bootstrap/cache', $stringService->urlHarmonize($this->app->bootstrapPath('cache')));
-        $this->assertStringEndsWith('/database/migrations', $stringService->urlHarmonize($this->app->databasePath('migrations')));
+        $this->assertStringEndsWith('/templates/views', $stringService->urlHarmonize($this->app->resourcesPath('views')));
+        $this->assertStringEndsWith('/templates/client/js/pages', $stringService->urlHarmonize($this->app->clientPath('js\\pages')));
+        $this->assertStringEndsWith('/runtime/cache', $stringService->urlHarmonize($this->app->bootstrapPath('cache')));
+        $this->assertStringEndsWith('/schema/migrations', $stringService->urlHarmonize($this->app->databasePath('migrations')));
         $this->assertStringEndsWith('/public/assets', $stringService->urlHarmonize($this->app->publicPath('assets')));
         $this->assertStringEndsWith('/storage/logs', $stringService->urlHarmonize($this->app->storagePath('logs')));
-        $this->assertStringEndsWith('/config/app.php', $stringService->urlHarmonize($this->app->configPath('app.php')));
-        $this->assertStringEndsWith('/lang/en', $stringService->urlHarmonize($this->app->langPath('en')));
+        $this->assertStringEndsWith('/runtime/config/app.php', $stringService->urlHarmonize($this->app->configPath('app.php')));
+        $this->assertStringEndsWith('/templates/lang/en', $stringService->urlHarmonize($this->app->langPath('en')));
     }
 
     public function testPathCaching(): void

--- a/tests/Console/CommandBehaviorCoverageTest.php
+++ b/tests/Console/CommandBehaviorCoverageTest.php
@@ -73,7 +73,7 @@ class CommandBehaviorCoverageTest extends TestCase
         $command->fakeArguments['name'] = 'ReportsSyncCommand';
 
         $result = $command->handle();
-        $file = Env::path('app/Schedule/Commands/ReportsSyncCommand.php');
+        $file = Env::path('src/Schedule/Commands/ReportsSyncCommand.php');
 
         $this->assertSame(0, $result);
         $this->assertFileExists($file);
@@ -88,16 +88,16 @@ class CommandBehaviorCoverageTest extends TestCase
             use InteractsWithFakeCommandIO;
         };
 
-        $routesPath = Env::path('routes/web.php');
+        $routesPath = Env::path('runtime/routes/web.php');
         mkdir(dirname($routesPath), 0755, true);
         file_put_contents($routesPath, "<?php\n");
 
         $result = $command->handle();
 
         $this->assertSame(0, $result);
-        $this->assertFileExists(Env::path('app/Http/Controllers/Auth/LoginController.php'));
-        $this->assertFileExists(Env::path('resources/views/auth/login.odo.php'));
-        $this->assertFileExists(Env::path('resources/views/layouts/app.odo.php'));
+        $this->assertFileExists(Env::path('src/Http/Controllers/Auth/LoginController.php'));
+        $this->assertFileExists(Env::path('templates/views/auth/login.odo.php'));
+        $this->assertFileExists(Env::path('templates/views/layouts/app.odo.php'));
         $this->assertSame("<?php\n", (string) file_get_contents($routesPath));
         $this->assertContains('Authentication scaffolding generated successfully', $command->capturedSuccesses);
     }
@@ -122,7 +122,7 @@ class CommandBehaviorCoverageTest extends TestCase
         $this->assertStringContainsString('namespace App\\Http\\Controllers\\Admin;', $content);
         $this->assertStringContainsString('class UserController', $content);
         $this->assertStringContainsString('view admin.users', $content);
-        $this->assertStringContainsString('path app/Http/Controllers/Admin/UserController.php', $content);
+        $this->assertStringContainsString('path src/Http/Controllers/Admin/UserController.php', $content);
     }
 
     public function testCommandHelpersNormalizeGeneratedNamesAndRelativePaths(): void
@@ -140,8 +140,8 @@ class CommandBehaviorCoverageTest extends TestCase
         $this->assertSame(['Admin', 'Hello'], $parts);
         $this->assertSame('TestProvider', $className);
         $this->assertSame(
-            'app/Providers/Hello/TestProvider.php',
-            $this->invokeMethod($command, 'relativePath', [Env::path('app/Providers/Hello/TestProvider.php')])
+            'src/Providers/Hello/TestProvider.php',
+            $this->invokeMethod($command, 'relativePath', [Env::path('src/Providers/Hello/TestProvider.php')])
         );
     }
 
@@ -155,7 +155,7 @@ class CommandBehaviorCoverageTest extends TestCase
         $command->fakeArguments['name'] = 'Hello\\TestProvider';
 
         $result = $command->handle();
-        $file = Env::path('app/Providers/Hello/TestProvider.php');
+        $file = Env::path('src/Providers/Hello/TestProvider.php');
         $contents = (string) file_get_contents($file);
         $lines = array_map(static fn(array $line): string => $line[0], $command->capturedLines);
 
@@ -164,7 +164,7 @@ class CommandBehaviorCoverageTest extends TestCase
         $this->assertStringContainsString('namespace App\\Providers\\Hello;', $contents);
         $this->assertStringContainsString('class TestProvider extends ServiceProvider', $contents);
         $this->assertContains(
-            '<fg=yellow>📦 File:</> <fg=white>app/Providers/Hello/TestProvider.php</>',
+            '<fg=yellow>📦 File:</> <fg=white>src/Providers/Hello/TestProvider.php</>',
             $lines
         );
     }
@@ -194,11 +194,11 @@ class CommandBehaviorCoverageTest extends TestCase
 
         $this->assertSame('App\\Http\\Controllers\\Admin', $namespace);
         $this->assertSame(
-            str_replace(['/', '\\'], DIRECTORY_SEPARATOR, Env::path('app/Http/Controllers/Admin/UserController.php')),
+            str_replace(['/', '\\'], DIRECTORY_SEPARATOR, Env::path('src/Http/Controllers/Admin/UserController.php')),
             $filePath
         );
         $this->assertSame('UserController', $className);
-        $this->assertFileExists(Env::path('resources/views/admin/users/default.odo.php'));
+        $this->assertFileExists(Env::path('templates/views/admin/users/default.odo.php'));
     }
 
     public function testMakeAuthorizerCommandGeneratesModelAwarePolicyMethods(): void
@@ -338,8 +338,8 @@ class CommandBehaviorCoverageTest extends TestCase
         $this->assertSame(0, $addColumn->handle());
         $this->assertSame(
             [
-                ['create_users_table', Env::path('database/migrations'), 'users', true],
-                ['add_status_to_orders', Env::path('database/migrations'), 'orders', false, 'status', 'string', 'name'],
+            ['create_users_table', Env::path('schema/migrations'), 'users', true],
+            ['add_status_to_orders', Env::path('schema/migrations'), 'orders', false, 'status', 'string', 'name'],
             ],
             $calls
         );
@@ -355,7 +355,7 @@ class CommandBehaviorCoverageTest extends TestCase
         $firstRun = $command->handle();
         $secondRun = $command->handle();
 
-        $paginationDir = Env::path('resources/views/vendor/pagination');
+        $paginationDir = Env::path('templates/views/vendor/pagination');
 
         $this->assertSame(0, $firstRun);
         $this->assertSame(0, $secondRun);
@@ -541,13 +541,13 @@ class CommandBehaviorCoverageTest extends TestCase
             use InteractsWithFakeCommandIO;
         };
 
-        $viewDir = Env::path('resources/views/admin');
+        $viewDir = Env::path('templates/views/admin');
         mkdir($viewDir, 0755, true);
         file_put_contents($viewDir . '/dashboard.odo.php', '<h1>Dashboard</h1>');
 
         $cacheDir = Env::path('storage/framework/views');
-        $this->invokeMethod($command, 'ensureDirectoriesExist', [Env::path('resources/views'), $cacheDir]);
-        $files = $this->invokeMethod($command, 'getAllViewFiles', [Env::path('resources/views')]);
+        $this->invokeMethod($command, 'ensureDirectoriesExist', [Env::path('templates/views'), $cacheDir]);
+        $files = $this->invokeMethod($command, 'getAllViewFiles', [Env::path('templates/views')]);
 
         $this->assertDirectoryExists($cacheDir);
         $this->assertSame([realpath($viewDir . '/dashboard.odo.php')], $files);

--- a/tests/Console/FrontendInstallCommandTest.php
+++ b/tests/Console/FrontendInstallCommandTest.php
@@ -16,7 +16,7 @@ class FrontendInstallCommandTest extends TestCase
         $pathMethod = new \ReflectionMethod($command, 'entryFilePath');
 
         $this->assertSame('main.tsx', $filenameMethod->invoke($command, 'react', true));
-        $this->assertSame('resources/client/js/main.tsx', $pathMethod->invoke($command, 'react', true));
+        $this->assertSame('templates/client/js/main.tsx', $pathMethod->invoke($command, 'react', true));
     }
 
     public function testVanillaWelcomeUsesSharedAppLayout(): void
@@ -57,7 +57,7 @@ class FrontendInstallCommandTest extends TestCase
         $this->assertStringContainsString("#extends('layouts.app')", $welcome);
         $this->assertStringContainsString('#section(\'content\')', $welcome);
         $this->assertStringContainsString('<div id="app"></div>', $welcome);
-        $this->assertStringContainsString("#vite('resources/client/js/main.ts')", $layout);
+        $this->assertStringContainsString("#vite('templates/client/js/main.ts')", $layout);
         $this->assertStringContainsString('<meta name="csrf-token" content="[[ csrf_token() ]]" />', $layout);
         $this->assertStringContainsString('window.__DOPPAR_FRONTEND__', $layout);
         $this->assertStringContainsString('csrfToken: "[[ csrf_token() ]]"', $layout);
@@ -72,7 +72,7 @@ class FrontendInstallCommandTest extends TestCase
 
         $layout = $method->invoke($command, 'vanilla', true);
 
-        $this->assertStringContainsString("#vite('resources/client/js/app.ts')", $layout);
+        $this->assertStringContainsString("#vite('templates/client/js/app.ts')", $layout);
         $this->assertStringContainsString("#yield('content')", $layout);
     }
 
@@ -85,7 +85,7 @@ class FrontendInstallCommandTest extends TestCase
         $config = $method->invoke($command, 'react', true);
         $entryFile = $entryMethod->invoke($command, 'react', 'none', true);
 
-        $this->assertStringContainsString("input: ['resources/client/js/main.tsx']", $config);
+        $this->assertStringContainsString("input: ['templates/client/js/main.tsx']", $config);
         $this->assertStringContainsString("publicDir: false", $config);
         $this->assertStringContainsString('fs.writeFileSync(hotFile, `${protocol}://${host}:${address.port}`);', $config);
         $this->assertStringContainsString("import './bootstrap';", $entryFile);
@@ -172,9 +172,9 @@ class FrontendInstallCommandTest extends TestCase
 
         $directories = array_map($this->normalizePath(...), $method->invoke($command));
 
-        $this->assertContains($this->normalizePath(getcwd() . '/resources/client'), $directories);
-        $this->assertContains($this->normalizePath(getcwd() . '/resources/client/css'), $directories);
-        $this->assertContains($this->normalizePath(getcwd() . '/resources/client/js'), $directories);
+        $this->assertContains($this->normalizePath(getcwd() . '/templates/client'), $directories);
+        $this->assertContains($this->normalizePath(getcwd() . '/templates/client/css'), $directories);
+        $this->assertContains($this->normalizePath(getcwd() . '/templates/client/js'), $directories);
     }
 
     public function testFrontendUninstallCommandIsRegisteredWithExpectedSignature(): void
@@ -195,7 +195,7 @@ class FrontendInstallCommandTest extends TestCase
 <html>
 <head>
     <!-- DOPPAR_FRONTEND_VITE_START -->
-    #vite('resources/client/js/main.tsx')
+    #vite('templates/client/js/main.tsx')
     <!-- DOPPAR_FRONTEND_VITE_END -->
 </head>
 <body>
@@ -207,7 +207,7 @@ ODO;
         $updated = $method->invoke($command, $contents);
 
         $this->assertStringNotContainsString('DOPPAR_FRONTEND_VITE_START', $updated);
-        $this->assertStringNotContainsString("#vite('resources/client/js/main.tsx')", $updated);
+        $this->assertStringNotContainsString("#vite('templates/client/js/main.tsx')", $updated);
         $this->assertStringNotContainsString('<div id="app"></div>', $updated);
     }
 
@@ -218,7 +218,7 @@ ODO;
 
         $directories = array_map($this->normalizePath(...), $method->invoke($command));
 
-        $this->assertContains($this->normalizePath(getcwd() . '/resources/client'), $directories);
+        $this->assertContains($this->normalizePath(getcwd() . '/templates/client'), $directories);
         $this->assertContains($this->normalizePath(getcwd() . '/client'), $directories);
     }
 

--- a/tests/Console/Support/CommandTestEnvironment.php
+++ b/tests/Console/Support/CommandTestEnvironment.php
@@ -263,7 +263,7 @@ namespace Phaseolies\Console\Commands {
     if (!function_exists(__NAMESPACE__ . '\resource_path')) {
         function resource_path(string $path = ''): string
         {
-            return CommandTestEnvironment::path('resources/' . ltrim($path, '/'));
+            return CommandTestEnvironment::path('templates/' . ltrim($path, '/'));
         }
     }
 

--- a/tests/Console/Support/CommandTestEnvironment.php
+++ b/tests/Console/Support/CommandTestEnvironment.php
@@ -2,241 +2,239 @@
 
 namespace Tests\Unit\Console\Support {
 
-final class CommandTestEnvironment
-{
-    public static string $root;
-
-    public static array $config = [];
-
-    public static array $appBindings = [];
-
-    public static ?object $appInstance = null;
-
-    public static array $errors = [];
-
-    public static function reset(): void
+    final class CommandTestEnvironment
     {
-        self::$root = rtrim(sys_get_temp_dir(), '/\\')
-            . DIRECTORY_SEPARATOR
-            . 'doppar-command-tests-'
-            . bin2hex(random_bytes(5));
-        self::$config = [
-            'app.name' => 'Doppar Demo',
-            'app.timezone' => 'UTC',
-            'database.default' => 'testing',
-        ];
-        self::$appBindings = [];
-        self::$appInstance = null;
-        self::$errors = [];
+        public static string $root;
 
-        if (!is_dir(self::$root)) {
-            mkdir(self::$root, 0755, true);
-        }
-    }
+        public static array $config = [];
 
-    public static function cleanup(): void
-    {
-        if (!isset(self::$root) || !is_dir(self::$root)) {
-            return;
+        public static array $appBindings = [];
+
+        public static ?object $appInstance = null;
+
+        public static array $errors = [];
+
+        public static function reset(): void
+        {
+            self::$root = rtrim(sys_get_temp_dir(), '/\\')
+                . DIRECTORY_SEPARATOR
+                . 'doppar-command-tests-'
+                . bin2hex(random_bytes(5));
+            self::$config = [
+                'app.name' => 'Doppar Demo',
+                'app.timezone' => 'UTC',
+                'database.default' => 'testing',
+            ];
+            self::$appBindings = [];
+            self::$appInstance = null;
+            self::$errors = [];
+
+            if (!is_dir(self::$root)) {
+                mkdir(self::$root, 0755, true);
+            }
         }
 
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator(self::$root, \FilesystemIterator::SKIP_DOTS),
-            \RecursiveIteratorIterator::CHILD_FIRST
-        );
+        public static function cleanup(): void
+        {
+            if (!isset(self::$root) || !is_dir(self::$root)) {
+                return;
+            }
 
-        foreach ($iterator as $item) {
-            if ($item->isLink()) {
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator(self::$root, \FilesystemIterator::SKIP_DOTS),
+                \RecursiveIteratorIterator::CHILD_FIRST
+            );
+
+            foreach ($iterator as $item) {
+                if ($item->isLink()) {
+                    unlink($item->getPathname());
+                    continue;
+                }
+
+                if ($item->isDir()) {
+                    rmdir($item->getPathname());
+                    continue;
+                }
+
                 unlink($item->getPathname());
-                continue;
             }
 
-            if ($item->isDir()) {
-                rmdir($item->getPathname());
-                continue;
+            rmdir(self::$root);
+        }
+
+        public static function path(string $path = ''): string
+        {
+            $base = rtrim(self::$root, '/\\');
+
+            if ($path === '') {
+                return $base;
             }
 
-            unlink($item->getPathname());
+            return $base . DIRECTORY_SEPARATOR . ltrim($path, '/\\');
         }
 
-        rmdir(self::$root);
-    }
+        public static function config(?string $key = null, mixed $default = null): mixed
+        {
+            if ($key === null) {
+                return self::$config;
+            }
 
-    public static function path(string $path = ''): string
-    {
-        $base = rtrim(self::$root, '/\\');
-
-        if ($path === '') {
-            return $base;
+            return self::$config[$key] ?? $default;
         }
 
-        return $base . DIRECTORY_SEPARATOR . ltrim($path, '/\\');
-    }
+        public static function app(?string $key = null): mixed
+        {
+            if ($key === null) {
+                return self::$appInstance;
+            }
 
-    public static function config(?string $key = null, mixed $default = null): mixed
-    {
-        if ($key === null) {
-            return self::$config;
+            return self::$appBindings[$key] ?? null;
         }
 
-        return self::$config[$key] ?? $default;
-    }
-
-    public static function app(?string $key = null): mixed
-    {
-        if ($key === null) {
-            return self::$appInstance;
+        public static function bind(string $key, mixed $value): void
+        {
+            self::$appBindings[$key] = $value;
         }
 
-        return self::$appBindings[$key] ?? null;
+        public static function recordError(string $message): void
+        {
+            self::$errors[] = $message;
+        }
     }
 
-    public static function bind(string $key, mixed $value): void
+    final class FakeStringHelper
     {
-        self::$appBindings[$key] = $value;
-    }
-
-    public static function recordError(string $message): void
-    {
-        self::$errors[] = $message;
-    }
-}
-
-final class FakeStringHelper
-{
-    public function suffixAppend(string $value, string $suffix): string
-    {
-        return str_ends_with($value, $suffix) ? $value : $value . $suffix;
-    }
-
-    public function removeSuffix(string $value, string $suffix): string
-    {
-        if (!str_ends_with($value, $suffix)) {
-            return $value;
+        public function suffixAppend(string $value, string $suffix): string
+        {
+            return str_ends_with($value, $suffix) ? $value : $value . $suffix;
         }
 
-        return substr($value, 0, -strlen($suffix));
-    }
+        public function removeSuffix(string $value, string $suffix): string
+        {
+            if (!str_ends_with($value, $suffix)) {
+                return $value;
+            }
 
-    public function snake(string $value): string
-    {
-        $value = preg_replace('/(?<!^)[A-Z]/', '_$0', $value) ?? $value;
-
-        return strtolower($value);
-    }
-}
-
-final class FakeSessionStore
-{
-    public int $flushCount = 0;
-
-    public function flush(): void
-    {
-        $this->flushCount++;
-    }
-}
-
-final class FakeDatabaseInspector
-{
-    public array $columns = [];
-
-    public function getTableColumns(string $table): array
-    {
-        return $this->columns[$table] ?? [];
-    }
-}
-
-trait InteractsWithFakeCommandIO
-{
-    public array $fakeArguments = [];
-
-    public array $fakeOptions = [];
-
-    public array $capturedLines = [];
-
-    public array $capturedInfos = [];
-
-    public array $capturedErrors = [];
-
-    public array $capturedWarnings = [];
-
-    public array $capturedSuccesses = [];
-
-    protected function argument($key = null)
-    {
-        if ($key === null) {
-            return $this->fakeArguments;
+            return substr($value, 0, -strlen($suffix));
         }
 
-        return $this->fakeArguments[$key] ?? null;
+        public function snake(string $value): string
+        {
+            $value = preg_replace('/(?<!^)[A-Z]/', '_$0', $value) ?? $value;
+
+            return strtolower($value);
+        }
     }
 
-    protected function option($key = null)
+    final class FakeSessionStore
     {
-        if ($key === null) {
-            return $this->fakeOptions;
+        public int $flushCount = 0;
+
+        public function flush(): void
+        {
+            $this->flushCount++;
+        }
+    }
+
+    final class FakeDatabaseInspector
+    {
+        public array $columns = [];
+
+        public function getTableColumns(string $table): array
+        {
+            return $this->columns[$table] ?? [];
+        }
+    }
+
+    trait InteractsWithFakeCommandIO
+    {
+        public array $fakeArguments = [];
+
+        public array $fakeOptions = [];
+
+        public array $capturedLines = [];
+
+        public array $capturedInfos = [];
+
+        public array $capturedErrors = [];
+
+        public array $capturedWarnings = [];
+
+        public array $capturedSuccesses = [];
+
+        protected function argument($key = null)
+        {
+            if ($key === null) {
+                return $this->fakeArguments;
+            }
+
+            return $this->fakeArguments[$key] ?? null;
         }
 
-        return $this->fakeOptions[$key] ?? null;
-    }
+        protected function option($key = null)
+        {
+            if ($key === null) {
+                return $this->fakeOptions;
+            }
 
-    protected function info($string): void
-    {
-        $this->capturedInfos[] = (string) $string;
-    }
-
-    protected function error($string): void
-    {
-        $this->capturedErrors[] = (string) $string;
-    }
-
-    protected function line(string $string, ?string $style = null): void
-    {
-        $this->capturedLines[] = [$string, $style];
-    }
-
-    protected function newLine($count = 1): void
-    {
-    }
-
-    protected function displaySuccess(string $message): void
-    {
-        $this->capturedSuccesses[] = $message;
-    }
-
-    protected function displayError(string $message): void
-    {
-        $this->capturedErrors[] = $message;
-    }
-
-    protected function displayWarning(string $message): void
-    {
-        $this->capturedWarnings[] = $message;
-    }
-
-    protected function displayInfo(string $message): void
-    {
-        $this->capturedInfos[] = $message;
-    }
-
-    protected function executeWithTiming(callable $callback): int
-    {
-        $result = $callback();
-
-        return is_int($result) ? $result : 0;
-    }
-
-    protected function withTiming(callable $operation, ?string $successMessage = null): int
-    {
-        $result = $operation();
-
-        if ($successMessage !== null) {
-            $this->displaySuccess($successMessage);
+            return $this->fakeOptions[$key] ?? null;
         }
 
-        return is_int($result) ? $result : 0;
+        protected function info($string): void
+        {
+            $this->capturedInfos[] = (string) $string;
+        }
+
+        protected function error($string): void
+        {
+            $this->capturedErrors[] = (string) $string;
+        }
+
+        protected function line(string $string, ?string $style = null): void
+        {
+            $this->capturedLines[] = [$string, $style];
+        }
+
+        protected function newLine($count = 1): void {}
+
+        protected function displaySuccess(string $message): void
+        {
+            $this->capturedSuccesses[] = $message;
+        }
+
+        protected function displayError(string $message): void
+        {
+            $this->capturedErrors[] = $message;
+        }
+
+        protected function displayWarning(string $message): void
+        {
+            $this->capturedWarnings[] = $message;
+        }
+
+        protected function displayInfo(string $message): void
+        {
+            $this->capturedInfos[] = $message;
+        }
+
+        protected function executeWithTiming(callable $callback): int
+        {
+            $result = $callback();
+
+            return is_int($result) ? $result : 0;
+        }
+
+        protected function withTiming(callable $operation, ?string $successMessage = null): int
+        {
+            $result = $operation();
+
+            if ($successMessage !== null) {
+                $this->displaySuccess($successMessage);
+            }
+
+            return is_int($result) ? $result : 0;
+        }
     }
-}
 }
 
 namespace Phaseolies\Console\Commands {
@@ -260,8 +258,8 @@ namespace Phaseolies\Console\Commands {
         }
     }
 
-    if (!function_exists(__NAMESPACE__ . '\resource_path')) {
-        function resource_path(string $path = ''): string
+    if (!function_exists(__NAMESPACE__ . '\template_path')) {
+        function template_path(string $path = ''): string
         {
             return CommandTestEnvironment::path('templates/' . ltrim($path, '/'));
         }

--- a/tests/Support/Database/ModelQueryDriverTestCase.php
+++ b/tests/Support/Database/ModelQueryDriverTestCase.php
@@ -317,7 +317,7 @@ abstract class ModelQueryDriverTestCase extends TestCase
             $this->markTestSkipped('The pdo_sqlite extension is required for SQLite model query tests.');
         }
 
-        return new PDO('sqlite:' . $this->sqliteDatabasePath());
+        return new PDO('sqlite:' . $this->sqliteschemaPath());
     }
 
     protected function createMysqlPdo(): PDO
@@ -431,7 +431,7 @@ abstract class ModelQueryDriverTestCase extends TestCase
         ];
     }
 
-    protected function sqliteDatabasePath(): string
+    protected function sqliteschemaPath(): string
     {
         $className = str_replace('\\', '-', static::class);
 

--- a/tests/Support/ViteManagerTest.php
+++ b/tests/Support/ViteManagerTest.php
@@ -62,10 +62,10 @@ class ViteManagerTest extends TestCase
 
         $manager = $this->stubbedManager(true);
 
-        $tags = $manager->tags('resources/client/js/app.js');
+        $tags = $manager->tags('templates/client/js/app.js');
 
         $this->assertStringContainsString('http://127.0.0.1:5173/@vite/client', $tags);
-        $this->assertStringContainsString('http://127.0.0.1:5173/resources/client/js/app.js', $tags);
+        $this->assertStringContainsString('http://127.0.0.1:5173/templates/client/js/app.js', $tags);
     }
 
     public function testHotReactEntriesAutomaticallyIncludeRefreshPreamble(): void
@@ -74,12 +74,12 @@ class ViteManagerTest extends TestCase
 
         $manager = $this->stubbedManager(true);
 
-        $tags = $manager->tags('resources/client/js/main.tsx');
+        $tags = $manager->tags('templates/client/js/main.tsx');
 
         $this->assertStringContainsString('http://127.0.0.1:5173/@react-refresh', $tags);
         $this->assertStringContainsString('__vite_plugin_react_preamble_installed__ = true', $tags);
         $this->assertStringContainsString('http://127.0.0.1:5173/@vite/client', $tags);
-        $this->assertStringContainsString('http://127.0.0.1:5173/resources/client/js/main.tsx', $tags);
+        $this->assertStringContainsString('http://127.0.0.1:5173/templates/client/js/main.tsx', $tags);
     }
 
     public function testTagsResolveManifestImportsStylesAndScripts(): void
@@ -87,19 +87,19 @@ class ViteManagerTest extends TestCase
         file_put_contents(
             Paths::$public . '/build/manifest.json',
             json_encode([
-                'resources/client/js/app.js' => [
+                'templates/client/js/app.js' => [
                     'file' => 'assets/app-123.js',
                     'css' => ['assets/app-123.css'],
-                    'imports' => ['resources/client/js/vendor.js'],
+                    'imports' => ['templates/client/js/vendor.js'],
                 ],
-                'resources/client/js/vendor.js' => [
+                'templates/client/js/vendor.js' => [
                     'file' => 'assets/vendor-456.js',
                     'css' => ['assets/vendor-456.css'],
                 ],
             ], JSON_PRETTY_PRINT)
         );
 
-        $tags = (new ViteManager())->tags('resources/client/js/app.js');
+        $tags = (new ViteManager())->tags('templates/client/js/app.js');
 
         $this->assertStringContainsString('modulepreload', $tags);
         $this->assertStringContainsString('https://example.test/build/assets/vendor-456.js', $tags);
@@ -113,7 +113,7 @@ class ViteManagerTest extends TestCase
         file_put_contents(
             Paths::$public . '/build/manifest.json',
             json_encode([
-                'resources/client/js/app.js' => ['file' => 'assets/app-123.js'],
+                'templates/client/js/app.js' => ['file' => 'assets/app-123.js'],
             ], JSON_PRETTY_PRINT)
         );
 
@@ -121,7 +121,7 @@ class ViteManagerTest extends TestCase
 
         $this->assertSame(
             'https://example.test/build/assets/app-123.js',
-            $manager->asset('resources/client/js/app.js')
+            $manager->asset('templates/client/js/app.js')
         );
 
         file_put_contents(Paths::$storage . '/framework/vite.hot', 'http://127.0.0.1:5173');
@@ -129,8 +129,8 @@ class ViteManagerTest extends TestCase
         $hotManager = $this->stubbedManager(true);
 
         $this->assertSame(
-            'http://127.0.0.1:5173/resources/client/js/app.js',
-            $hotManager->asset('resources/client/js/app.js')
+            'http://127.0.0.1:5173/templates/client/js/app.js',
+            $hotManager->asset('templates/client/js/app.js')
         );
     }
 
@@ -140,7 +140,7 @@ class ViteManagerTest extends TestCase
         file_put_contents(
             Paths::$public . '/build/manifest.json',
             json_encode([
-                'resources/client/js/app.js' => [
+                'templates/client/js/app.js' => [
                     'file' => 'assets/app-123.js',
                 ],
             ], JSON_PRETTY_PRINT)
@@ -148,7 +148,7 @@ class ViteManagerTest extends TestCase
 
         $manager = $this->stubbedManager(false);
 
-        $tags = $manager->tags('resources/client/js/app.js');
+        $tags = $manager->tags('templates/client/js/app.js');
 
         $this->assertStringContainsString('https://example.test/build/assets/app-123.js', $tags);
         $this->assertFileDoesNotExist(Paths::$storage . '/framework/vite.hot');
@@ -161,13 +161,13 @@ class ViteManagerTest extends TestCase
         file_put_contents(
             Paths::$public . '/build/.vite/manifest.json',
             json_encode([
-                'resources/client/js/app.js' => [
+                'templates/client/js/app.js' => [
                     'file' => 'assets/app-123.js',
                 ],
             ], JSON_PRETTY_PRINT)
         );
 
-        $tags = (new ViteManager())->tags('resources/client/js/app.js');
+        $tags = (new ViteManager())->tags('templates/client/js/app.js');
 
         $this->assertStringContainsString('https://example.test/build/assets/app-123.js', $tags);
     }
@@ -177,7 +177,7 @@ class ViteManagerTest extends TestCase
         file_put_contents(
             Paths::$public . '/build/manifest.json',
             json_encode([
-                'resources/client/js/app.js' => [
+                'templates/client/js/app.js' => [
                     'file' => 'assets/app-123.js',
                 ],
             ], JSON_PRETTY_PRINT)


### PR DESCRIPTION
Refactored the application skeleton to remove Laravel-style directory conventions while preserving existing framework behavior and APIs.

### New Folder Structure
```
my-app/
├── src/
│   ├── Http/
│   ├── Models/
│   ├── Providers/
│   ├── Jobs/
│   └── ...
├── runtime/
│   ├── app.php
│   ├── config/
│   └── routes/
│       ├── web.php
│       ├── api.php
├── schema/
│   ├── migrations/
│   ├── seeders/
│   └── database.sqlite
├── templates/
│   ├── views/
│   └── lang/
├── tests/
├── storage/
└── public/
```