### PR TITLE
fix: Route response()->view() through the Odo rendering engine

### DIFF
--- a/src/Phaseolies/Http/Response.php
+++ b/src/Phaseolies/Http/Response.php
@@ -7,6 +7,7 @@ use Phaseolies\Http\Response\ResponseHeaderBag;
 use Phaseolies\Http\Response\JsonResponse;
 use Phaseolies\Http\Response\HttpStatus;
 use Phaseolies\Http\Exceptions\HttpException;
+use Phaseolies\Http\Controllers\Controller;
 
 class Response implements HttpStatus
 {
@@ -728,15 +729,7 @@ class Response implements HttpStatus
      */
     public function renderView(string $view, array $data = []): string
     {
-        $viewPath = str_replace('.', '/', $view);
-
-        extract($data);
-
-        ob_start();
-
-        include base_path("templates/views/{$viewPath}.odo.php");
-
-        return ob_get_clean();
+        return app(Controller::class)->render($view, $data, true);
     }
 
     /**

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit;
 
 use Phaseolies\Http\Response;
 use Phaseolies\Http\Request;
+use Phaseolies\Http\Controllers\Controller;
 use Phaseolies\Http\Response\JsonResponse;
 use Phaseolies\Http\Response\RedirectResponse;
 use Phaseolies\Http\Response\Stream\StreamedJsonResponse;
@@ -151,6 +152,28 @@ class ResponseTest extends TestCase
     {
         $this->response->setBody('Render test');
         $this->assertEquals('Render test', $this->response->render());
+    }
+
+    public function testRenderViewDelegatesToOdoController(): void
+    {
+        $controller = $this->createMock(Controller::class);
+        $controller->expects($this->once())
+            ->method('render')
+            ->with('demo', ['name' => 'Doppar'], true)
+            ->willReturn('<h1>Doppar</h1>');
+
+        $container = new Container();
+        $container->instance(Controller::class, $controller);
+        Container::setInstance($container);
+
+        try {
+            $this->assertSame(
+                '<h1>Doppar</h1>',
+                $this->response->renderView('demo', ['name' => 'Doppar'])
+            );
+        } finally {
+            Container::forgetInstance();
+        }
     }
 
     public function testJson()


### PR DESCRIPTION
response()->view() rendered .odo.php files directly with PHP, As a result, Odo directives such as #extends, #include ... were not compiled or processed

`view('foo')` and `response()->view('foo');` didn't render the same result