### PR TITLE
resolve terminating callback dependencies via container

### DIFF
--- a/src/Phaseolies/Application.php
+++ b/src/Phaseolies/Application.php
@@ -1143,15 +1143,9 @@ class Application extends Container
                 $resolved = true;
             }
 
-            if (!$resolved && $parameter->isDefaultValueAvailable()) {
-                $arguments[] = $parameter->getDefaultValue();
-                $resolved = true;
-            }
-
             if (!$resolved) {
-                throw new \RuntimeException(
-                    "Unresolvable terminating callback parameter '\${$parameter->getName()}'."
-                );
+                $primitives = $namedContext;
+                $arguments[] = $this->resolveDependency($parameter, $primitives);
             }
         }
 

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -561,6 +561,24 @@ final class ApplicationTest extends TestCase
         $this->assertSame($exception, $captured['exception']);
     }
 
+    public function testTerminatingCallbackCanTypeHintAnArbitraryContainerService(): void
+    {
+        // Beyond request/response/exception, a terminating callback
+        // parameter that doesn't match the lifecycle context by type
+        // or name should be resolved from the container like any
+        // other injected dependency, not just default-valued or
+        // rejected outright.
+        $captured = null;
+
+        $this->app->terminating(function (StringService $strings) use (&$captured): void {
+            $captured = $strings;
+        });
+
+        $this->app->terminate(new Request(), new Response('ok'));
+
+        $this->assertInstanceOf(StringService::class, $captured);
+    }
+
     public function testTerminateCleansRequestScopedServicesAfterCallbacks(): void
     {
         $_SESSION = [];


### PR DESCRIPTION
## Summary

Simplifies `Application::callTerminatingCallback()` by delegating to the DI container instead of hand-rolling dependency resolution for anything beyond the `request/response/exception` lifecycle context.

- Kept the existing, tested `instanceof`-based matching for `Request`/`Response`/`\Throwable` params (including interface-typed ones like `?\Throwable $exception`) — this can't move into the container since its `get()` is a flat exact-name lookup, not polymorphism-aware.
- Replaced the tail-end hand-rolled default-value fallback + custom `throw new \RuntimeException(...)` with a single call to `$this->resolveDependency()` (the container's own resolver, accessible since `Application extends Container`).
- Side effect: a terminating callback can now type-hint any container-bound service, not just the three lifecycle values — previously that combination hard-threw.