### PR TITLE
fix: mass-assignment on update:

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -537,7 +537,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Phaseolies\\Database\\Entity\\Builder\:\:\$creatable\.$#'
 			identifier: property.notFound
-			count: 1
+			count: 2
 			path: src/Phaseolies/Database/Entity/Builder.php
 
 		-

--- a/src/Phaseolies/Database/Entity/Query/InteractsWithModelQueryProcessing.php
+++ b/src/Phaseolies/Database/Entity/Query/InteractsWithModelQueryProcessing.php
@@ -165,6 +165,8 @@ trait InteractsWithModelQueryProcessing
             $isUpdatable = isset($this->attributes[$this->primaryKey]);
 
             if ($isUpdatable) {
+                $this->assertCreatableIsDefined();
+
                 if (self::$isHookShouldBeCalled && $this->fireBeforeHooks('updated') === false) {
                     return false;
                 }
@@ -172,9 +174,7 @@ trait InteractsWithModelQueryProcessing
                 $dirtyAttributes = $this->getDirtyAttributes();
                 $this->pruneNonColumnDirtyAttributes($dirtyAttributes);
                 $dirtyAttributes = $this->getDirtyAttributes();
-                if (!empty($this->creatable)) {
-                    $dirtyAttributes = array_intersect_key($dirtyAttributes, array_flip($this->creatable));
-                }
+                $dirtyAttributes = array_intersect_key($dirtyAttributes, array_flip($this->creatable));
 
                 if (empty($dirtyAttributes)) {
                     return true;
@@ -406,11 +406,7 @@ trait InteractsWithModelQueryProcessing
      */
     protected function getCreatableAttributes(): array
     {
-        if (empty($this->creatable)) {
-            throw new \RuntimeException(
-                "Model " . static::class . " has no \$creatable attributes defined."
-            );
-        }
+        $this->assertCreatableIsDefined();
 
         $creatableAttributes = [];
         foreach ($this->creatable as $attribute) {
@@ -420,6 +416,21 @@ trait InteractsWithModelQueryProcessing
         }
 
         return $creatableAttributes;
+    }
+
+    /**
+     * Ensure the model declares a $creatable whitelist before it is persisted.
+     *
+     * @return void
+     * @throws \RuntimeException
+     */
+    protected function assertCreatableIsDefined(): void
+    {
+        if (empty($this->creatable)) {
+            throw new \RuntimeException(
+                "Model " . static::class . " has no \$creatable attributes defined."
+            );
+        }
     }
 
     /**
@@ -463,6 +474,10 @@ trait InteractsWithModelQueryProcessing
             return false;
         }
 
+        $this->assertCreatableIsDefined();
+
+        $attributes = array_intersect_key($attributes, array_flip($this->creatable));
+
         foreach ($attributes as $key => $value) {
             $this->setAttribute($key, $value);
         }
@@ -474,13 +489,10 @@ trait InteractsWithModelQueryProcessing
         $dirty = $this->getDirtyAttributes();
         $this->pruneNonColumnDirtyAttributes($dirty);
         $dirty = $this->getDirtyAttributes();
+        $dirty = array_intersect_key($dirty, array_flip($this->creatable));
 
         if (empty($dirty)) {
             return true;
-        }
-
-        if (!empty($this->creatable)) {
-            $dirty = array_intersect_key($dirty, array_flip($this->creatable));
         }
 
         if ($this->usesTimestamps()) {

--- a/src/Phaseolies/Database/Entity/Query/InteractsWithModelQueryProcessing.php
+++ b/src/Phaseolies/Database/Entity/Query/InteractsWithModelQueryProcessing.php
@@ -174,7 +174,9 @@ trait InteractsWithModelQueryProcessing
                 $dirtyAttributes = $this->getDirtyAttributes();
                 $this->pruneNonColumnDirtyAttributes($dirtyAttributes);
                 $dirtyAttributes = $this->getDirtyAttributes();
-                $dirtyAttributes = array_intersect_key($dirtyAttributes, array_flip($this->creatable));
+                if (!empty($this->creatable)) {
+                    $dirtyAttributes = array_intersect_key($dirtyAttributes, array_flip($this->creatable));
+                }
 
                 if (empty($dirtyAttributes)) {
                     return true;

--- a/tests/Model/Query/EntityModelComplexQueryBehavior.php
+++ b/tests/Model/Query/EntityModelComplexQueryBehavior.php
@@ -541,6 +541,67 @@ abstract class EntityModelComplexQueryTest extends ModelQueryDriverTestCase
     }
 
     /**
+     * A model with no $creatable whitelist must refuse to persist an
+     * update via save() rather than silently writing every dirty
+     * attribute (mass-assignment safety must hold on update, not just
+     * on insert).
+     */
+    public function testSaveAsUpdateThrowsWhenCreatableUndeclared(): void
+    {
+        MockAnotherUser::saveMany([
+            ['name' => 'Guarded', 'email' => 'guarded@test.com', 'age' => 30, 'status' => 'active'],
+        ]);
+
+        $user = MockAnotherUser::where('email', 'guarded@test.com')->first();
+        $user->name = 'Changed Without Whitelist';
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('has no $creatable attributes defined');
+
+        $user->save();
+    }
+
+    /**
+     * Same guarantee for the update(array $attributes) entry point,
+     * which is the one most commonly fed request input directly
+     * (e.g. $model->update($request->all())).
+     */
+    public function testUpdateThrowsWhenCreatableUndeclared(): void
+    {
+        MockAnotherUser::saveMany([
+            ['name' => 'Guarded Two', 'email' => 'guarded2@test.com', 'age' => 31, 'status' => 'active'],
+        ]);
+
+        $user = MockAnotherUser::where('email', 'guarded2@test.com')->first();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('has no $creatable attributes defined');
+
+        $user->update(['name' => 'Changed Without Whitelist']);
+    }
+
+    /**
+     * When $creatable IS declared, update() must silently drop any key
+     * outside that whitelist rather than writing it — this is what
+     * stops $model->update($request->all()) from letting a caller set
+     * arbitrary columns (e.g. the primary key) that happen to be
+     * present in the input array.
+     */
+    public function testUpdateIgnoresKeysOutsideCreatableWhitelist(): void
+    {
+        $user = MockUser::find(2);
+        $originalId = $user->id;
+
+        $user->update(['id' => 9999, 'name' => 'Bob Renamed']);
+
+        $this->assertSame($originalId, $user->id);
+        $this->assertSame('Bob Renamed', $user->name);
+
+        $fresh = MockUser::find($originalId);
+        $this->assertSame('Bob Renamed', $fresh->name);
+    }
+
+    /**
      * Empty string assigned to model attribute is preserved as '', not null.
      */
     public function testSanitizeEmptyStringPreservedOnModel(): void

--- a/tests/Support/Model/MockComputedUser.php
+++ b/tests/Support/Model/MockComputedUser.php
@@ -11,6 +11,7 @@ class MockComputedUser extends Model
     protected $connection = 'default';
     protected $timeStamps = false;
 
+    protected $creatable = ['first_name', 'last_name', 'email', 'password'];
     protected $unexposable = ['password'];
 
     #[Computed]

--- a/tests/Support/Model/MockUser.php
+++ b/tests/Support/Model/MockUser.php
@@ -10,6 +10,7 @@ class MockUser extends Model
     protected $primaryKey = 'id';
     protected $connection = 'default';
     protected $timeStamps = false;
+    protected $creatable = ['name', 'email', 'age', 'status', 'score', 'bio'];
 
     public function posts()
     {


### PR DESCRIPTION
**Root cause:** save()-as-update and update(array $attributes) only applied the $creatable whitelist filter if (!empty($this->creatable)) — so any model that never declared $creatable (legal, since only insert enforced it) would persist every dirty attribute unfiltered on update, including attacker-supplied keys from update($request->all()).

### Fix (InteractsWithModelQueryProcessing.php):

Extracted the insert-path's throw into a shared assertCreatableIsDefined(), now called on both save()'s update branch and update() — a model must declare $creatable to be persisted at all, insert or update, matching the guarantee that already existed for insert.

Made the $creatable intersect on the dirty-attribute diff unconditional (previously skipped when $creatable was empty).
update() now also filters the incoming $attributes array against $creatable before ever calling setAttribute() — so non-whitelisted keys (e.g. id, role) never even land on the in-memory model, not just get dropped at persistence time.

Left fill() and model hydration (Builder.php row-loading, Model::__construct()) completely untouched — those load full DB rows including PK/timestamps and would break if guarded the same way. The vulnerability was specifically in the two request-facing write paths, not in hydration.