### PR TITLE
Fix Model::__get() swallowing \Throwable

### DIFF
--- a/src/Phaseolies/Database/Entity/Model.php
+++ b/src/Phaseolies/Database/Entity/Model.php
@@ -1008,96 +1008,88 @@ abstract class Model implements Jsonable, \ArrayAccess, \JsonSerializable, \Stri
      */
     public function __get($name)
     {
-        try {
-            if (array_key_exists($name, $this->attributes)) {
-                return $this->castForGet($name, $this->attributes[$name]);
-            }
-
-            if (array_key_exists($name, $this->relations)) {
-                return $this->relations[$name];
-            }
-
-            if ($this->isComputed($name)) {
-                return $this->resolveComputed($name);
-            }
-
-            if (method_exists($this, $name)) {
-                $relation = $this->$name();
-
-                if ($relation instanceof Builder) {
-                    $relationType = $this->getLastRelationType();
-
-                    switch ($relationType) {
-                        case 'linkOne':
-                            $result = $relation->first();
-                            $this->setRelation($name, $result);
-                            return $result;
-
-                        case 'bindTo':
-                            $result = $relation->first();
-                            $this->setRelation($name, $result);
-                            return $result;
-
-                        case 'linkMany':
-                            $results = $relation->get();
-                            $this->setRelation($name, $results);
-                            return $results;
-
-                        case 'bindToMany':
-                            $relatedModel = app($this->getLastRelatedModel());
-                            $relatedModelClass = get_class($relatedModel);
-                            $pivotColumns = app('db')->getTableColumns($this->getLastPivotTable());
-                            $pivotTable = $this->getLastPivotTable();
-                            $pivotSelects = array_map(function ($column) use ($pivotTable) {
-                                return "{$pivotTable}.{$column} as pivot_{$column}";
-                            }, $pivotColumns);
-
-                            $query = $relatedModel->query()
-                                ->select(array_merge(
-                                    ["{$relatedModel->getTable()}.*"],
-                                    $pivotSelects
-                                ))
-                                ->join(
-                                    $this->getLastPivotTable(),
-                                    "{$this->getLastPivotTable()}.{$this->getLastRelatedKey()}",
-                                    '=',
-                                    "{$relatedModel->getTable()}.{$relatedModel->getKeyName()}"
-                                )
-                                ->where("{$this->getLastPivotTable()}.{$this->getLastForeignKey()}", '=', $this->getKey());
-
-                            $results = $query->get();
-                            $grouped = [];
-                            foreach ($results as $result) {
-                                $pivot = [];
-                                foreach ($pivotColumns as $column) {
-                                    $pivot[$column] = $result["pivot_{$column}"];
-                                    unset($result["pivot_{$column}"]);
-                                }
-                                $pivotObj = (object) $pivot;
-                                $result->pivot = $pivotObj;
-                                $grouped[$pivot[$this->getLastForeignKey()]][] = $result;
-                            }
-
-                            $this->setRelation(
-                                $name,
-                                new Collection($relatedModelClass, $grouped[$this->getKey()] ?? [])
-                            );
-
-                            return $results;
-                    }
-                }
-
-                return $relation;
-            }
-
-            if (!isset($this->attributes[$name])) {
-                throw new \Exception("Property or relation '$name' does not exist on " . static::class);
-            }
-
-            return $this->attributes[$name];
-        } catch (\Throwable) {
-            return;
+        if (array_key_exists($name, $this->attributes)) {
+            return $this->castForGet($name, $this->attributes[$name]);
         }
+
+        if (array_key_exists($name, $this->relations)) {
+            return $this->relations[$name];
+        }
+
+        if ($this->isComputed($name)) {
+            return $this->resolveComputed($name);
+        }
+
+        if (method_exists($this, $name)) {
+            $relation = $this->$name();
+
+            if ($relation instanceof Builder) {
+                $relationType = $this->getLastRelationType();
+
+                switch ($relationType) {
+                    case 'linkOne':
+                        $result = $relation->first();
+                        $this->setRelation($name, $result);
+                        return $result;
+
+                    case 'bindTo':
+                        $result = $relation->first();
+                        $this->setRelation($name, $result);
+                        return $result;
+
+                    case 'linkMany':
+                        $results = $relation->get();
+                        $this->setRelation($name, $results);
+                        return $results;
+
+                    case 'bindToMany':
+                        $relatedModel = app($this->getLastRelatedModel());
+                        $relatedModelClass = get_class($relatedModel);
+                        $pivotColumns = app('db')->getTableColumns($this->getLastPivotTable());
+                        $pivotTable = $this->getLastPivotTable();
+                        $pivotSelects = array_map(function ($column) use ($pivotTable) {
+                            return "{$pivotTable}.{$column} as pivot_{$column}";
+                        }, $pivotColumns);
+
+                        $query = $relatedModel->query()
+                            ->select(array_merge(
+                                ["{$relatedModel->getTable()}.*"],
+                                $pivotSelects
+                            ))
+                            ->join(
+                                $this->getLastPivotTable(),
+                                "{$this->getLastPivotTable()}.{$this->getLastRelatedKey()}",
+                                '=',
+                                "{$relatedModel->getTable()}.{$relatedModel->getKeyName()}"
+                            )
+                            ->where("{$this->getLastPivotTable()}.{$this->getLastForeignKey()}", '=', $this->getKey());
+
+                        $results = $query->get();
+                        $grouped = [];
+                        foreach ($results as $result) {
+                            $pivot = [];
+                            foreach ($pivotColumns as $column) {
+                                $pivot[$column] = $result["pivot_{$column}"];
+                                unset($result["pivot_{$column}"]);
+                            }
+                            $pivotObj = (object) $pivot;
+                            $result->pivot = $pivotObj;
+                            $grouped[$pivot[$this->getLastForeignKey()]][] = $result;
+                        }
+
+                        $this->setRelation(
+                            $name,
+                            new Collection($relatedModelClass, $grouped[$this->getKey()] ?? [])
+                        );
+
+                        return $results;
+                }
+            }
+
+            return $relation;
+        }
+
+        return null;
     }
 
     /**

--- a/tests/API/Presenter/SQLitePresenterTest.php
+++ b/tests/API/Presenter/SQLitePresenterTest.php
@@ -26,6 +26,7 @@ class SQLitePresenterTest extends TestCase
         $container = new Container();
         $container->bind('request', fn() => new Request());
         $container->bind('url', fn() => UrlGenerator::class);
+        $container->bind('db', fn() => new Database('default'));
 
         $this->pdo = new PDO('sqlite::memory:');
         $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);

--- a/tests/Model/CastSystemTest.php
+++ b/tests/Model/CastSystemTest.php
@@ -603,10 +603,20 @@ class CastSystemTest extends TestCase
 
     public function testInvalidEnumValueThrows(): void
     {
-        // __get swallows all Throwables, so test the handler directly
         $this->expectException(\ValueError::class);
 
         CastManager::resolve(CastTestColor::class)->get('Purple');
+    }
+
+    public function testInvalidEnumValuePropagatesThroughModelGetter(): void
+    {
+        // Model::__get() must let real errors (not just "property missing")
+        // propagate, instead of silently returning null.
+        $model = new MockEnumCastModel(['color' => 'Purple']);
+
+        $this->expectException(\ValueError::class);
+
+        $model->color;
     }
     public function testCustomCastGetUppercases(): void
     {


### PR DESCRIPTION
Removed the broad try { ... } catch (\Throwable) { return; } wrapper around the entire method body.

The previous implementation was silently swallowing all exceptions, including genuine application errors from cast resolution, relation queries, computed properties, and other property-resolution logic.

It was also masking dead code: the explicit throw new \Exception("Property or relation '$name' does not exist...") could never reach the caller because it was immediately caught by the enclosing catch. The "not found" case has therefore been simplified to a direct return null;, while all other exceptions are now allowed to propagate normally.