### PR TITLE
fix: base_path() ambiguity crashes Router::getControllerClasses() on getPrefixesPsr4()

### DIFF
--- a/src/Phaseolies/Helpers/helpers.php
+++ b/src/Phaseolies/Helpers/helpers.php
@@ -427,16 +427,7 @@ if (!function_exists('base_path')) {
             return $basePath;
         }
 
-        $normalizedPath = str_replace(['\\', '/'], DIRECTORY_SEPARATOR, $path);
-        $isAbsolutePath = DIRECTORY_SEPARATOR === '\\'
-            ? preg_match('/^(?:[A-Za-z]:[\\\\\\/]|[\\\\]{2})/', $path) === 1
-            : str_starts_with($normalizedPath, '/');
-
-        if ($isAbsolutePath) {
-            return $normalizedPath;
-        }
-
-        $normalizedPath = trim($normalizedPath, DIRECTORY_SEPARATOR);
+        $normalizedPath = trim(str_replace(['\\', '/'], DIRECTORY_SEPARATOR, $path), DIRECTORY_SEPARATOR);
 
         return $normalizedPath === ''
             ? $basePath

--- a/src/Phaseolies/Http/Controllers/Controller.php
+++ b/src/Phaseolies/Http/Controllers/Controller.php
@@ -363,7 +363,9 @@ class Controller extends View
     protected function findRegularView(string $view): string
     {
         $viewPath = str_replace('.', DIRECTORY_SEPARATOR, $view);
-        $basePath = base_path($this->viewFolder);
+        $basePath = $this->isAbsolutePath($this->viewFolder)
+            ? rtrim($this->viewFolder, DIRECTORY_SEPARATOR)
+            : base_path($this->viewFolder);
 
         $possiblePaths = [
             $basePath . DIRECTORY_SEPARATOR . $viewPath . $this->fileExtension
@@ -380,6 +382,21 @@ class Controller extends View
         throw new NotFoundHttpException(
             "View [{$view}] not found. Attempted paths:\n  - {$attemptedPaths}"
         );
+    }
+
+    /**
+     * Determine if the given path is an absolute filesystem path
+     *
+     * @param string $path
+     * @return bool
+     */
+    protected function isAbsolutePath(string $path): bool
+    {
+        $normalizedPath = str_replace('\\', '/', $path);
+
+        return DIRECTORY_SEPARATOR === '\\'
+            ? preg_match('/^(?:[A-Za-z]:[\\\\\\/]|[\\\\]{2})/', $path) === 1
+            : str_starts_with($normalizedPath, '/');
     }
 
     /**

--- a/src/Phaseolies/Support/Router.php
+++ b/src/Phaseolies/Support/Router.php
@@ -298,7 +298,7 @@ class Router extends Kernel
         $controllers = [];
         $composerLoader = $this->getComposerClassLoader();
 
-        $prefixes = $composerLoader->getPrefixesPsr4();
+        $prefixes = $composerLoader?->getPrefixesPsr4() ?? [];
 
         foreach ($prefixes as $namespace => $paths) {
             if (

--- a/src/Phaseolies/Support/Router/InteractsWithDynamicControllerBinding.php
+++ b/src/Phaseolies/Support/Router/InteractsWithDynamicControllerBinding.php
@@ -11,7 +11,7 @@ trait InteractsWithDynamicControllerBinding
      */
     protected function getComposerClassLoader(): ?object
     {
-        $vendorDir = base_path('/vendor');
+        $vendorDir = base_path('vendor');
         $autoloadFile = $vendorDir . '/autoload.php';
 
         if (!file_exists($autoloadFile)) {


### PR DESCRIPTION
## Summery

1. base_path() previously treated any argument starting with / as a true absolute filesystem path and returned it verbatim, ignoring BASE_PATH. This collided with call sites (and app code) that pass a leading / purely stylistically to mean "relative to the app root" — e.g. getComposerClassLoader() calling base_path('/vendor'), which resolved to the filesystem's /vendor instead of {app}/vendor.
2. Because /vendor/autoload.php doesn't exist, getComposerClassLoader() returned null, and Router::getControllerClasses() called ->getPrefixesPsr4() on it unguarded, producing: Call to a member function getPrefixesPsr4() on null.
3. base_path() is now unambiguous: it always strips leading slashes and joins onto BASE_PATH, matching Laravel's base_path() semantics. base_path('/vendor') and base_path('vendor') now both resolve correctly.
4. The one legitimate use of "preserve an absolute path" — custom, out-of-project view folders via Controller::setViewFolder() — is now handled locally in Controller::findRegularView() via a new isAbsolutePath() helper, instead of being baked into the general-purpose base_path() helper.
5. Router::getControllerClasses() also now guards the loader lookup with ?->getPrefixesPsr4() ?? [] as defense-in-depth, since getComposerClassLoader() is legitimately nullable (e.g. non-standard autoloader setups).