### PR TITLE
fix : cross-platform absolute path handling in base_path()

### DIFF
--- a/src/Phaseolies/Helpers/helpers.php
+++ b/src/Phaseolies/Helpers/helpers.php
@@ -427,7 +427,16 @@ if (!function_exists('base_path')) {
             return $basePath;
         }
 
-        $normalizedPath = trim(str_replace(['\\', '/'], DIRECTORY_SEPARATOR, $path), DIRECTORY_SEPARATOR);
+        $normalizedPath = str_replace(['\\', '/'], DIRECTORY_SEPARATOR, $path);
+        $isAbsolutePath = DIRECTORY_SEPARATOR === '\\'
+            ? preg_match('/^(?:[A-Za-z]:[\\\\\\/]|[\\\\]{2})/', $path) === 1
+            : str_starts_with($normalizedPath, '/');
+
+        if ($isAbsolutePath) {
+            return $normalizedPath;
+        }
+
+        $normalizedPath = trim($normalizedPath, DIRECTORY_SEPARATOR);
 
         return $normalizedPath === ''
             ? $basePath

--- a/tests/Controller/ControllerTest.php
+++ b/tests/Controller/ControllerTest.php
@@ -51,6 +51,24 @@ class ControllerTest extends TestCase
         $this->assertEquals('custom' . DIRECTORY_SEPARATOR . 'views', $viewFolderProperty->getValue($this->controller));
     }
 
+    public function testFindRegularViewPreservesAbsoluteViewFolder(): void
+    {
+        $viewFolder = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'phaseolies_views_' . uniqid();
+        $viewFile = $viewFolder . DIRECTORY_SEPARATOR . 'sample.odo.php';
+        mkdir($viewFolder, 0777, true);
+        file_put_contents($viewFile, 'sample');
+
+        try {
+            $this->controller->setViewFolder($viewFolder);
+            $method = (new \ReflectionClass(Controller::class))->getMethod('findRegularView');
+
+            $this->assertSame($viewFile, $method->invoke($this->controller, 'sample'));
+        } finally {
+            @unlink($viewFile);
+            @rmdir($viewFolder);
+        }
+    }
+
     public function testSetEchoFormat(): void
     {
         $this->controller->setEchoFormat('custom_format(%s)');


### PR DESCRIPTION
Bug : on windows the error page path didn't work

Fixed cross-platform absolute path handling in base_path() so Doppar’s debug error views work correctly on Windows, Linux, and macOS. Added a regression test to ensure absolute view directories are resolved without being prefixed by the application path.







