### PR TITLE
Environment configuration switches from .env to env.toml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
   "require": {
     "php": "^8.5",
     "chillerlan/php-qrcode": "^6.0",
+    "devium/toml": "^1.1",
     "dragonmantank/cron-expression": "^3.6",
     "monolog/monolog": "^3.10",
     "nesbot/carbon": "^3.13",
@@ -33,8 +34,7 @@
     "symfony/console": "^8.1",
     "symfony/mailer": "^8.1",
     "symfony/process": "^8.1",
-    "symfony/var-dumper": "^8.1",
-    "vlucas/phpdotenv": "^5.7"
+    "symfony/var-dumper": "^8.1"
   },
   "require-dev": {
     "mockery/mockery": "^1.6",

--- a/src/Phaseolies/Application.php
+++ b/src/Phaseolies/Application.php
@@ -15,7 +15,8 @@ use Phaseolies\Error\ErrorHandler;
 use Phaseolies\DI\Container;
 use Phaseolies\Config\Config;
 use Phaseolies\ApplicationBuilder;
-use Dotenv\Dotenv;
+use Devium\Toml\Toml;
+use RuntimeException;
 
 class Application extends Container
 {
@@ -106,7 +107,7 @@ class Application extends Container
      *
      * @var string
      */
-    protected $environmentFile = '.env';
+    protected $environmentFile = 'env.toml';
 
     /**
      * The environment name.
@@ -288,7 +289,7 @@ class Application extends Container
     }
 
     /**
-     * Load environment variables from .env file
+     * Load environment variables from env.toml
      *
      * @return void
      */
@@ -298,8 +299,39 @@ class Application extends Container
             return;
         }
 
-        $dotenv = Dotenv::createImmutable(base_path());
-        $dotenv->safeLoad();
+        $tomlFile = $this->basePath('env.toml');
+
+        if (is_file($tomlFile)) {
+            $this->loadTomlEnvironment($tomlFile);
+        }
+    }
+
+    /**
+     * Load environment variables from a flat env.toml file.
+     *
+     * @param string $file
+     * @return void
+     *
+     * @throws RuntimeException
+     */
+    protected function loadTomlEnvironment(string $file): void
+    {
+        $values = Toml::decode(file_get_contents($file), asArray: true);
+
+        foreach ($values as $key => $value) {
+            if (is_array($value)) {
+                throw new RuntimeException(
+                    "env.toml key \"{$key}\" must be a scalar value — nested tables and arrays are not supported."
+                );
+            }
+
+            if (getenv($key) !== false) {
+                continue;
+            }
+
+            $_ENV[$key] = $value;
+            $_SERVER[$key] = $value;
+        }
     }
 
     /**

--- a/src/Phaseolies/Config/Config.php
+++ b/src/Phaseolies/Config/Config.php
@@ -87,7 +87,7 @@ final class Config
                 $hashes[] = md5_file($file) . '|' . filemtime($file);
             }
 
-            $envFile = base_path('.env');
+            $envFile = base_path('env.toml');
             if (file_exists($envFile)) {
                 $hashes[] = md5_file($envFile) . '|' . filemtime($envFile);
             }

--- a/src/Phaseolies/Console/Commands/Cron/CronRunCommand.php
+++ b/src/Phaseolies/Console/Commands/Cron/CronRunCommand.php
@@ -4,6 +4,7 @@ namespace Phaseolies\Console\Commands\Cron;
 
 use App\Schedule\Schedule;
 use Phaseolies\Console\Schedule\Command;
+use Phaseolies\Console\Schedule\SchedulePool;
 use Symfony\Component\Process\Process;
 use React\EventLoop\Loop;
 
@@ -259,7 +260,7 @@ class CronRunCommand extends Command
     protected function executeCommand($command, bool $isSecondBased = false): void
     {
         try {
-            $env = array_merge(getenv(), [
+            $env = SchedulePool::buildEnv([
                 'APP_RUNNING_IN_CONSOLE' => true,
                 'APP_SCHEDULE_RUNNING' => true,
                 'APP_SECOND_SCHEDULE' => $isSecondBased ? 'true' : 'false'

--- a/src/Phaseolies/Console/Commands/KeyGenerateCommand.php
+++ b/src/Phaseolies/Console/Commands/KeyGenerateCommand.php
@@ -19,7 +19,7 @@ class KeyGenerateCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Generate a new application key and set it in the .env file';
+    protected $description = 'Generate a new application key and set it in the env.toml file';
 
     /**
      * Execute the console command.
@@ -30,21 +30,21 @@ class KeyGenerateCommand extends Command
     {
         return $this->executeWithTiming(function() {
             $randomKey = base64_encode(random_bytes(32));
-            $envPath = base_path() . '/.env';
+            $envPath = base_path() . '/env.toml';
 
             if (!file_exists($envPath)) {
-                throw new RuntimeException('.env file not found!');
+                throw new RuntimeException('env.toml file not found!');
             }
 
             $envContent = file_get_contents($envPath);
             $newEnvContent = preg_replace(
-                '/^APP_KEY=.*$/m',
-                "APP_KEY=base64:$randomKey",
+                '/^APP_KEY\s*=.*$/m',
+                "APP_KEY = \"base64:$randomKey\"",
                 $envContent
             );
 
             if (file_put_contents($envPath, $newEnvContent) === false) {
-                throw new RuntimeException('Failed to update .env file.');
+                throw new RuntimeException('Failed to update env.toml file.');
             }
 
             $this->displaySuccess('Application key set successfully');

--- a/src/Phaseolies/Console/Schedule/SchedulePool.php
+++ b/src/Phaseolies/Console/Schedule/SchedulePool.php
@@ -15,6 +15,29 @@ class SchedulePool
     protected static $runningProcesses = [];
 
     /**
+     * Build a subprocess environment from the current $_SERVER/$_ENV state
+     *
+     * @param array $overrides
+     * @return array<string, string>
+     */
+    public static function buildEnv(array $overrides = []): array
+    {
+        $env = [];
+
+        foreach (array_merge($_SERVER, $_ENV, $overrides) as $key => $value) {
+            // $_SERVER carries non-scalar entries (e.g. 'argv') that have
+            // no meaningful string form as an env var — skip them.
+            if ($value === null || !is_scalar($value)) {
+                continue;
+            }
+
+            $env[$key] = is_bool($value) ? ($value ? 'true' : 'false') : (string) $value;
+        }
+
+        return $env;
+    }
+
+    /**
      * Call a command through the pool
      *
      * @param string $command
@@ -31,7 +54,7 @@ class SchedulePool
         $process = new Process(
             $commandArray,
             base_path(),
-            array_merge($_SERVER, $_ENV, [
+            self::buildEnv([
                 'APP_RUNNING_IN_CONSOLE' => true,
                 'APP_SCHEDULE_RUNNING' => true
             ]),

--- a/src/Phaseolies/Error/Handlers/WebErrorHandler.php
+++ b/src/Phaseolies/Error/Handlers/WebErrorHandler.php
@@ -25,7 +25,7 @@ class WebErrorHandler implements ErrorHandlerInterface
 
         $renderer = new WebErrorRenderer();
 
-        if (env('APP_DEBUG') === "true") {
+        if (env('APP_DEBUG', false)) {
             $response = $renderer->renderDebug($exception);
         } else {
             $response = $renderer->renderProduction($exception);

--- a/src/Phaseolies/Helpers/helpers.php
+++ b/src/Phaseolies/Helpers/helpers.php
@@ -45,7 +45,15 @@ if (!function_exists('dopparEnv')) {
      */
     function dopparEnv(string $key, string|float|int|bool|null $default = null): string|float|int|bool|null
     {
-        $value = $_ENV[$key] ?? $_SERVER[$key] ?? getenv($key);
+        if (array_key_exists($key, $_ENV)) {
+            return $_ENV[$key];
+        }
+
+        if (array_key_exists($key, $_SERVER)) {
+            return $_SERVER[$key];
+        }
+
+        $value = getenv($key);
 
         return $value !== false ? $value : $default;
     }
