### PR TITLE
fix: Schema::table() generated CREATE TABLE instead of ALTER TABLE on every driver

### DIFF
--- a/src/Phaseolies/Database/Migration/Blueprint.php
+++ b/src/Phaseolies/Database/Migration/Blueprint.php
@@ -25,15 +25,25 @@ class Blueprint
     protected Grammar $grammar;
 
     /**
+     * Whether this blueprint is creating a new table (true) or
+     * modifying an existing one (false)
+     *
+     * @var bool
+     */
+    protected bool $creating;
+
+    /**
      * Create a new table blueprint instance.
      *
      * @param string $table
      * @param string|null $driver
+     * @param bool $creating
      */
-    public function __construct(string $table, ?string $driver = null)
+    public function __construct(string $table, ?string $driver = null, bool $creating = true)
     {
         $this->table = $table;
         $this->grammar = GrammarFactory::make($driver ?? $this->getDefaultDriver());
+        $this->creating = $creating;
     }
 
     /**
@@ -763,11 +773,7 @@ class Blueprint
             throw new \RuntimeException("No columns defined for table {$this->table}");
         }
 
-        $hasColumnOrdering = !empty(array_filter($columns, function ($col) {
-            return isset($col->attributes['after']);
-        }));
-
-        if (!$hasColumnOrdering || !$this->grammar->supportsColumnOrdering()) {
+        if ($this->creating) {
             // Create table with all columns
             $columnDefinitions = [];
             $primaryKeys = [];
@@ -793,8 +799,12 @@ class Blueprint
                 $this->handleIndexAndUniqueColumn($column, $statements);
             }
         } else {
-            // Handle ALTER TABLE for adding columns with ordering
+            // Modifying an existing table:
             foreach ($columns as $column) {
+                // Only MySQL supports positioning an added column with
+                // AFTER, and only in this ALTER TABLE context.
+                $column->attributes['altering'] = true;
+
                 $columnSql = $column->toSql();
 
                 // Skip if this is a primary key column and the grammar doesn't support adding it with ALTER
@@ -834,8 +844,16 @@ class Blueprint
 
         if (isset($column->attributes['unique']) && $column->attributes['unique']) {
             $sql = $this->grammar->compileCreateUnique($this->table, $column->name);
+
             if (!empty($sql)) {
                 $statements[] = $sql;
+            } elseif (!$this->creating) {
+                throw new \RuntimeException(
+                    "Cannot add a UNIQUE constraint to column \"{$column->name}\" on table " .
+                    "\"{$this->table}\" via ALTER TABLE on this database driver. " .
+                    "Declare the column as unique in the table's original CREATE TABLE " .
+                    "migration instead."
+                );
             }
         }
     }

--- a/src/Phaseolies/Database/Migration/ColumnDefinition.php
+++ b/src/Phaseolies/Database/Migration/ColumnDefinition.php
@@ -123,8 +123,12 @@ class ColumnDefinition
             $sql .= ' PRIMARY KEY';
         }
 
-        // Add UNIQUE constraint if grammar requires it in column definition
-        if (!empty($this->attributes['unique']) && $grammar->shouldAddUniqueInColumnDefinition()) {
+        // Add UNIQUE constraint if grammar requires it in column definition.
+        if (
+            !empty($this->attributes['unique']) &&
+            $grammar->shouldAddUniqueInColumnDefinition() &&
+            empty($this->attributes['altering'])
+        ) {
             $sql .= ' UNIQUE';
         }
 
@@ -150,10 +154,12 @@ class ColumnDefinition
             $sql .= " DEFAULT {$default}";
         }
 
-        if ($this->getDriver() !== 'pgsql') {
-            if (isset($this->attributes['after'])) {
-                $sql .= " AFTER {$this->attributes['after']}";
-            }
+        if (
+            $this->getDriver() === 'mysql' &&
+            !empty($this->attributes['altering']) &&
+            isset($this->attributes['after'])
+        ) {
+            $sql .= " AFTER {$this->attributes['after']}";
         }
 
         return $sql;

--- a/src/Phaseolies/Database/Migration/Schema.php
+++ b/src/Phaseolies/Database/Migration/Schema.php
@@ -46,7 +46,7 @@ class Schema
      */
     public function table(string $table, callable $callback): void
     {
-        $blueprint = new Blueprint($table);
+        $blueprint = new Blueprint($table, null, false);
 
         $callback($blueprint);
 

--- a/tests/Builder/BlueprintAlterModeTest.php
+++ b/tests/Builder/BlueprintAlterModeTest.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace Tests\Unit\Builder;
+
+use PHPUnit\Framework\TestCase;
+use Phaseolies\Database\Migration\Blueprint;
+use Phaseolies\DI\Container;
+use PDO;
+
+/**
+ * Blueprint must know explicitly whether it's building a CREATE TABLE
+ * (Schema::create()) or modifying an existing table (Schema::table()),
+ * instead of inferring this from whether any column happens to use
+ * after() — that heuristic meant Schema::table() silently generated a
+ * bogus CREATE TABLE (failing with "table already exists") on every
+ * driver whenever no column used after(), which is the common case.
+ */
+class BlueprintAlterModeTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        $reflection = new \ReflectionClass(Container::class);
+        $property = $reflection->getProperty('instance');
+        $property->setValue(null, null);
+    }
+
+    private function bindFakeDriver(string $driverName): void
+    {
+        $container = new Container();
+        $container->bind('db', fn() => new class($driverName) {
+            public function __construct(private string $driverName)
+            {
+            }
+            public function getConnection()
+            {
+                return new class($this->driverName) {
+                    public function __construct(private string $driverName)
+                    {
+                    }
+                    public function getAttribute($attribute)
+                    {
+                        return $this->driverName;
+                    }
+                };
+            }
+        });
+
+        Container::setInstance($container);
+    }
+
+    public function testAlterModeProducesAddColumnWithoutAfterOnSqlite(): void
+    {
+        $this->bindFakeDriver('sqlite');
+
+        $blueprint = new Blueprint('users', 'sqlite', false);
+        $blueprint->string('nickname')->nullable();
+
+        $sql = $blueprint->toSql();
+
+        $this->assertStringContainsString('ALTER TABLE `users` ADD COLUMN nickname TEXT NULL', $sql);
+        $this->assertStringNotContainsString('CREATE TABLE', $sql);
+    }
+
+    public function testAlterModeProducesAddColumnWithoutAfterOnPostgres(): void
+    {
+        $this->bindFakeDriver('pgsql');
+
+        $blueprint = new Blueprint('users', 'pgsql', false);
+        $blueprint->string('nickname')->nullable();
+
+        $sql = $blueprint->toSql();
+
+        $this->assertStringContainsString('ALTER TABLE "users" ADD COLUMN nickname VARCHAR(255) NULL', $sql);
+        $this->assertStringNotContainsString('CREATE TABLE', $sql);
+    }
+
+    public function testAlterModeProducesAddColumnWithoutAfterOnMysql(): void
+    {
+        $this->bindFakeDriver('mysql');
+
+        $blueprint = new Blueprint('users', 'mysql', false);
+        $blueprint->string('nickname')->nullable();
+
+        $sql = $blueprint->toSql();
+
+        $this->assertStringContainsString('ADD COLUMN nickname VARCHAR(255) NULL', $sql);
+        $this->assertStringNotContainsString('CREATE TABLE', $sql);
+    }
+
+    public function testCreateModeIgnoresColumnOrderingForBranchSelection(): void
+    {
+        // Regression guard: create mode must always produce CREATE
+        // TABLE, even when a column uses after() (which is meaningless
+        // for a brand-new table but must not flip the statement type).
+        $this->bindFakeDriver('mysql');
+
+        $blueprint = new Blueprint('users', 'mysql', true);
+        $blueprint->id();
+        $blueprint->string('nickname')->after('id');
+
+        $sql = $blueprint->toSql();
+
+        $this->assertStringContainsString('CREATE TABLE', $sql);
+        $this->assertStringNotContainsString('ALTER TABLE', $sql);
+        // AFTER is only valid in MySQL's ALTER TABLE ADD COLUMN syntax,
+        // not CREATE TABLE — must not appear here.
+        $this->assertStringNotContainsString('AFTER', $sql);
+    }
+
+    public function testAlterModeIncludesAfterClauseOnMysql(): void
+    {
+        $this->bindFakeDriver('mysql');
+
+        $blueprint = new Blueprint('users', 'mysql', false);
+        $blueprint->string('nickname')->after('id');
+
+        $sql = $blueprint->toSql();
+
+        $this->assertStringContainsString('AFTER id', $sql);
+    }
+
+    public function testAlteringExistingSqliteTableAddsColumnAtDatabaseLevel(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY)');
+
+        $container = new Container();
+        $container->bind('db', fn() => new class($pdo) {
+            public function __construct(private PDO $pdo)
+            {
+            }
+            public function getConnection()
+            {
+                return $this->pdo;
+            }
+        });
+        Container::setInstance($container);
+
+        $blueprint = new Blueprint('users', 'sqlite', false);
+        $blueprint->string('nickname')->nullable();
+
+        $pdo->exec($blueprint->toSql());
+
+        $columns = array_column($pdo->query('PRAGMA table_info(users)')->fetchAll(PDO::FETCH_ASSOC), 'name');
+        $this->assertContains('nickname', $columns);
+    }
+
+    public function testAddingUniqueColumnViaAlterOnSqliteThrowsClearError(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY)');
+
+        $container = new Container();
+        $container->bind('db', fn() => new class($pdo) {
+            public function __construct(private PDO $pdo)
+            {
+            }
+            public function getConnection()
+            {
+                return $this->pdo;
+            }
+        });
+        Container::setInstance($container);
+
+        $blueprint = new Blueprint('users', 'sqlite', false);
+        $blueprint->string('code')->unique();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot add a UNIQUE constraint');
+
+        // toSql() itself throws — handleIndexAndUniqueColumn() runs
+        // during SQL generation, before anything touches the database.
+        $blueprint->toSql();
+    }
+
+    public function testCreatingTableWithUniqueColumnOnSqliteStillWorks(): void
+    {
+        // The unique-via-alter restriction must not affect the normal
+        // CREATE TABLE case, where SQLite embeds UNIQUE inline.
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $container = new Container();
+        $container->bind('db', fn() => new class($pdo) {
+            public function __construct(private PDO $pdo)
+            {
+            }
+            public function getConnection()
+            {
+                return $this->pdo;
+            }
+        });
+        Container::setInstance($container);
+
+        $blueprint = new Blueprint('users', 'sqlite');
+        $blueprint->id();
+        $blueprint->string('code')->unique();
+
+        $pdo->exec($blueprint->toSql());
+
+        $pdo->exec("INSERT INTO users (code) VALUES ('a')");
+        $this->expectException(\PDOException::class);
+        $pdo->exec("INSERT INTO users (code) VALUES ('a')");
+    }
+
+    public function testAlteringExistingPostgresTableAddsColumnAtDatabaseLevel(): void
+    {
+        if (!extension_loaded('pdo_pgsql')) {
+            $this->markTestSkipped('The pdo_pgsql extension is required for this test.');
+        }
+
+        $host = getenv('DOPPAR_TEST_PGSQL_HOST') ?: '';
+        $database = getenv('DOPPAR_TEST_PGSQL_DATABASE') ?: '';
+
+        if ($host === '' || $database === '') {
+            $this->markTestSkipped(
+                'Configure DOPPAR_TEST_PGSQL_HOST/DOPPAR_TEST_PGSQL_DATABASE to run this test.'
+            );
+        }
+
+        $port = getenv('DOPPAR_TEST_PGSQL_PORT') ?: '5432';
+        $username = getenv('DOPPAR_TEST_PGSQL_USERNAME') ?: 'postgres';
+        $password = getenv('DOPPAR_TEST_PGSQL_PASSWORD') ?: '';
+
+        $pdo = new PDO(
+            sprintf('pgsql:host=%s;port=%s;dbname=%s', $host, $port, $database),
+            $username,
+            $password
+        );
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $table = 'doppar_alter_test_' . uniqid();
+        $pdo->exec("DROP TABLE IF EXISTS {$table}");
+        $pdo->exec("CREATE TABLE {$table} (id SERIAL PRIMARY KEY)");
+
+        try {
+            $container = new Container();
+            $container->bind('db', fn() => new class($pdo) {
+                public function __construct(private PDO $pdo)
+                {
+                }
+                public function getConnection()
+                {
+                    return $this->pdo;
+                }
+            });
+            Container::setInstance($container);
+
+            $blueprint = new Blueprint($table, 'pgsql', false);
+            $blueprint->string('nickname')->nullable();
+
+            $pdo->exec($blueprint->toSql());
+
+            $stmt = $pdo->query(
+                "SELECT column_name FROM information_schema.columns WHERE table_name = " .
+                $pdo->quote($table)
+            );
+            $columns = $stmt->fetchAll(PDO::FETCH_COLUMN);
+
+            $this->assertContains('nickname', $columns);
+        } finally {
+            $pdo->exec("DROP TABLE IF EXISTS {$table}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`Blueprint::toSql()` decided CREATE TABLE vs. ALTER TABLE ADD COLUMN by checking whether any column used `->after()`, instead of knowing whether it was actually building a new table or modifying an existing one. Since `->after()` is rarely used, `Schema::table('existing', fn($t) => $t->string('x'))` generated a bogus `CREATE TABLE` statement and failed with "table already exists" / "relation already exists" — reproduced live against MySQL-grammar output, real SQLite, and a real running Postgres server, not just SQLite as originally suspected.

- `Blueprint` now takes an explicit `bool $creating` constructor flag (default `true`, so all direct `new Blueprint(...)` usage — tests included — is unaffected). `Schema::create()` passes `true`, `Schema::table()` passes `false`. Branch selection in `toSql()` uses this flag directly instead of inferring it from column attributes.
- Fixed the specific case that surfaced once the ALTER path became reachable: SQLite cannot add a `UNIQUE` constraint to an existing table via `ALTER TABLE` at all (inline or otherwise) — `handleIndexAndUniqueColumn()` now throws a clear `RuntimeException` explaining this and the workaround, instead of a silent no-op or a cryptic raw PDO error.
- Fixed a latent bug the same change could have exposed: MySQL's `AFTER` clause is only valid in `ALTER TABLE ADD COLUMN`, never in `CREATE TABLE` (any driver) — now gated on `mysql AND altering` instead of the previous `driver !== 'pgsql'` check, which would have let `AFTER` leak into an invalid `CREATE TABLE` statement.