### PR TITLE
Prompt for launcher selection in vendor:publish

### DIFF
--- a/src/Phaseolies/Console/Commands/VendorPublishCommand.php
+++ b/src/Phaseolies/Console/Commands/VendorPublishCommand.php
@@ -42,7 +42,7 @@ class VendorPublishCommand extends Command
         return $this->executeWithTiming(function () {
             $launcher = $this->option('launcher');
             $tag = $this->option('tag');
-            $force = $this->option('force');
+            $force = (bool) $this->option('force');
 
             if ($launcher) {
                 $this->publishLauncher($launcher, $force);
@@ -54,10 +54,61 @@ class VendorPublishCommand extends Command
                 return Command::SUCCESS;
             }
 
-            $this->publishAll($force);
-
-            return Command::SUCCESS;
+            return $this->publishInteractively($force);
         });
+    }
+
+    /**
+     * Prompt the user to choose which registered launcher to publish,
+     * falling back to publishing everything in non-interactive environments.
+     *
+     * @param bool $force
+     * @return int
+     */
+    protected function publishInteractively(bool $force): int
+    {
+        $launchers = $this->publishableLaunchers();
+
+        if (empty($launchers)) {
+            $this->displayWarning('No publishable launchers found.');
+            return Command::SUCCESS;
+        }
+
+        if (!$this->isInteractive()) {
+            $this->publishAll($force);
+            return Command::SUCCESS;
+        }
+
+        $choices = array_merge(['All'], $launchers);
+
+        $choice = $this->choice('Which launcher would you like to publish?', $choices, 'All');
+
+        if ($choice === 'All') {
+            $this->publishAll($force);
+            return Command::SUCCESS;
+        }
+
+        $this->publishLauncher($choice, $force);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Get the class names of registered launchers that have publishable paths.
+     *
+     * @return array<int, string>
+     */
+    protected function publishableLaunchers(): array
+    {
+        $launchers = [];
+
+        foreach ($this->app->getLaunchers() as $launcherInstance) {
+            if (!empty($launcherInstance->pathsToPublish())) {
+                $launchers[] = get_class($launcherInstance);
+            }
+        }
+
+        return $launchers;
     }
 
     protected function publishLauncher(string $launcher, bool $force = false)

--- a/src/Phaseolies/Console/Schedule/Command.php
+++ b/src/Phaseolies/Console/Schedule/Command.php
@@ -483,6 +483,16 @@ abstract class Command extends SymfonyCommand
     }
 
     /**
+     * Determine if the command is running in an interactive environment.
+     *
+     * @return bool
+     */
+    protected function isInteractive(): bool
+    {
+        return $this->input->isInteractive();
+    }
+
+    /**
      * Give the user a single choice from an array of answers.
      *
      * @param string $question

--- a/tests/Console/CommandBehaviorCoverageTest.php
+++ b/tests/Console/CommandBehaviorCoverageTest.php
@@ -32,6 +32,7 @@ use Phaseolies\Console\Commands\StorageLinkCommand;
 use Phaseolies\Console\Commands\StorageUnlinkCommand;
 use Phaseolies\Console\Commands\Tests\UnitTestCommand;
 use Phaseolies\Console\Commands\VendorPublishCommand;
+use Phaseolies\Launchers\ServiceLauncher;
 use Phaseolies\Console\Commands\ViewCacheCommand;
 use Phaseolies\Console\Commands\ViewClearCommand;
 use Phaseolies\Database\Migration\MigrationCreator;
@@ -678,10 +679,130 @@ class CommandBehaviorCoverageTest extends TestCase
         $this->assertContains('Skipping: File already exists at ' . $targetFile, $command->capturedWarnings);
     }
 
+    public function testVendorPublishCommandWarnsWhenNoLaunchersArePublishable(): void
+    {
+        $appStub = $this->createStub(Application::class);
+        $appStub->method('getLaunchers')->willReturn([]);
+        Env::$appInstance = $appStub;
+
+        $command = new class extends VendorPublishCommand
+        {
+            use InteractsWithFakeCommandIO;
+        };
+
+        $result = $command->handle();
+
+        $this->assertSame(0, $result);
+        $this->assertContains('No publishable launchers found.', $command->capturedWarnings);
+        $this->assertEmpty($command->capturedChoiceQuestions);
+    }
+
+    public function testVendorPublishCommandFallsBackToPublishingAllWhenNonInteractive(): void
+    {
+        $appStub = $this->createStub(Application::class);
+        $launcher = $this->makeFakePublishableLauncher($appStub, 'alpha');
+        $appStub->method('getLaunchers')->willReturn([$launcher]);
+        Env::$appInstance = $appStub;
+
+        $command = new class extends VendorPublishCommand
+        {
+            use InteractsWithFakeCommandIO;
+        };
+        $command->fakeInteractive = false;
+
+        $result = $command->handle();
+
+        $this->assertSame(0, $result);
+        $this->assertEmpty($command->capturedChoiceQuestions);
+        $this->assertContains('Published assets from 1 launchers', $command->capturedSuccesses);
+    }
+
+    public function testVendorPublishCommandPublishesAllWhenChoiceIsAll(): void
+    {
+        $appStub = $this->createStub(Application::class);
+        $launcherA = $this->makeFakePublishableLauncher($appStub, 'alpha', FakePublishableLauncherAlpha::class);
+        $launcherB = $this->makeFakePublishableLauncher($appStub, 'beta', FakePublishableLauncherBeta::class);
+        $appStub->method('getLaunchers')->willReturn([$launcherA, $launcherB]);
+        Env::$appInstance = $appStub;
+
+        $command = new class extends VendorPublishCommand
+        {
+            use InteractsWithFakeCommandIO;
+        };
+        $command->fakeChoiceAnswer = 'All';
+
+        $result = $command->handle();
+
+        $this->assertSame(0, $result);
+        $this->assertCount(1, $command->capturedChoiceQuestions);
+        $this->assertSame('All', $command->capturedChoiceQuestions[0]['default']);
+        $this->assertContains(get_class($launcherA), $command->capturedChoiceQuestions[0]['choices']);
+        $this->assertContains(get_class($launcherB), $command->capturedChoiceQuestions[0]['choices']);
+        $this->assertContains('Published assets from 2 launchers', $command->capturedSuccesses);
+    }
+
+    public function testVendorPublishCommandPublishesOnlyTheChosenLauncher(): void
+    {
+        $appStub = $this->createStub(Application::class);
+        $launcherA = $this->makeFakePublishableLauncher($appStub, 'alpha', FakePublishableLauncherAlpha::class);
+        $launcherB = $this->makeFakePublishableLauncher($appStub, 'beta', FakePublishableLauncherBeta::class);
+        $appStub->method('getLaunchers')->willReturn([$launcherA, $launcherB]);
+        $appStub->method('getLauncher')->willReturnCallback(
+            fn(string $class) => $class === get_class($launcherA) ? $launcherA : null
+        );
+        Env::$appInstance = $appStub;
+
+        $command = new class extends VendorPublishCommand
+        {
+            use InteractsWithFakeCommandIO;
+        };
+        $command->fakeChoiceAnswer = get_class($launcherA);
+
+        $result = $command->handle();
+
+        $this->assertSame(0, $result);
+        $this->assertContains('Published assets for launcher: ' . get_class($launcherA), $command->capturedSuccesses);
+        $this->assertNotContains('Published assets for launcher: ' . get_class($launcherB), $command->capturedSuccesses);
+    }
+
+    private function makeFakePublishableLauncher(object $app, string $label, string $className = FakePublishableLauncherAlpha::class): ServiceLauncher
+    {
+        $from = Env::path("vendor/{$label}/config.php");
+        $to = Env::path("published/{$label}/config.php");
+
+        @mkdir(dirname($from), 0755, true);
+        file_put_contents($from, '<?php return [];');
+
+        $launcher = new $className($app);
+        $launcher->publishes([$from => $to]);
+
+        return $launcher;
+    }
+
     private function invokeMethod(object $instance, string $method, array $arguments = []): mixed
     {
         $reflection = new \ReflectionMethod($instance, $method);
 
         return $reflection->invokeArgs($instance, $arguments);
     }
+}
+
+/**
+ * Distinct launcher fixtures for VendorPublishCommand tests.
+ *
+ * These must be separately-named (not anonymous) classes: two anonymous
+ * class expressions with identical bodies at the same source location
+ * resolve to the same PHP class, which would make it impossible to tell
+ * two fake launchers apart by class name in the tests above.
+ */
+class FakePublishableLauncherAlpha extends ServiceLauncher
+{
+    public function register() {}
+    public function launch() {}
+}
+
+class FakePublishableLauncherBeta extends ServiceLauncher
+{
+    public function register() {}
+    public function launch() {}
 }

