### PR TITLE
fix: enforce enum column values on Postgres and SQLite

### DIFF
--- a/src/Phaseolies/Database/Migration/ColumnDefinition.php
+++ b/src/Phaseolies/Database/Migration/ColumnDefinition.php
@@ -177,22 +177,6 @@ class ColumnDefinition
     }
 
     /**
-     * Get formatted enum values for ENUM/SET types.
-     *
-     * @return string
-     */
-    protected function getEnumValues(): string
-    {
-        if (!isset($this->attributes['values']) || !is_array($this->attributes['values'])) {
-            return '';
-        }
-
-        return implode(',', array_map(function ($value) {
-            return "'" . addslashes($value) . "'";
-        }, $this->attributes['values']));
-    }
-
-    /**
      * Get the current PDO driver
      *
      * @return string

--- a/src/Phaseolies/Database/Migration/Grammars/Grammar.php
+++ b/src/Phaseolies/Database/Migration/Grammars/Grammar.php
@@ -80,4 +80,42 @@ abstract class Grammar
     {
         return false;
     }
+
+    /**
+     * Extract and validate the allowed values for an enum/set column.
+     *
+     * @param array $attributes
+     * @return array
+     * @throws \InvalidArgumentException
+     */
+    protected function getEnumAllowedValues(array $attributes): array
+    {
+        $values = $attributes['allowed'] ?? $attributes['values'] ?? null;
+
+        if (!$values || !is_array($values)) {
+            throw new \InvalidArgumentException('Enum type requires an array of allowed values');
+        }
+
+        return $values;
+    }
+
+    /**
+     * Build an inline CHECK constraint clause restricting a column to
+     * a fixed set of values, for drivers with no native ENUM type.
+     * Appended directly to the column's type definition, so it applies
+     * the same way in both CREATE TABLE and ALTER TABLE ADD COLUMN.
+     *
+     * @param string $column
+     * @param array $values
+     * @return string
+     */
+    protected function compileEnumCheckClause(string $column, array $values): string
+    {
+        $quoted = array_map(
+            fn($value) => "'" . str_replace("'", "''", (string) $value) . "'",
+            $values
+        );
+
+        return "CHECK ({$column} IN (" . implode(', ', $quoted) . '))';
+    }
 }

--- a/src/Phaseolies/Database/Migration/Grammars/MySQLGrammar.php
+++ b/src/Phaseolies/Database/Migration/Grammars/MySQLGrammar.php
@@ -238,12 +238,13 @@ class MySQLGrammar extends Grammar
      */
     protected function getEnumValues(array $attributes): string
     {
-        $values = $attributes['allowed'] ?? $attributes['values'] ?? null;
+        $values = $this->getEnumAllowedValues($attributes);
 
-        if (!$values || !is_array($values)) {
-            throw new \InvalidArgumentException('Enum type requires an array of allowed values');
-        }
+        $quoted = array_map(
+            fn($value) => "'" . str_replace("'", "''", (string) $value) . "'",
+            $values
+        );
 
-        return "'" . implode("','", $values) . "'";
+        return implode(',', $quoted);
     }
 }

