### PR TITLE
feat: add attribute-based DTO validation

### DIFF
--- a/src/Phaseolies/Http/Requests/Attributes/BindPayload.php
+++ b/src/Phaseolies/Http/Requests/Attributes/BindPayload.php
@@ -7,5 +7,6 @@ final class BindPayload
 {
     public function __construct(
         public bool $strict = false,
+        public bool $validate = false,
     ) {}
 }

--- a/src/Phaseolies/Http/Support/InteractsWithDTO.php
+++ b/src/Phaseolies/Http/Support/InteractsWithDTO.php
@@ -19,7 +19,10 @@ trait InteractsWithDTO
     /**
      * Binds the given data to an object.
      *
+     * @param object $object
      * @param array<string, mixed> $data
+     * @param bool $strict
+     * @return object
      */
     public function bindData(object $object, array $data, bool $strict = true): object
     {

--- a/src/Phaseolies/Http/Support/InteractsWithDTO.php
+++ b/src/Phaseolies/Http/Support/InteractsWithDTO.php
@@ -13,8 +13,16 @@ trait InteractsWithDTO
      */
     public function bindTo(object $object, bool $strict = true): object
     {
-        $data = $this->all();
+        return $this->bindData($object, $this->all(), $strict);
+    }
 
+    /**
+     * Binds the given data to an object.
+     *
+     * @param array<string, mixed> $data
+     */
+    public function bindData(object $object, array $data, bool $strict = true): object
+    {
         foreach ($data as $key => $value) {
             if ($strict && !property_exists($object, $key)) {
                 continue;

--- a/src/Phaseolies/Http/Support/RequestHelper.php
+++ b/src/Phaseolies/Http/Support/RequestHelper.php
@@ -4,6 +4,8 @@ namespace Phaseolies\Http\Support;
 
 use InvalidArgumentException;
 use Phaseolies\Database\Entity\Model;
+use Phaseolies\Validation\DtoValidator;
+use Phaseolies\Validation\MessageResolver;
 
 trait RequestHelper
 {
@@ -71,6 +73,23 @@ trait RequestHelper
         $exclude = array_flip($excludeKeys);
 
         return array_diff_key($this->passedData, $exclude);
+    }
+
+    /**
+     * Validates and hydrates a DTO using property constraints.
+     */
+    public function validateDto(object $dto, bool $strict = true): object
+    {
+        $validator = new DtoValidator(
+            new MessageResolver(app('translator')),
+        );
+        $errors = $validator->errors($dto, $this->all());
+
+        if ($errors !== []) {
+            $this->failValidation($errors);
+        }
+
+        return $this->bindData($dto, $validator->normalize($dto, $this->all()), $strict);
     }
 
     /**

--- a/src/Phaseolies/Http/Support/RequestHelper.php
+++ b/src/Phaseolies/Http/Support/RequestHelper.php
@@ -77,6 +77,10 @@ trait RequestHelper
 
     /**
      * Validates and hydrates a DTO using property constraints.
+     *
+     * @param object $dto
+     * @param bool $strict
+     * @return object
      */
     public function validateDto(object $dto, bool $strict = true): object
     {

--- a/src/Phaseolies/Http/Validation/Rule.php
+++ b/src/Phaseolies/Http/Validation/Rule.php
@@ -14,6 +14,39 @@ trait Rule
     use ValidationRules;
 
     /**
+     * Converts validation errors into the response expected by the request type.
+     */
+    protected function failValidation(array $errors): never
+    {
+        if (request()->isAjax() || request()->isApiRequest()) {
+            $exception = new HttpResponseException(
+                $errors,
+                Response::HTTP_UNPROCESSABLE_ENTITY
+            );
+
+            $exception->setResponse(
+                (new JsonErrorRenderer())->render(
+                    $exception,
+                    Response::HTTP_UNPROCESSABLE_ENTITY,
+                    $errors
+                )
+            );
+
+            throw $exception;
+        }
+
+        $this->setErrors($errors);
+        foreach ($errors as $key => $error) {
+            session()->putPeek($key, implode(' ', (array) $error));
+        }
+
+        $response = redirect()->back()->withInput()->withErrors($errors);
+
+        throw (new HttpResponseException($errors, $response->getStatusCode()))
+            ->setResponse($response);
+    }
+
+    /**
      * Validate the input data against the given rules.
      *
      * @access public
@@ -50,32 +83,7 @@ trait Rule
         }
 
         if (!empty($errors)) {
-            if (request()->isAjax() || request()->isApiRequest()) {
-                $exception = new HttpResponseException(
-                    $errors,
-                    Response::HTTP_UNPROCESSABLE_ENTITY
-                );
-
-                $exception->setResponse(
-                    (new JsonErrorRenderer())->render(
-                        $exception,
-                        Response::HTTP_UNPROCESSABLE_ENTITY,
-                        $errors
-                    )
-                );
-
-                throw $exception;
-            }
-
-            $this->setErrors($errors);
-            foreach ($errors as $key => $error) {
-                session()->putPeek($key, implode(' ', (array)$error));
-            }
-
-            $response = redirect()->back()->withInput()->withErrors($errors);
-
-            throw (new HttpResponseException($errors, $response->getStatusCode()))
-                ->setResponse($response);
+            $this->failValidation($errors);
         }
 
         $this->setPassedData($input);

--- a/src/Phaseolies/Http/Validation/Rule.php
+++ b/src/Phaseolies/Http/Validation/Rule.php
@@ -15,6 +15,8 @@ trait Rule
 
     /**
      * Converts validation errors into the response expected by the request type.
+     *
+     * @param array<string, mixed> $errors
      */
     protected function failValidation(array $errors): never
     {

--- a/src/Phaseolies/Support/Router.php
+++ b/src/Phaseolies/Support/Router.php
@@ -1590,6 +1590,7 @@ class Router extends Kernel
         }
 
         $dto = $app->make($dtoClass);
+        /** @var Request $request */
         $request = $app->make('request');
         $attributeInstance = $mapAttributes[0]->newInstance();
         $strict = (bool) ($attributeInstance->strict ?? true);

--- a/src/Phaseolies/Support/Router.php
+++ b/src/Phaseolies/Support/Router.php
@@ -1592,7 +1592,10 @@ class Router extends Kernel
         $dto = $app->make($dtoClass);
         $request = $app->make('request');
         $attributeInstance = $mapAttributes[0]->newInstance();
-        $instance = $request->bindTo($dto, (bool)($attributeInstance->strict ?? true));
+        $strict = (bool) ($attributeInstance->strict ?? true);
+        $instance = $attributeInstance->validate
+            ? $request->validateDto($dto, $strict)
+            : $request->bindTo($dto, $strict);
 
         return ['handled' => true, 'instance' => $instance];
     }

--- a/src/Phaseolies/Validation/Attributes/Between.php
+++ b/src/Phaseolies/Validation/Attributes/Between.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Phaseolies\Validation\Attributes;
+
+use Attribute;
+use Phaseolies\Validation\Constraint;
+use Phaseolies\Validation\ConstraintViolation;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class Between implements Constraint
+{
+    public function __construct(
+        private readonly int|float $min,
+        private readonly int|float $max,
+    ) {
+    }
+
+    public function validate(mixed $value, string $property, array $payload): ?ConstraintViolation
+    {
+        if ($value === null || !is_numeric($value)) {
+            return null;
+        }
+
+        return $value < $this->min || $value > $this->max
+            ? new ConstraintViolation($property, 'between', [
+                ':min' => $this->min,
+                'min' => $this->min,
+                ':max' => $this->max,
+                'max' => $this->max,
+            ])
+            : null;
+    }
+}

--- a/src/Phaseolies/Validation/Attributes/Between.php
+++ b/src/Phaseolies/Validation/Attributes/Between.php
@@ -9,12 +9,26 @@ use Phaseolies\Validation\ConstraintViolation;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class Between implements Constraint
 {
+    /**
+     * Creates a between constraint.
+     *
+     * @param int|float $min
+     * @param int|float $max
+     */
     public function __construct(
         private readonly int|float $min,
         private readonly int|float $max,
     ) {
     }
 
+    /**
+     * Validates that a value is within the configured range.
+     *
+     * @param mixed $value
+     * @param string $property
+     * @param array<string, mixed> $payload
+     * @return ConstraintViolation|null
+     */
     public function validate(mixed $value, string $property, array $payload): ?ConstraintViolation
     {
         if ($value === null || !is_numeric($value)) {

--- a/src/Phaseolies/Validation/Attributes/Integer.php
+++ b/src/Phaseolies/Validation/Attributes/Integer.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Phaseolies\Validation\Attributes;
+
+use Attribute;
+use Phaseolies\Validation\Constraint;
+use Phaseolies\Validation\ConstraintViolation;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class Integer implements Constraint
+{
+    public function __construct(
+        private readonly string $messageKey = 'int',
+    ) {
+    }
+
+    public function validate(mixed $value, string $property, array $payload): ?ConstraintViolation
+    {
+        $valid = is_int($value) || (is_string($value) && filter_var($value, FILTER_VALIDATE_INT) !== false);
+
+        return $value !== null && !$valid
+            ? new ConstraintViolation($property, $this->messageKey)
+            : null;
+    }
+}

--- a/src/Phaseolies/Validation/Attributes/Integer.php
+++ b/src/Phaseolies/Validation/Attributes/Integer.php
@@ -9,11 +9,24 @@ use Phaseolies\Validation\ConstraintViolation;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class Integer implements Constraint
 {
+    /**
+     * Creates an integer constraint.
+     *
+     * @param string $messageKey
+     */
     public function __construct(
         private readonly string $messageKey = 'int',
     ) {
     }
 
+    /**
+     * Validates that a value is an integer.
+     *
+     * @param mixed $value
+     * @param string $property
+     * @param array<string, mixed> $payload
+     * @return ConstraintViolation|null
+     */
     public function validate(mixed $value, string $property, array $payload): ?ConstraintViolation
     {
         $valid = is_int($value) || (is_string($value) && filter_var($value, FILTER_VALIDATE_INT) !== false);

--- a/src/Phaseolies/Validation/Attributes/Length.php
+++ b/src/Phaseolies/Validation/Attributes/Length.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Phaseolies\Validation\Attributes;
+
+use Attribute;
+use Phaseolies\Validation\Constraint;
+use Phaseolies\Validation\ConstraintViolation;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class Length implements Constraint
+{
+    public function __construct(
+        private readonly ?int $min = null,
+        private readonly ?int $max = null,
+    ) {
+    }
+
+    public function validate(mixed $value, string $property, array $payload): ?ConstraintViolation
+    {
+        if ($value === null || !is_string($value)) {
+            return null;
+        }
+
+        $length = mb_strlen($value);
+
+        if ($this->min !== null && $length < $this->min) {
+            return new ConstraintViolation($property, 'min.string', [
+                ':min' => $this->min,
+                'min' => $this->min,
+            ]);
+        }
+
+        if ($this->max !== null && $length > $this->max) {
+            return new ConstraintViolation($property, 'max.string', [
+                ':max' => $this->max,
+                'max' => $this->max,
+            ]);
+        }
+
+        return null;
+    }
+}

--- a/src/Phaseolies/Validation/Attributes/Length.php
+++ b/src/Phaseolies/Validation/Attributes/Length.php
@@ -9,12 +9,26 @@ use Phaseolies\Validation\ConstraintViolation;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class Length implements Constraint
 {
+    /**
+     * Creates a length constraint.
+     *
+     * @param int|null $min
+     * @param int|null $max
+     */
     public function __construct(
         private readonly ?int $min = null,
         private readonly ?int $max = null,
     ) {
     }
 
+    /**
+     * Validates the length of a string value.
+     *
+     * @param mixed $value
+     * @param string $property
+     * @param array<string, mixed> $payload
+     * @return ConstraintViolation|null
+     */
     public function validate(mixed $value, string $property, array $payload): ?ConstraintViolation
     {
         if ($value === null || !is_string($value)) {

--- a/src/Phaseolies/Validation/Attributes/NotBlank.php
+++ b/src/Phaseolies/Validation/Attributes/NotBlank.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Phaseolies\Validation\Attributes;
+
+use Attribute;
+use Phaseolies\Validation\Constraint;
+use Phaseolies\Validation\ConstraintViolation;
+
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
+final class NotBlank implements Constraint
+{
+    public function __construct(
+        private readonly string $messageKey = 'required',
+    ) {
+    }
+
+    public function validate(mixed $value, string $property, array $payload): ?ConstraintViolation
+    {
+        return $value === null || (is_string($value) && trim($value) === '')
+            ? new ConstraintViolation($property, $this->messageKey)
+            : null;
+    }
+}

--- a/src/Phaseolies/Validation/Attributes/NotBlank.php
+++ b/src/Phaseolies/Validation/Attributes/NotBlank.php
@@ -9,11 +9,24 @@ use Phaseolies\Validation\ConstraintViolation;
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 final class NotBlank implements Constraint
 {
+    /**
+     * Creates a not-blank constraint.
+     *
+     * @param string $messageKey
+     */
     public function __construct(
         private readonly string $messageKey = 'required',
     ) {
     }
 
+    /**
+     * Validates that a value is not blank.
+     *
+     * @param mixed $value
+     * @param string $property
+     * @param array<string, mixed> $payload
+     * @return ConstraintViolation|null
+     */
     public function validate(mixed $value, string $property, array $payload): ?ConstraintViolation
     {
         return $value === null || (is_string($value) && trim($value) === '')

--- a/src/Phaseolies/Validation/Attributes/StringType.php
+++ b/src/Phaseolies/Validation/Attributes/StringType.php
@@ -9,11 +9,24 @@ use Phaseolies\Validation\ConstraintViolation;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class StringType implements Constraint
 {
+    /**
+     * Creates a string constraint.
+     *
+     * @param string $messageKey
+     */
     public function __construct(
         private readonly string $messageKey = 'string',
     ) {
     }
 
+    /**
+     * Validates that a value is a string.
+     *
+     * @param mixed $value
+     * @param string $property
+     * @param array<string, mixed> $payload
+     * @return ConstraintViolation|null
+     */
     public function validate(mixed $value, string $property, array $payload): ?ConstraintViolation
     {
         return $value !== null && !is_string($value)

--- a/src/Phaseolies/Validation/Attributes/StringType.php
+++ b/src/Phaseolies/Validation/Attributes/StringType.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Phaseolies\Validation\Attributes;
+
+use Attribute;
+use Phaseolies\Validation\Constraint;
+use Phaseolies\Validation\ConstraintViolation;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class StringType implements Constraint
+{
+    public function __construct(
+        private readonly string $messageKey = 'string',
+    ) {
+    }
+
+    public function validate(mixed $value, string $property, array $payload): ?ConstraintViolation
+    {
+        return $value !== null && !is_string($value)
+            ? new ConstraintViolation($property, $this->messageKey)
+            : null;
+    }
+}

--- a/src/Phaseolies/Validation/Constraint.php
+++ b/src/Phaseolies/Validation/Constraint.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Phaseolies\Validation;
+
+interface Constraint
+{
+    public function validate(mixed $value, string $property, array $payload): ?ConstraintViolation;
+}

--- a/src/Phaseolies/Validation/ConstraintViolation.php
+++ b/src/Phaseolies/Validation/ConstraintViolation.php
@@ -4,6 +4,13 @@ namespace Phaseolies\Validation;
 
 final readonly class ConstraintViolation
 {
+    /**
+     * Creates a validation constraint violation.
+     *
+     * @param string $property
+     * @param string $messageKey
+     * @param array<string, mixed> $parameters
+     */
     public function __construct(
         public string $property,
         public string $messageKey,

--- a/src/Phaseolies/Validation/ConstraintViolation.php
+++ b/src/Phaseolies/Validation/ConstraintViolation.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Phaseolies\Validation;
+
+final readonly class ConstraintViolation
+{
+    public function __construct(
+        public string $property,
+        public string $messageKey,
+        public array $parameters = [],
+    ) {
+    }
+}

--- a/src/Phaseolies/Validation/DtoValidator.php
+++ b/src/Phaseolies/Validation/DtoValidator.php
@@ -13,6 +13,13 @@ final class DtoValidator
     ) {
     }
 
+    /**
+     * Returns validation errors for a DTO payload.
+     *
+     * @param object $dto
+     * @param array<string, mixed> $payload
+     * @return array<string, list<string>>
+     */
     public function errors(object $dto, array $payload): array
     {
         $errors = [];
@@ -38,6 +45,13 @@ final class DtoValidator
         return $errors;
     }
 
+    /**
+     * Normalizes built-in DTO property values in a payload.
+     *
+     * @param object $dto
+     * @param array<string, mixed> $payload
+     * @return array<string, mixed>
+     */
     public function normalize(object $dto, array $payload): array
     {
         $normalized = $payload;
@@ -55,6 +69,13 @@ final class DtoValidator
         return $normalized;
     }
 
+    /**
+     * Normalizes a value according to a reflected property type.
+     *
+     * @param ReflectionProperty $property
+     * @param mixed $value
+     * @return mixed
+     */
     private function normalizeValue(ReflectionProperty $property, mixed $value): mixed
     {
         $type = $property->getType();

--- a/src/Phaseolies/Validation/DtoValidator.php
+++ b/src/Phaseolies/Validation/DtoValidator.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Phaseolies\Validation;
+
+use ReflectionClass;
+use ReflectionNamedType;
+use ReflectionProperty;
+
+final class DtoValidator
+{
+    public function __construct(
+        private readonly MessageResolver $messages,
+    ) {
+    }
+
+    public function errors(object $dto, array $payload): array
+    {
+        $errors = [];
+        $reflection = new ReflectionClass($dto);
+
+        foreach ($reflection->getProperties() as $property) {
+            $constraints = $property->getAttributes(Constraint::class, \ReflectionAttribute::IS_INSTANCEOF);
+            if ($constraints === []) {
+                continue;
+            }
+
+            $value = $payload[$property->getName()] ?? null;
+            foreach ($constraints as $attribute) {
+                $violation = $attribute->newInstance()->validate($value, $property->getName(), $payload);
+                if ($violation === null) {
+                    continue;
+                }
+
+                $errors[$violation->property][] = $this->messages->resolve($violation);
+            }
+        }
+
+        return $errors;
+    }
+
+    public function normalize(object $dto, array $payload): array
+    {
+        $normalized = $payload;
+        $reflection = new ReflectionClass($dto);
+
+        foreach ($reflection->getProperties() as $property) {
+            $name = $property->getName();
+            if (!array_key_exists($name, $normalized)) {
+                continue;
+            }
+
+            $normalized[$name] = $this->normalizeValue($property, $normalized[$name]);
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeValue(ReflectionProperty $property, mixed $value): mixed
+    {
+        $type = $property->getType();
+        if (!$type instanceof ReflectionNamedType || !$type->isBuiltin() || $value === null) {
+            return $value;
+        }
+
+        return match ($type->getName()) {
+            'int' => (int) $value,
+            'float' => (float) $value,
+            'bool' => filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? $value,
+            default => $value,
+        };
+    }
+}

--- a/src/Phaseolies/Validation/MessageResolver.php
+++ b/src/Phaseolies/Validation/MessageResolver.php
@@ -11,6 +11,12 @@ final class MessageResolver
     ) {
     }
 
+    /**
+     * Resolves a constraint violation into a translated message.
+     *
+     * @param ConstraintViolation $violation
+     * @return string
+     */
     public function resolve(ConstraintViolation $violation): string
     {
         $attribute = $this->translator->get(

--- a/src/Phaseolies/Validation/MessageResolver.php
+++ b/src/Phaseolies/Validation/MessageResolver.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Phaseolies\Validation;
+
+use Phaseolies\Translation\Translator;
+
+final class MessageResolver
+{
+    public function __construct(
+        private readonly Translator $translator,
+    ) {
+    }
+
+    public function resolve(ConstraintViolation $violation): string
+    {
+        $attribute = $this->translator->get(
+            "validation.attributes.{$violation->property}",
+            [],
+            null,
+        );
+        $attributeKey = "validation.attributes.{$violation->property}";
+
+        if ($attribute === $attributeKey) {
+            $attribute = ucwords(str_replace('_', ' ', $violation->property));
+        }
+
+        $key = "validation.{$violation->messageKey}";
+        $replacements = array_merge([
+            ':attribute' => $attribute,
+            'attribute' => $attribute,
+        ], $violation->parameters);
+        $message = $this->translator->get($key, $replacements);
+
+        if ($message !== $key) {
+            return $message;
+        }
+
+        $fallbacks = [
+            'required' => 'The :attribute field is required.',
+            'string' => 'The :attribute must be a string.',
+            'int' => 'The :attribute must be an integer.',
+            'between' => 'The :attribute must be between :min and :max.',
+            'min.string' => 'The :attribute must be at least :min characters.',
+            'max.string' => 'The :attribute may not be greater than :max characters.',
+        ];
+
+        return strtr(
+            $fallbacks[$violation->messageKey] ?? 'Validation failed.',
+            $replacements,
+        );
+    }
+}

--- a/tests/Validation/DtoValidationTest.php
+++ b/tests/Validation/DtoValidationTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Unit\Validation;
+
+use Mockery;
+use Phaseolies\Translation\Translator;
+use Phaseolies\Validation\Attributes\Between;
+use Phaseolies\Validation\Attributes\Integer;
+use Phaseolies\Validation\Attributes\Length;
+use Phaseolies\Validation\Attributes\NotBlank;
+use Phaseolies\Validation\Attributes\StringType;
+use Phaseolies\Validation\DtoValidator;
+use Phaseolies\Validation\MessageResolver;
+use PHPUnit\Framework\TestCase;
+
+final class DtoValidationTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+    }
+
+    public function testValidDtoHasNoErrorsAndNumericValuesCanBeNormalized(): void
+    {
+        $translator = Mockery::mock(Translator::class);
+        $validator = new DtoValidator(new MessageResolver($translator));
+        $dto = new BookPayload();
+
+        $errors = $validator->errors($dto, [
+            'title' => 'The Odyssey',
+            'pages' => '320',
+            'author' => 'Homer',
+            'rating' => '4',
+        ]);
+
+        $normalized = $validator->normalize($dto, [
+            'title' => 'The Odyssey',
+            'pages' => '320',
+            'author' => 'Homer',
+            'rating' => '4',
+        ]);
+
+        $this->assertSame([], $errors);
+        $this->assertSame(320, $normalized['pages']);
+        $this->assertSame(4, $normalized['rating']);
+    }
+
+    public function testDtoErrorsUseValidationTranslationsAndAttributeNames(): void
+    {
+        $translator = Mockery::mock(Translator::class);
+        $translator->shouldReceive('get')
+            ->with('validation.attributes.pages', [], null)
+            ->andReturn('number of pages');
+        $translator->shouldReceive('get')
+            ->with('validation.between', Mockery::on(function (array $replacements): bool {
+                return $replacements[':attribute'] === 'number of pages'
+                    && $replacements[':min'] === 1
+                    && $replacements[':max'] === 10000;
+            }))
+            ->andReturn('The number of pages must be between 1 and 10000.');
+
+        $validator = new DtoValidator(new MessageResolver($translator));
+        $errors = $validator->errors(new BookPayload(), [
+            'title' => 'The Odyssey',
+            'pages' => '0',
+            'author' => 'Homer',
+            'rating' => '4',
+        ]);
+
+        $this->assertSame([
+            'pages' => ['The number of pages must be between 1 and 10000.'],
+        ], $errors);
+    }
+
+    public function testDtoErrorsAccumulateMultipleConstraints(): void
+    {
+        $translator = Mockery::mock(Translator::class);
+        $translator->shouldReceive('get')->andReturnUsing(function (string $key, array $replace = [], ?string $locale = null): string {
+            return $key;
+        });
+
+        $validator = new DtoValidator(new MessageResolver($translator));
+        $errors = $validator->errors(new BookPayload(), [
+            'pages' => 'not-an-integer',
+            'rating' => '0',
+        ]);
+
+        $this->assertArrayHasKey('title', $errors);
+        $this->assertArrayHasKey('author', $errors);
+        $this->assertArrayHasKey('pages', $errors);
+        $this->assertArrayHasKey('rating', $errors);
+    }
+}
+
+final class BookPayload
+{
+    #[NotBlank]
+    #[StringType]
+    #[Length(max: 255)]
+    public string $title;
+
+    #[NotBlank]
+    #[Integer]
+    #[Between(min: 1, max: 10000)]
+    public int $pages;
+
+    #[NotBlank]
+    #[StringType]
+    #[Length(max: 255)]
+    public string $author;
+
+    #[NotBlank]
+    #[Integer]
+    #[Between(min: 1, max: 5)]
+    public int $rating;
+}


### PR DESCRIPTION
Added DTO validation constraints:
```php
#[NotBlank]
#[StringType]
#[Integer]
#[Length]
#[Between]
```
Example : 
```php
final class BookData
{
    #[NotBlank]
    #[StringType]
    #[Length(max: 255)]
    public string $title;

    #[NotBlank]
    #[Integer]
    #[Between(min: 1, max: 10000)]
    public int $pages;

    #[NotBlank]
    #[StringType]
    #[Length(max: 255)]
    public string $author;

    #[NotBlank]
    #[Integer]
    #[Between(min: 1, max: 5)]
    public int $rating;
}
```
```php
public function storeManual(
    #[BindPayload(strict: true, validate: true)]
    BookData $book,
) {
    Book::create($book->toArray());

    return redirect('/books');
}
```