### PR TITLE
fix: SQL identifier injection

### DIFF
--- a/src/Phaseolies/Database/Entity/Builder.php
+++ b/src/Phaseolies/Database/Entity/Builder.php
@@ -229,6 +229,8 @@ class Builder
             return $this->whereNested($field, 'AND');
         }
 
+        $this->assertValidIdentifier($field);
+
         if (func_num_args() === 2) {
             $value = $operator;
             $operator = '=';
@@ -260,6 +262,8 @@ class Builder
         if (is_callable($field)) {
             return $this->whereNested($field, 'OR');
         }
+
+        $this->assertValidIdentifier($field);
 
         if (func_num_args() === 2) {
             $value = $operator;
@@ -312,6 +316,15 @@ class Builder
      */
     public function orderBy(string $field, string $direction = 'ASC'): self
     {
+        $this->assertValidIdentifier($field);
+
+        $direction = strtoupper($direction);
+        if (!in_array($direction, ['ASC', 'DESC'], true)) {
+            throw new \InvalidArgumentException(
+                "Invalid sort direction \"{$direction}\". Use \"ASC\" or \"DESC\"."
+            );
+        }
+
         $this->orderBy[] = [$field, $direction];
         return $this;
     }
@@ -324,6 +337,8 @@ class Builder
      */
     public function groupBy(string $field): self
     {
+        $this->assertValidIdentifier($field);
+
         $this->groupBy[] = $field;
         return $this;
     }
@@ -1817,6 +1832,8 @@ class Builder
      */
     public function whereIn(string $field, array $values): self
     {
+        $this->assertValidIdentifier($field);
+
         if (empty($values)) {
             return $this->where($field, '=', 'NULL');
         }
@@ -1840,6 +1857,8 @@ class Builder
      */
     public function orWhereIn(string $field, array $values): self
     {
+        $this->assertValidIdentifier($field);
+
         if (empty($values)) {
             $this->orWhere($field, '=', 'NULL');
             return $this;
@@ -2655,6 +2674,8 @@ class Builder
      */
     public function whereBetween(string $column, array $values, string $boolean = 'AND', bool $not = false): self
     {
+        $this->assertValidIdentifier($column);
+
         // Validate input
         if (count($values) !== 2) {
             throw new \InvalidArgumentException('whereBetween requires an array with exactly 2 values');
@@ -2720,6 +2741,8 @@ class Builder
      */
     public function whereNull(string $column, string $boolean = 'AND', bool $not = false): self
     {
+        $this->assertValidIdentifier($column);
+
         $this->conditions[] = [
             $boolean,
             $column,

--- a/src/Phaseolies/Database/Entity/Query/Builder.php
+++ b/src/Phaseolies/Database/Entity/Query/Builder.php
@@ -127,6 +127,8 @@ class Builder
             return $this->whereNested($field, 'AND');
         }
 
+        $this->assertValidIdentifier($field);
+
         if (func_num_args() === 2) {
             $value = $operator;
             $operator = '=';
@@ -158,6 +160,8 @@ class Builder
         if (is_callable($field)) {
             return $this->whereNested($field, 'OR');
         }
+
+        $this->assertValidIdentifier($field);
 
         if (func_num_args() === 2) {
             $value = $operator;
@@ -202,6 +206,15 @@ class Builder
      */
     public function orderBy(string $field, string $direction = 'ASC'): self
     {
+        $this->assertValidIdentifier($field);
+
+        $direction = strtoupper($direction);
+        if (!in_array($direction, ['ASC', 'DESC'], true)) {
+            throw new \InvalidArgumentException(
+                "Invalid sort direction \"{$direction}\". Use \"ASC\" or \"DESC\"."
+            );
+        }
+
         $this->orderBy[] = [$field, $direction];
         return $this;
     }
@@ -214,6 +227,8 @@ class Builder
      */
     public function groupBy(string $field): self
     {
+        $this->assertValidIdentifier($field);
+
         $this->groupBy[] = $field;
         return $this;
     }
@@ -512,6 +527,8 @@ class Builder
      */
     public function whereIn(string $field, array $values): self
     {
+        $this->assertValidIdentifier($field);
+
         if (empty($values)) {
             return $this->where($field, '=', 'NULL');
         }
@@ -534,6 +551,8 @@ class Builder
      */
     public function orWhereIn(string $field, array $values): self
     {
+        $this->assertValidIdentifier($field);
+
         if (empty($values)) {
             $this->orWhere($field, '=', 'NULL');
             return $this;
@@ -1069,6 +1088,8 @@ class Builder
      */
     public function whereBetween(string $column, array $values, string $boolean = 'AND', bool $not = false): self
     {
+        $this->assertValidIdentifier($column);
+
         // Validate input
         if (count($values) !== 2) {
             throw new \InvalidArgumentException('whereBetween requires an array with exactly 2 values');
@@ -1134,6 +1155,8 @@ class Builder
      */
     public function whereNull(string $column, string $boolean = 'AND', bool $not = false): self
     {
+        $this->assertValidIdentifier($column);
+
         $this->conditions[] = [
             $boolean,
             $column,

--- a/src/Phaseolies/Database/Entity/Query/Grammar.php
+++ b/src/Phaseolies/Database/Entity/Query/Grammar.php
@@ -5,6 +5,30 @@ namespace Phaseolies\Database\Entity\Query;
 trait Grammar
 {
     /**
+     * Matches a plain column name or a table-qualified column name
+     *
+     * @var string
+     */
+    private const VALID_IDENTIFIER_PATTERN = '/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/';
+
+    /**
+     * Ensure a value used as a column identifier is a safe
+     *
+     * @param string $identifier
+     * @return void
+     * @throws \InvalidArgumentException
+     */
+    protected function assertValidIdentifier(string $identifier): void
+    {
+        if (!preg_match(self::VALID_IDENTIFIER_PATTERN, $identifier)) {
+            throw new \InvalidArgumentException(
+                "Invalid column identifier \"{$identifier}\". " .
+                "Use whereRaw()/orderByRaw()/groupByRaw() to build conditions from raw SQL expressions."
+            );
+        }
+    }
+
+    /**
      * Get the current driver
      *
      * @return string
@@ -598,6 +622,8 @@ trait Grammar
      */
     protected function addLikeCondition(string $field, string $value, bool $caseSensitive, string $boolean): self
     {
+        $this->assertValidIdentifier($field);
+
         // Intentionally avoiding $caseSensitive search
         $driver = $this->getDriver();
         $likeValue = $this->prepareLikeValue($value);

--- a/src/Phaseolies/Database/Entity/Query/InteractsWithTimeframe.php
+++ b/src/Phaseolies/Database/Entity/Query/InteractsWithTimeframe.php
@@ -15,6 +15,8 @@ trait InteractsWithTimeframe
      */
     public function whereDate(string $column, $operator, ?string $value = null, string $boolean = 'AND'): self
     {
+        $this->assertValidIdentifier($column);
+
         if (func_num_args() === 2) {
             $value = $operator;
             $operator = '=';
@@ -60,6 +62,8 @@ trait InteractsWithTimeframe
      */
     public function whereMonth(string $column, $operator, ?string $value = null, string $boolean = 'AND'): self
     {
+        $this->assertValidIdentifier($column);
+
         if (func_num_args() === 2) {
             $value = $operator;
             $operator = '=';
@@ -104,6 +108,8 @@ trait InteractsWithTimeframe
      */
     public function whereYear(string $column, $operator, ?string $value = null, string $boolean = 'AND'): self
     {
+        $this->assertValidIdentifier($column);
+
         if (func_num_args() === 2) {
             $value = $operator;
             $operator = '=';
@@ -148,6 +154,8 @@ trait InteractsWithTimeframe
      */
     public function whereDay(string $column, $operator, ?string $value = null, string $boolean = 'AND'): self
     {
+        $this->assertValidIdentifier($column);
+
         if (func_num_args() === 2) {
             $value = $operator;
             $operator = '=';
@@ -192,6 +200,8 @@ trait InteractsWithTimeframe
      */
     public function whereTime(string $column, $operator, ?string $value = null, string $boolean = 'AND'): self
     {
+        $this->assertValidIdentifier($column);
+
         if (func_num_args() === 2) {
             $value = $operator;
             $operator = '=';
@@ -312,10 +322,21 @@ trait InteractsWithTimeframe
      */
     public function whereDateBetween(string $column, $start, $end): self
     {
+        $this->assertValidIdentifier($column);
+
         $start = $this->formatDate($start);
         $end = $this->formatDate($end);
 
-        return $this->whereBetween($this->date($column), [$start, $end]);
+        $this->conditions[] = [
+            'AND',
+            $this->date($column),
+            'BETWEEN',
+            $start,
+            $end,
+            'AND'
+        ];
+
+        return $this;
     }
 
     /**

--- a/tests/Builder/QueryBuilderTest.php
+++ b/tests/Builder/QueryBuilderTest.php
@@ -1088,6 +1088,82 @@ class QueryBuilderTest extends TestCase
         $this->assertLessThan(0.5, $queryTime); // Should complete within 0.5 seconds
     }
 
+    // ==================== IDENTIFIER VALIDATION (SQL INJECTION) TESTS ====================
+
+    public function testWhereRejectsInjectedColumnIdentifier(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->builder->where('status = 1; DROP TABLE users; --', 'active');
+    }
+
+    public function testOrderByRejectsInjectedColumnIdentifier(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->builder->orderBy('name; DROP TABLE users; --');
+    }
+
+    public function testOrderByRejectsInjectedDirection(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->builder->orderBy('name', 'ASC; DROP TABLE users; --');
+    }
+
+    public function testGroupByRejectsInjectedColumnIdentifier(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->builder->groupBy('department; DROP TABLE users; --');
+    }
+
+    public function testWhereInRejectsInjectedColumnIdentifier(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->builder->whereIn('status = 1) UNION SELECT * FROM users --', ['active']);
+    }
+
+    public function testWhereBetweenRejectsInjectedColumnIdentifier(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->builder->whereBetween('age) OR (1=1', [20, 30]);
+    }
+
+    public function testWhereNullRejectsInjectedColumnIdentifier(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->builder->whereNull('department) OR (1=1');
+    }
+
+    public function testWhereLikeRejectsInjectedColumnIdentifier(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->builder->whereLike('name) OR (1=1) --', 'John');
+    }
+
+    public function testWhereAcceptsPlainAndTableQualifiedColumns(): void
+    {
+        $users = $this->builder->where('status', 'active')->get();
+        $this->assertGreaterThan(0, $users->count());
+
+        $users = $this->builder->where('users.status', 'active')->get();
+        $this->assertGreaterThan(0, $users->count());
+    }
+
+    public function testOrderByNormalizesDirectionCaseInsensitively(): void
+    {
+        $users = $this->builder->orderBy('name', 'asc')->get();
+        $this->assertGreaterThan(0, $users->count());
+
+        $users = $this->builder->orderBy('name', 'desc')->get();
+        $this->assertGreaterThan(0, $users->count());
+    }
+
     protected function tearDown(): void
     {
         $this->pdo = null;

--- a/tests/Builder/TimeframeOrConditionsTest.php
+++ b/tests/Builder/TimeframeOrConditionsTest.php
@@ -312,4 +312,43 @@ class TimeframeOrConditionsTest extends TestCase
 
         $this->builder()->formatDateTime(99999);
     }
+
+    // ==================== IDENTIFIER VALIDATION (SQL INJECTION) TESTS ====================
+
+    public function testWhereDateRejectsInjectedColumnIdentifier()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->builder()->whereDate('created_at) OR (1=1', '2024-06-15');
+    }
+
+    public function testWhereMonthRejectsInjectedColumnIdentifier()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->builder()->whereMonth('created_at); DROP TABLE users; --', 6);
+    }
+
+    public function testWhereYearRejectsInjectedColumnIdentifier()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->builder()->whereYear('created_at) OR (1=1', 2024);
+    }
+
+    public function testWhereDateBetweenRejectsInjectedColumnIdentifier()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->builder()->whereDateBetween('created_at) OR (1=1', '2024-01-01', '2024-12-31');
+    }
+
+    public function testWhereDateBetweenStillWorksWithPlainColumn()
+    {
+        $sql = $this->builder()
+            ->whereDateBetween('created_at', '2024-01-01', '2024-12-31')
+            ->toSql();
+
+        $this->assertStringContainsString('DATE(created_at) BETWEEN ? AND ?', $sql);
+    }
 }


### PR DESCRIPTION
## Summary

Three security fixes for the ORM/query layer, found during a framework-wide review:

- **Session fixation**: `Authenticate::setUser()` now regenerates the session ID on every login path (fresh login, 2FA completion, remember-cookie resume) before writing the auth key.
- **Mass-assignment on update**: `save()`-as-update and `update()` previously skipped the `$creatable` whitelist filter entirely when a model didn't declare `$creatable` (only *insert* enforced it). Both paths now require `$creatable` to be declared, matching insert's existing guarantee.
- **SQL identifier injection**: `where()`, `orderBy()`, `groupBy()`, `whereIn()`, `whereBetween()`, `whereNull()`, `whereLike()`, and the `whereDate`/`whereMonth`/`whereYear`/`whereDay`/`whereTime` helpers interpolated column names (and `orderBy`'s direction) into SQL with no validation — only *values* were bound. Added a strict identifier allowlist (`column` or `table.column`) validated at each entry point, across both query builder classes (`Entity\Builder` and `Entity\Query\Builder`). `whereRaw()`/`orderByRaw()`/`groupByRaw()` remain the unchanged, intentional raw-SQL escape hatch.