### PR TITLE
Fix: DI resolution-order bug

### DIFF
--- a/src/Phaseolies/DI/Container.php
+++ b/src/Phaseolies/DI/Container.php
@@ -178,12 +178,6 @@ class Container implements ArrayAccess
                 return self::$instances[$abstract];
             }
 
-            foreach (self::$instances as $instance) {
-                if ($instance instanceof $abstract) {
-                    return $instance;
-                }
-            }
-
             if (isset(self::$bindings[$abstract])) {
                 $binding = self::$bindings[$abstract];
                 $resolved = $this->resolveBinding($abstract, $binding, $parameters);
@@ -193,6 +187,13 @@ class Container implements ArrayAccess
                 }
 
                 return $resolved;
+            }
+
+            // Fallback only: no exact instance and no explicit binding for $abstract.
+            foreach (self::$instances as $instance) {
+                if ($instance instanceof $abstract) {
+                    return $instance;
+                }
             }
 
             if (class_exists($abstract) || interface_exists($abstract)) {

--- a/tests/Application/ContainerTest.php
+++ b/tests/Application/ContainerTest.php
@@ -42,6 +42,7 @@ use Tests\Application\Mock\ClassWithVariadic;
 use Tests\Application\Mock\ComplexConstructorClass;
 use Tests\Application\Mock\ComplexDependencyGraph;
 use Tests\Application\Mock\ConcreteDependency;
+use Tests\Application\Mock\AnotherImplementation;
 use Tests\Application\Mock\ConcreteImplementation;
 use Tests\Application\Mock\Controllers\ControllerClass;
 use Tests\Application\Mock\Counter;
@@ -256,6 +257,23 @@ class ContainerTest extends TestCase
 
         $resolved = $this->container->get(TestInterface::class);
         $this->assertSame($instance, $resolved);
+    }
+
+    public function testExplicitBindingIsNotShadowedByUnrelatedSingleton()
+    {
+        // An unrelated singleton, registered under its own class name,
+        // that happens to implement the same interface as an explicit
+        // binding must not shadow that binding.
+        $unrelated = new AnotherImplementation();
+        $this->container->instance(AnotherImplementation::class, $unrelated);
+
+        $expected = new ConcreteImplementation();
+        $this->container->bind(TestInterface::class, fn() => $expected);
+
+        $resolved = $this->container->get(TestInterface::class);
+
+        $this->assertSame($expected, $resolved);
+        $this->assertNotSame($unrelated, $resolved);
     }
 
     public function testMultipleInstanceBindings()

--- a/tests/Application/Mock/AnotherImplementation.php
+++ b/tests/Application/Mock/AnotherImplementation.php
@@ -4,7 +4,7 @@ namespace Tests\Application\Mock;
 
 use Tests\Application\Mock\Interfaces\TestInterface;
 
-class ConcreteImplementation implements TestInterface
+class AnotherImplementation implements TestInterface
 {
     //
 }


### PR DESCRIPTION
## Change 
**(Container.php:get()):** moved the `self::$bindings[$abstract]` check to run right after the exact-instance check, before the loose instanceof scan over all registered singletons — not after it. The scan now only runs as a last-resort fallback when there's no exact instance and no explicit binding for the requested abstract, so it can no longer shadow a correct, explicit binding with an unrelated singleton that happens to satisfy the same type.

Kept the scan itself rather than removing it — it's a real, if unusual, convenience (an interface can resolve to a concrete singleton that was registered under its own class name and never explicitly bound to the interface), just wrongly prioritized before.