### PR TITLE
Fix #9 after_created hook ordering

### DIFF
--- a/src/Phaseolies/Database/Entity/Query/InteractsWithModelQueryProcessing.php
+++ b/src/Phaseolies/Database/Entity/Query/InteractsWithModelQueryProcessing.php
@@ -214,16 +214,20 @@ trait InteractsWithModelQueryProcessing
 
             $id = $this->newQuery()->insert($attributes);
 
-            if ($id && self::$isHookShouldBeCalled) {
+            if (!$id) {
+                return false;
+            }
+
+            // Set the primary key before firing after_created hooks so
+            // that hooks (e.g. Temporal snapshots) see a fully-formed
+            // model via getKey() instead of null.
+            $this->attributes[$this->primaryKey] = $id;
+
+            if (self::$isHookShouldBeCalled) {
                 $this->fireAfterHooks('created');
             }
 
-            if ($id) {
-                $this->attributes[$this->primaryKey] = $id;
-                return true;
-            }
-
-            return false;
+            return true;
         } finally {
             self::$isHookShouldBeCalled = true;
         }

--- a/tests/Model/EntityModelHookTest.php
+++ b/tests/Model/EntityModelHookTest.php
@@ -85,11 +85,20 @@ class EntityModelHookTest extends TestCase
     public function testAfterCreatedHook(): void
     {
         MockHook::$wasCalledAfterCreated = false;
+        MockHook::$capturedKeyAtAfterCreated = null;
 
         // Creating a new record should trigger the [after_created] hook
-        MockHook::create(['name' => 'Hook Test']);
+        $created = MockHook::create(['name' => 'Hook Test']);
 
         $this->assertTrue(MockHook::$wasCalledAfterCreated, 'after_created hook should have fired');
+
+        // The primary key must already be set on the model by the time
+        // after_created hooks run, not just after they return.
+        $this->assertNotNull(
+            MockHook::$capturedKeyAtAfterCreated,
+            'getKey() should be populated inside the after_created hook'
+        );
+        $this->assertSame((string) $created->getKey(), MockHook::$capturedKeyAtAfterCreated);
     }
 
     public function testAfterUpdatedHook(): void

--- a/tests/Support/Model/MockHook.php
+++ b/tests/Support/Model/MockHook.php
@@ -29,6 +29,10 @@ class MockHook extends Model
     public static bool $wasCalledAfterUpdated = false;
     public static bool $wasCalledAfterDeleted = false;
 
+    // Captures getKey() as observed from inside the after_created hook,
+    // to verify the primary key is populated before the hook fires.
+    public static ?string $capturedKeyAtAfterCreated = null;
+
     /**
      * Define the model’s lifecycle hooks.
      *
@@ -97,6 +101,7 @@ class MockHook extends Model
     public static function shouldBeCalledAfterAnItemCreated(Model $model): void
     {
         self::$wasCalledAfterCreated = true;
+        self::$capturedKeyAtAfterCreated = $model->getKey();
     }
 
     /**


### PR DESCRIPTION
### Change

Updated the insert path in `InteractsWithModelQueryProcessing.php` so that the model's primary key is assigned **before** `fireAfterHooks('created')` is executed, rather than three lines afterward.

As a result, `after_created` hooks now receive a fully initialized model, and calls such as `getKey()` or `$model->id` correctly return the newly created record's primary key instead of `null`.

### Tests

Extended `MockHook` to capture the result of `getKey()` from inside the hook callback.

Strengthened `testAfterCreatedHook` to verify that:

* The key available inside the `created` hook is not `null`.
* The captured key matches the model's actual primary key.

The regression test was verified by temporarily reverting the fix and confirming that the test fails with:

`Failed asserting that null is not null`

The test was then re-run with the fix in place and passes successfully.