--- a/tests/Console/Support/CommandTestEnvironment.php
+++ b/tests/Console/Support/CommandTestEnvironment.php
@@ -217,6 +217,28 @@ namespace Tests\Unit\Console\Support {
             $this->capturedInfos[] = $message;
         }
 
+        public bool $fakeInteractive = true;
+
+        public mixed $fakeChoiceAnswer = null;
+
+        public array $capturedChoiceQuestions = [];
+
+        protected function isInteractive(): bool
+        {
+            return $this->fakeInteractive;
+        }
+
+        protected function choice(string $question, array $choices, $default = null): mixed
+        {
+            $this->capturedChoiceQuestions[] = [
+                'question' => $question,
+                'choices' => $choices,
+                'default' => $default,
+            ];
+
+            return $this->fakeChoiceAnswer ?? $default;
+        }
+
         protected function executeWithTiming(callable $callback): int
         {
             $result = $callback();


### PR DESCRIPTION
## Summary
`vendor:publish` previously had two explicit modes `(--launcher=, --tag=)` and one silent default: run it with no options and it published assets from every registered launcher at once. There was no way to pick a single launcher without knowing its exact class name up front.

This adds an interactive picker for that default case, using the `choice()` prompt.

1. Running `vendor:publish` with no `--launcher/--tag` now lists every registered launcher that actually has publishable paths, plus an All option, and asks which to publish.
2. Non-interactive environments (CI, scripts, --no-interaction) are unaffected — falls back to publishing everything, same as before. Added a small isInteractive() wrapper on Command for this.
3. If no launcher has anything publishable, it says so instead of silently reporting Published assets from 0 launchers.