### PR TITLE
Fix #4 done: path traversal in Storage

### DIFF
--- a/src/Phaseolies/Support/Storage/FileSystem.php
+++ b/src/Phaseolies/Support/Storage/FileSystem.php
@@ -27,6 +27,46 @@ class FileSystem
     }
 
     /**
+     * Resolve a caller-supplied relative path against the storage root,
+     * rejecting any path that would escape outside the root
+     *
+     * @param string $relativePath
+     * @return string
+     * @throws \InvalidArgumentException
+     */
+    protected function resolvePath(string $relativePath): string
+    {
+        foreach (preg_split('#[/\\\\]#', $relativePath) as $segment) {
+            if ($segment === '..' || $segment === '.') {
+                throw new \InvalidArgumentException(
+                    "Invalid path \"{$relativePath}\": path traversal is not allowed."
+                );
+            }
+        }
+
+        $root = rtrim($this->filePath, '/\\');
+        $fullPath = $root . '/' . ltrim($relativePath, '/\\');
+
+        $resolvedTarget = realpath($fullPath);
+
+        if ($resolvedTarget !== false) {
+            $resolvedRoot = realpath($root);
+            $withinRoot = $resolvedRoot !== false && (
+                $resolvedTarget === $resolvedRoot ||
+                str_starts_with($resolvedTarget, $resolvedRoot . DIRECTORY_SEPARATOR)
+            );
+
+            if (!$withinRoot) {
+                throw new \InvalidArgumentException(
+                    "Invalid path \"{$relativePath}\": resolves outside the storage root."
+                );
+            }
+        }
+
+        return $fullPath;
+    }
+
+    /**
      * move file in local file system
      *
      * @param string $path
@@ -117,10 +157,10 @@ class FileSystem
      */
     public function isDirectoryExists(string $path): string
     {
-        $realPath = $this->storeageBasePath();
+        $fullPath = $this->resolvePath($path);
 
-        if (! $this->isDirectory($realPath . '/' . trim($path, '/'))) {
-            $this->makeDirectory($realPath . '/' . $path, 0755, true);
+        if (! $this->isDirectory($fullPath)) {
+            $this->makeDirectory($fullPath, 0755, true);
         }
         return $path;
     }
@@ -140,11 +180,12 @@ class FileSystem
      * create the destination full path according in os
      *
      * @param string $path
+     * @param string $fileName
      * @return string
      */
     public function destinationFile(string $path, $fileName): string
     {
-        return $this->filePath . '/' . $path . '/' . $fileName;
+        return $this->resolvePath($path . '/' . $fileName);
     }
 
     /**

--- a/src/Phaseolies/Support/Storage/LocalFileSystem.php
+++ b/src/Phaseolies/Support/Storage/LocalFileSystem.php
@@ -37,7 +37,7 @@ class LocalFileSystem extends FileSystem implements IFileSystem
      */
     public function get(string $path): ?string
     {
-        $fullPath = $this->filePath . '/' . $path;
+        $fullPath = $this->resolvePath($path);
 
         if ($this->isFile($fullPath)) {
             return $fullPath;
@@ -55,7 +55,7 @@ class LocalFileSystem extends FileSystem implements IFileSystem
      */
     public function content($path)
     {
-        $fullPath = $this->filePath . '/' . $path;
+        $fullPath = $this->resolvePath($path);
 
         if ($this->isFile($fullPath)) {
             $file = new \SplFileObject($fullPath, 'r');
@@ -80,7 +80,7 @@ class LocalFileSystem extends FileSystem implements IFileSystem
         $success = true;
 
         foreach ((array) $path as $filePath) {
-            $fullPath = $this->filePath . '/' . $filePath;
+            $fullPath = $this->resolvePath($filePath);
 
             if (file_exists($fullPath)) {
                 if (!unlink($fullPath)) {

--- a/src/Phaseolies/Support/Storage/PublicFileSystem.php
+++ b/src/Phaseolies/Support/Storage/PublicFileSystem.php
@@ -39,7 +39,7 @@ class PublicFileSystem extends FileSystem implements IFileSystem
      */
     public function get(string $path): ?string
     {
-        $fullPath = $this->filePath . '/' . $path;
+        $fullPath = $this->resolvePath($path);
 
         if ($this->isFile($fullPath)) {
             return $fullPath;
@@ -58,10 +58,10 @@ class PublicFileSystem extends FileSystem implements IFileSystem
      */
     public function content($path)
     {
-        $fullPath = $this->filePath . '/' . $path;
+        $fullPath = $this->resolvePath($path);
 
         if ($this->isFile($fullPath)) {
-            $file = new \SplFileObject($path, 'r');
+            $file = new \SplFileObject($fullPath, 'r');
             $contents = '';
             while (!$file->eof()) {
                 $contents .= $file->fgets();
@@ -83,7 +83,7 @@ class PublicFileSystem extends FileSystem implements IFileSystem
         $success = true;
 
         foreach ((array) $path as $filePath) {
-            $fullPath = $this->filePath . '/' . $filePath;
+            $fullPath = $this->resolvePath($filePath);
 
             if (file_exists($fullPath)) {
                 if (!unlink($fullPath)) {

--- a/tests/Storage/FileSystemTest.php
+++ b/tests/Storage/FileSystemTest.php
@@ -216,4 +216,63 @@ class FileSystemTest extends TestCase
         $this->assertTrue($customFs->put('uploads', $file));
         $this->assertFileExists($this->tmpDir . '/uploads/avatar.jpeg');
     }
+
+    // ==================== PATH TRAVERSAL TESTS ====================
+
+    public function testDestinationFileRejectsPathTraversalInPath()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->fs->destinationFile('../../etc', 'passwd');
+    }
+
+    public function testDestinationFileRejectsPathTraversalInFileName()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->fs->destinationFile('uploads', '../../etc/passwd');
+    }
+
+    public function testIsDirectoryExistsRejectsPathTraversal()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->fs->isDirectoryExists('../outside');
+    }
+
+    public function testDestinationFileRejectsBackslashPathTraversal()
+    {
+        // Windows-style separators must be caught too, not just "/".
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->fs->destinationFile('uploads', '..\\..\\windows\\win.ini');
+    }
+
+    public function testDestinationFileHandlesRootConfiguredWithTrailingBackslash()
+    {
+        // Simulates a Windows-style config value like "C:\storage\".
+        $winStyleFs = new FileSystem(rtrim($this->tmpDir, '/') . '\\');
+
+        $result = $winStyleFs->destinationFile('uploads', 'image.jpg');
+
+        $this->assertEquals($this->tmpDir . '/uploads/image.jpg', $result);
+    }
+
+    public function testResolvePathRejectsSymlinkEscapingRoot()
+    {
+        $outside = sys_get_temp_dir() . '/doppar_fs_outside_' . uniqid();
+        mkdir($outside, 0755, true);
+        file_put_contents($outside . '/secret.txt', 'top secret');
+
+        symlink($outside, $this->tmpDir . '/escape');
+
+        try {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->fs->destinationFile('escape', 'secret.txt');
+        } finally {
+            unlink($this->tmpDir . '/escape');
+            unlink($outside . '/secret.txt');
+            rmdir($outside);
+        }
+    }
 }

--- a/tests/Storage/LocalFileSystemTest.php
+++ b/tests/Storage/LocalFileSystemTest.php
@@ -195,4 +195,45 @@ class LocalFileSystemTest extends TestCase
             $this->assertStringContainsString($this->tmpDir . '/' . $missing, $e->getMessage());
         }
     }
+
+    // ==================== PATH TRAVERSAL TESTS ====================
+
+    public function testGetRejectsPathTraversal()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->fs->get('../../etc/passwd');
+    }
+
+    public function testContentRejectsPathTraversal()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->fs->content('../../etc/passwd');
+    }
+
+    public function testDeleteRejectsPathTraversal()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->fs->delete('../../etc/passwd');
+    }
+
+    public function testDeleteRejectsPathTraversalInAnyArrayEntry()
+    {
+        $this->createTempFile('legit.txt');
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->fs->delete(['legit.txt', '../../etc/passwd']);
+    }
+
+    public function testGetCannotEscapeRootViaAbsoluteLookingPath()
+    {
+        $result = $this->fs->get('/etc/passwd');
+
+        // Treated as a subpath of the storage root, not an absolute
+        // filesystem path, so it does not resolve to the real /etc/passwd.
+        $this->assertNull($result);
+    }
 }

--- a/tests/Storage/PublicFileSystemTest.php
+++ b/tests/Storage/PublicFileSystemTest.php
@@ -82,4 +82,27 @@ class PublicFileSystemTest extends TestCase
 
         $this->assertFalse($result);
     }
+
+    // ==================== PATH TRAVERSAL TESTS ====================
+
+    public function testGetRejectsPathTraversal(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->fs->get('../../etc/passwd');
+    }
+
+    public function testContentRejectsPathTraversal(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->fs->content('../../etc/passwd');
+    }
+
+    public function testDeleteRejectsPathTraversal(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->fs->delete('../../etc/passwd');
+    }
 }


### PR DESCRIPTION
## Root Cause

The `LocalFileSystem`, `PublicFileSystem`, and shared `FileSystem` implementations were constructing filesystem paths using naive string concatenation:

`$this->filePath . '/' . $path`

This was done across methods such as `get()`, `content()`, `delete()`, `destinationFile()`, and `isDirectoryExists()`. The implementation did not reject path traversal sequences such as `..` or verify that the resolved path remained within the intended filesystem root, creating a potential path traversal vulnerability.

## Fix

The filesystem path handling has been updated to ensure that:

* Path traversal attempts using `..` are rejected.
* Resolved paths are validated to remain within the configured filesystem root.
* Path construction is handled consistently across the affected filesystem methods.

### Additional Finding

During the review, I also identified a third, previously unreviewed class: `PublicFileSystem.php`. It contained the same vulnerable path-handling pattern through the shared `FileSystem` base class, including the same `get()`, `content()`, and `delete()` behavior.

This was fixed as part of the same change to avoid leaving an obvious sibling implementation vulnerable.