@@ -480,7 +488,7 @@ if (!function_exists('detect_scheme')) {
     function detect_scheme(): string
     {
         // Force HTTPS via environment variable
-        if (getenv('FORCE_HTTPS') === 'true') {
+        if (env('FORCE_HTTPS') === true || env('FORCE_HTTPS') === 'true') {
             return 'https';
         }
 

--- a/src/Phaseolies/Installer.php
+++ b/src/Phaseolies/Installer.php
@@ -12,9 +12,9 @@ class Installer
 
         $io->write("<info>🎉 Setting up doppar skeleton application...</info>");
 
-        if (!file_exists('.env')) {
-            copy('.env.example', '.env');
-            $io->write("<comment>  ✓ Created .env file from .env.example</comment>");
+        if (!file_exists('env.toml')) {
+            copy('env.toml.example', 'env.toml');
+            $io->write("<comment>  ✓ Created env.toml file from env.toml.example</comment>");
         }
     }
 }

--- a/src/Phaseolies/Support/Router.php
+++ b/src/Phaseolies/Support/Router.php
@@ -248,7 +248,7 @@ class Router
      */
     public function shouldCacheRoutes(): bool
     {
-        return env('APP_ROUTE_CACHE', false) === 'true';
+        return env('APP_ROUTE_CACHE', false);
     }
 
     /**

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -208,7 +208,7 @@ final class ApplicationTest extends TestCase
 
     public function testEnvironmentFileManagement(): void
     {
-        $this->assertSame('.env', $this->app->environmentFile());
+        $this->assertSame('env.toml', $this->app->environmentFile());
 
         $result = $this->app->loadEnvironmentFrom('.env.testing');
         $this->assertSame($this->app, $result);

--- a/tests/Application/TomlEnvironmentTest.php
+++ b/tests/Application/TomlEnvironmentTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Unit\Application;
+
+use Phaseolies\Application;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+use RuntimeException;
+
+final class TomlEnvironmentTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/phaseolies_toml_test_' . uniqid();
+        mkdir($this->tempDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (['TOML_BOOL_KEY', 'TOML_INT_KEY', 'TOML_STRING_KEY', 'TOML_PRE_EXISTING_KEY'] as $key) {
+            unset($_ENV[$key], $_SERVER[$key]);
+        }
+
+        putenv('TOML_PRE_EXISTING_KEY');
+
+        $this->deleteDirectory($this->tempDir);
+    }
+
+    public function testTomlValuesKeepRealTypesInsteadOfBecomingStrings(): void
+    {
+        $file = $this->tempDir . '/env.toml';
+        file_put_contents($file, <<<TOML
+        TOML_BOOL_KEY = false
+        TOML_INT_KEY = 42
+        TOML_STRING_KEY = "hello"
+        TOML
+
+        );
+
+        $this->loadTomlEnvironment($file);
+
+        $this->assertSame(false, $_ENV['TOML_BOOL_KEY']);
+        $this->assertSame(42, $_ENV['TOML_INT_KEY']);
+        $this->assertSame('hello', $_ENV['TOML_STRING_KEY']);
+    }
+
+    public function testRealEnvironmentVariableTakesPriorityOverTomlFile(): void
+    {
+        putenv('TOML_PRE_EXISTING_KEY=from-os');
+
+        $file = $this->tempDir . '/env.toml';
+        file_put_contents($file, 'TOML_PRE_EXISTING_KEY = "from-toml"');
+
+        $this->loadTomlEnvironment($file);
+
+        $this->assertArrayNotHasKey('TOML_PRE_EXISTING_KEY', $_ENV);
+    }
+
+    public function testNestedTableThrowsBecauseEnvCallSitesExpectFlatKeys(): void
+    {
+        $file = $this->tempDir . '/env.toml';
+        file_put_contents($file, "[nested]\nkey = \"value\"");
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('nested');
+
+        $this->loadTomlEnvironment($file);
+    }
+
+    private function loadTomlEnvironment(string $file): void
+    {
+        $app = (new ReflectionClass(Application::class))->newInstanceWithoutConstructor();
+        $method = new ReflectionMethod(Application::class, 'loadTomlEnvironment');
+        $method->invoke($app, $file);
+    }
+
+    private function deleteDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($files as $file) {
+            $file->isDir() ? rmdir($file->getRealPath()) : unlink($file->getRealPath());
+        }
+
+        rmdir($dir);
+    }
+}

--- a/tests/Console/CommandBehaviorCoverageTest.php
+++ b/tests/Console/CommandBehaviorCoverageTest.php
@@ -372,14 +372,14 @@ class CommandBehaviorCoverageTest extends TestCase
             use InteractsWithFakeCommandIO;
         };
 
-        $envFile = Env::path('.env');
-        file_put_contents($envFile, "APP_NAME=Doppar\nAPP_KEY=base64:old-key\n");
+        $envFile = Env::path('env.toml');
+        file_put_contents($envFile, "APP_NAME = \"Doppar\"\nAPP_KEY = \"base64:old-key\"\n");
 
         $result = $command->handle();
         $contents = (string) file_get_contents($envFile);
 
         $this->assertSame(0, $result);
-        $this->assertMatchesRegularExpression('/APP_KEY=base64:[A-Za-z0-9+\/=]+/', $contents);
+        $this->assertMatchesRegularExpression('/APP_KEY = "base64:[A-Za-z0-9+\/=]+"/', $contents);
         $this->assertContains('Application key set successfully', $command->capturedSuccesses);
     }
 

--- a/tests/Console/SchedulePoolTest.php
+++ b/tests/Console/SchedulePoolTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Unit\Console;
+
+use Phaseolies\Console\Schedule\SchedulePool;
+use PHPUnit\Framework\TestCase;
+
+class SchedulePoolTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        unset($_ENV['SCHEDULE_POOL_TEST_BOOL_FALSE'], $_ENV['SCHEDULE_POOL_TEST_BOOL_TRUE'], $_ENV['SCHEDULE_POOL_TEST_INT']);
+    }
+
+    public function testRealFalseIsStringifiedInsteadOfBeingDroppedBySymfonyProcess(): void
+    {
+        // Symfony's Process treats a literal `false` env value as "unset
+        // this var for the child" instead of passing it through. A real
+        // `false` from env.toml must survive as the string "false", not
+        // silently vanish from the subprocess's environment.
+        $_ENV['SCHEDULE_POOL_TEST_BOOL_FALSE'] = false;
+
+        $env = SchedulePool::buildEnv();
+
+        $this->assertSame('false', $env['SCHEDULE_POOL_TEST_BOOL_FALSE']);
+    }
+
+    public function testRealTrueIsStringifiedConsistently(): void
+    {
+        $_ENV['SCHEDULE_POOL_TEST_BOOL_TRUE'] = true;
+
+        $env = SchedulePool::buildEnv();
+
+        $this->assertSame('true', $env['SCHEDULE_POOL_TEST_BOOL_TRUE']);
+    }
+
+    public function testIntValueIsStringified(): void
+    {
+        $_ENV['SCHEDULE_POOL_TEST_INT'] = 3306;
+
+        $env = SchedulePool::buildEnv();
+
+        $this->assertSame('3306', $env['SCHEDULE_POOL_TEST_INT']);
+    }
+
+    public function testOverridesAreIncludedAndStringified(): void
+    {
+        $env = SchedulePool::buildEnv([
+            'APP_RUNNING_IN_CONSOLE' => true,
+            'APP_SCHEDULE_RUNNING' => true,
+        ]);
+
+        $this->assertSame('true', $env['APP_RUNNING_IN_CONSOLE']);
+        $this->assertSame('true', $env['APP_SCHEDULE_RUNNING']);
+    }
+}

--- a/tests/Helpers/EnvHelperTest.php
+++ b/tests/Helpers/EnvHelperTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Unit\Helpers;
+
+use PHPUnit\Framework\TestCase;
+
+class EnvHelperTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        unset($_ENV['ENV_HELPER_TEST_KEY'], $_SERVER['ENV_HELPER_TEST_KEY']);
+        putenv('ENV_HELPER_TEST_KEY');
+    }
+
+    public function testFalseValueInEnvIsReturnedAsIs(): void
+    {
+        // A real `false` (e.g. sourced from env.toml) must not be confused
+        // with getenv()'s "key not found" sentinel, which is also false.
+        $_ENV['ENV_HELPER_TEST_KEY'] = false;
+
+        $this->assertSame(false, env('ENV_HELPER_TEST_KEY', 'default'));
+    }
+
+    public function testFalseValueInServerIsReturnedAsIs(): void
+    {
+        $_SERVER['ENV_HELPER_TEST_KEY'] = false;
+
+        $this->assertSame(false, env('ENV_HELPER_TEST_KEY', 'default'));
+    }
+
+    public function testZeroValueInEnvIsReturnedAsIs(): void
+    {
+        $_ENV['ENV_HELPER_TEST_KEY'] = 0;
+
+        $this->assertSame(0, env('ENV_HELPER_TEST_KEY', 'default'));
+    }
+
+    public function testMissingKeyReturnsDefault(): void
+    {
+        $this->assertSame('default', env('ENV_HELPER_TEST_KEY_DOES_NOT_EXIST', 'default'));
+        $this->assertNull(env('ENV_HELPER_TEST_KEY_DOES_NOT_EXIST'));
+    }
+
+    public function testRealProcessEnvironmentVariableIsReturned(): void
+    {
+        putenv('ENV_HELPER_TEST_KEY=from-getenv');
+
+        $this->assertSame('from-getenv', env('ENV_HELPER_TEST_KEY'));
+    }
+}


### PR DESCRIPTION
### Description
## Why TOML instead of .env
`.env` files only ever produce strings — `APP_DEBUG=false` is not a boolean, it's the four-character string "false", and (bool) "false" is true in PHP. This isn't a hypothetical: `runtime/config/app.php` had "debug" => (bool) env("APP_DEBUG", false) — a real, live footgun that would have silently left debug mode on for any deployment that tried to explicitly disable it. The Router and error handler each grew their `own === 'true'` string-comparison workaround for the same reason.

TOML is a natural fit for `env.toml` specifically (not application config generally) because environment files are inherently flat scalar data — no closures, no ::class constants, nothing that TOML can't express. `env.toml` gives real types end to end: `APP_DEBUG = false` is an actual bool, `DB_PORT = 3306` is a real int, and `env()` returns them as such, no casting required at every call site.