--- a/src/Phaseolies/Database/Migration/Grammars/PostgreSQLGrammar.php
+++ b/src/Phaseolies/Database/Migration/Grammars/PostgreSQLGrammar.php
@@ -14,7 +14,14 @@ class PostgreSQLGrammar extends Grammar
      */
     public function getTypeDefinition(ColumnDefinition $column): string
     {
-        return $this->mapType($column->type, $column->attributes);
+        $type = $this->mapType($column->type, $column->attributes);
+
+        if ($column->type === 'enum') {
+            $values = $this->getEnumAllowedValues($column->attributes);
+            $type .= ' ' . $this->compileEnumCheckClause($column->name, $values);
+        }
+
+        return $type;
     }
 
     /**
@@ -202,65 +209,16 @@ class PostgreSQLGrammar extends Grammar
     }
 
     /**
-     * Create an ENUM type definition for PostgreSQL
+     * Create an ENUM type definition for 
      *
      * @param array $attributes
      * @return string
      */
     protected function createEnumType(array $attributes): string
     {
-        $values = $attributes['allowed'] ?? $attributes['values'] ?? null;
-
-        if (!$values || !is_array($values)) {
-            throw new \InvalidArgumentException('Enum type requires an array of allowed values');
-        }
+        $this->getEnumAllowedValues($attributes);
 
         return 'TEXT';
-    }
-
-    /**
-     * Compile a CHECK constraint for an enum column
-     *
-     * @param string $table
-     * @param string $column
-     * @param array $values
-     * @return string
-     */
-    public function compileAddEnumCheckConstraint(string $table, string $column, array $values): string
-    {
-        $constraintName = "chk_{$table}_{$column}_enum";
-        $quotedValues = array_map(function ($value) {
-            return "'" . str_replace("'", "''", $value) . "'";
-        }, $values);
-
-        return "ALTER TABLE \"{$table}\" ADD CONSTRAINT \"{$constraintName}\" CHECK (\"{$column}\" IN (" . implode(', ', $quotedValues) . "))";
-    }
-
-    /**
-     * Compile a statement to create an enum type (alternative approach)
-     *
-     * @param string $typeName
-     * @param array $values
-     * @return string
-     */
-    public function compileCreateEnumType(string $typeName, array $values): string
-    {
-        $quotedValues = array_map(function ($value) {
-            return "'" . str_replace("'", "''", $value) . "'";
-        }, $values);
-
-        return "CREATE TYPE {$typeName} AS ENUM (" . implode(', ', $quotedValues) . ")";
-    }
-
-    /**
-     * Compile a statement to drop an enum type
-     *
-     * @param string $typeName
-     * @return string
-     */
-    public function compileDropEnumType(string $typeName): string
-    {
-        return "DROP TYPE IF EXISTS {$typeName}";
     }
 
     /**

--- a/src/Phaseolies/Database/Migration/Grammars/SQLiteGrammar.php
+++ b/src/Phaseolies/Database/Migration/Grammars/SQLiteGrammar.php
@@ -14,7 +14,14 @@ class SQLiteGrammar extends Grammar
      */
     public function getTypeDefinition(ColumnDefinition $column): string
     {
-        return $this->mapType($column->type, $column->attributes);
+        $type = $this->mapType($column->type, $column->attributes);
+
+        if ($column->type === 'enum') {
+            $values = $this->getEnumAllowedValues($column->attributes);
+            $type .= ' ' . $this->compileEnumCheckClause($column->name, $values);
+        }
+
+        return $type;
     }
 
     /**

--- a/tests/Builder/EnumColumnMigrationTest.php
+++ b/tests/Builder/EnumColumnMigrationTest.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace Tests\Unit\Builder;
+
+use PHPUnit\Framework\TestCase;
+use Phaseolies\Database\Migration\Blueprint;
+use Phaseolies\DI\Container;
+use PDO;
+
+/**
+ * Enum columns must reject values outside the declared list on every
+ * supported driver:
+ *  - MySQL:    native ENUM(...) type (already enforced before this test).
+ *  - Postgres: TEXT + inline CHECK constraint.
+ *  - SQLite:   TEXT + inline CHECK constraint.
+ *
+ * Postgres and SQLite have no native enum type reachable from a portable
+ * migration column definition, so both use an inline CHECK clause
+ * instead of leaving the column unconstrained.
+ */
+class EnumColumnMigrationTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        $reflection = new \ReflectionClass(Container::class);
+        $property = $reflection->getProperty('instance');
+        $property->setValue(null, null);
+    }
+
+    /**
+     * Bind a fake 'db' service reporting the given PDO driver name, so
+     * Blueprint/ColumnDefinition pick the matching grammar.
+     */
+    private function bindFakeDriver(string $driverName): void
+    {
+        $container = new Container();
+        $container->bind('db', fn() => new class($driverName) {
+            public function __construct(private string $driverName)
+            {
+            }
+            public function getConnection()
+            {
+                return new class($this->driverName) {
+                    public function __construct(private string $driverName)
+                    {
+                    }
+                    public function getAttribute($attribute)
+                    {
+                        return $this->driverName;
+                    }
+                };
+            }
+        });
+
+        Container::setInstance($container);
+    }
+
+    public function testMySqlEnumProducesNativeEnumType(): void
+    {
+        $this->bindFakeDriver('mysql');
+
+        $blueprint = new Blueprint('posts', 'mysql');
+        $blueprint->enum('status', ['draft', 'published']);
+
+        $sql = $blueprint->toSql();
+
+        $this->assertStringContainsString("status ENUM('draft','published')", $sql);
+    }
+
+    public function testPostgresEnumAddsInlineCheckConstraint(): void
+    {
+        $this->bindFakeDriver('pgsql');
+
+        $blueprint = new Blueprint('posts', 'pgsql');
+        $blueprint->enum('status', ['draft', 'published']);
+
+        $sql = $blueprint->toSql();
+
+        $this->assertStringContainsString(
+            "status TEXT CHECK (status IN ('draft', 'published'))",
+            $sql
+        );
+    }
+
+    public function testSqliteEnumAddsInlineCheckConstraint(): void
+    {
+        $this->bindFakeDriver('sqlite');
+
+        $blueprint = new Blueprint('posts', 'sqlite');
+        $blueprint->enum('status', ['draft', 'published']);
+
+        $sql = $blueprint->toSql();
+
+        $this->assertStringContainsString(
+            "status TEXT CHECK (status IN ('draft', 'published'))",
+            $sql
+        );
+    }
+
+    public function testEnumWithoutValuesThrowsOnEveryDriver(): void
+    {
+        foreach (['mysql', 'pgsql', 'sqlite'] as $driver) {
+            $this->bindFakeDriver($driver);
+
+            $blueprint = new Blueprint('posts', $driver);
+            $blueprint->addColumn('enum', 'status', ['values' => []]);
+
+            try {
+                $blueprint->toSql();
+                $this->fail("Expected InvalidArgumentException for driver {$driver}");
+            } catch (\InvalidArgumentException $e) {
+                $this->assertSame('Enum type requires an array of allowed values', $e->getMessage());
+            }
+        }
+    }
+
+    public function testEnumValuesContainingQuotesAreEscapedOnEveryDriver(): void
+    {
+        foreach (['mysql', 'pgsql', 'sqlite'] as $driver) {
+            $this->bindFakeDriver($driver);
+
+            $blueprint = new Blueprint('posts', $driver);
+            $blueprint->enum('label', ["O'Brien", 'plain']);
+
+            // Must not throw and must double the embedded quote rather
+            // than leave it able to break out of the string literal.
+            $sql = $blueprint->toSql();
+            $this->assertStringContainsString("O''Brien", $sql, "Driver: {$driver}");
+        }
+    }
+
+    public function testSqliteEnumConstraintIsEnforcedAtDatabaseLevel(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $container = new Container();
+        $container->bind('db', fn() => new class($pdo) {
+            public function __construct(private PDO $pdo)
+            {
+            }
+            public function getConnection()
+            {
+                return $this->pdo;
+            }
+        });
+        Container::setInstance($container);
+
+        $blueprint = new Blueprint('posts', 'sqlite');
+        $blueprint->id();
+        $blueprint->enum('status', ['draft', 'published']);
+
+        $pdo->exec($blueprint->toSql());
+
+        // A declared value must be accepted.
+        $pdo->exec("INSERT INTO posts (status) VALUES ('draft')");
+        $this->assertSame('1', (string) $pdo->query('SELECT COUNT(*) FROM posts')->fetchColumn());
+
+        // A value outside the declared set must be rejected by the
+        // database itself, not merely by application-level validation.
+        $this->expectException(\PDOException::class);
+        $pdo->exec("INSERT INTO posts (status) VALUES ('archived')");
+    }
+
+    public function testPostgresEnumConstraintIsEnforcedAtDatabaseLevel(): void
+    {
+        if (!extension_loaded('pdo_pgsql')) {
+            $this->markTestSkipped('The pdo_pgsql extension is required for this test.');
+        }
+
+        $host = getenv('DOPPAR_TEST_PGSQL_HOST') ?: '';
+        $database = getenv('DOPPAR_TEST_PGSQL_DATABASE') ?: '';
+
+        if ($host === '' || $database === '') {
+            $this->markTestSkipped(
+                'Configure DOPPAR_TEST_PGSQL_HOST/DOPPAR_TEST_PGSQL_DATABASE to run this test.'
+            );
+        }
+
+        $port = getenv('DOPPAR_TEST_PGSQL_PORT') ?: '5432';
+        $username = getenv('DOPPAR_TEST_PGSQL_USERNAME') ?: 'postgres';
+        $password = getenv('DOPPAR_TEST_PGSQL_PASSWORD') ?: '';
+
+        $pdo = new PDO(
+            sprintf('pgsql:host=%s;port=%s;dbname=%s', $host, $port, $database),
+            $username,
+            $password
+        );
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $table = 'doppar_enum_check_test_' . uniqid();
+        $pdo->exec("DROP TABLE IF EXISTS {$table}");
+
+        try {
+            $container = new Container();
+            $container->bind('db', fn() => new class($pdo) {
+                public function __construct(private PDO $pdo)
+                {
+                }
+                public function getConnection()
+                {
+                    return $this->pdo;
+                }
+            });
+            Container::setInstance($container);
+
+            $blueprint = new Blueprint($table, 'pgsql');
+            $blueprint->id();
+            $blueprint->enum('status', ['draft', 'published']);
+
+            $pdo->exec($blueprint->toSql());
+
+            $pdo->exec("INSERT INTO {$table} (status) VALUES ('draft')");
+            $this->assertSame('1', (string) $pdo->query("SELECT COUNT(*) FROM {$table}")->fetchColumn());
+
+            $this->expectException(\PDOException::class);
+            $pdo->exec("INSERT INTO {$table} (status) VALUES ('archived')");
+        } finally {
+            $pdo->exec("DROP TABLE IF EXISTS {$table}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`$table->enum('role', ['admin', 'editor', 'publisher'])` previously only enforced allowed values on MySQL (native `ENUM` type). On Postgres and SQLite the exact same migration silently produced a plain `TEXT` column with zero constraint — any string was accepted.

- Postgres and SQLite now get an inline `CHECK (column IN (...))` constraint embedded directly in the column definition, applied consistently for both `CREATE TABLE` and `ALTER TABLE ADD COLUMN`.
- Removed `compileAddEnumCheckConstraint()`, `compileCreateEnumType()`, `compileDropEnumType()` — an abandoned native-Postgres-type approach with zero callers anywhere in the codebase.
- Removed a second, entirely dead duplicate enum-value formatter in `ColumnDefinition.php`.
- Fixed a real bug in the formatter that *is* used: `MySQLGrammar::getEnumValues()` had no quote-escaping — a value containing `'` would have produced broken SQL. Now escaped consistently across all three grammars via a shared `Grammar::compileEnumCheckClause()` / `getEnumAllowedValues()` helper.
- SQLite's enum mapping now validates non-empty values too, matching MySQL/Postgres (previously silently allowed `[]`).
