### PR TITLE
Redesign the 4.x welcome page across all frontend install stubs

### DIFF
--- a/src/Phaseolies/Console/Commands/stubs/frontend/components/react.jsx.stub
+++ b/src/Phaseolies/Console/Commands/stubs/frontend/components/react.jsx.stub
@@ -2,38 +2,92 @@ const runtime = window.__DOPPAR_FRONTEND__ ?? {};
 
 export default function App() {
     return (
-        <main className="doppar-welcome-shell">
-            <header className="doppar-welcome-header">
-                <img className="doppar-welcome-logo" src={runtime.logoUrl ?? '/logo.png'} alt="Logo" />
-                <h2>Welcome to Doppar</h2>
-            </header>
-            <section className="doppar-cta-box">
-                <h3>{runtime.version ?? 'Doppar'}</h3>
-                <p>Craft Fast-Loading PHP Application</p>
-            </section>
-            <section className="doppar-grid">
-                <a href="https://doppar.com/versions/3.x/starter-kits" className="doppar-card">
-                    <h3>Starter kits</h3>
-                    <p>To give you a head start building your new Doppar application, we are happy to offer application starter kits.</p>
-                </a>
-                <a href="https://doppar.com/versions/3.x/architecture-concept" className="doppar-card">
-                    <h3>System Architecture</h3>
-                    <p>Doppar follows the Model-View-Controller (MVC) architectural pattern, a widely accepted standard in web application development.</p>
-                </a>
-                <a href="https://doppar.com/versions/3.x/routing" className="doppar-card">
-                    <h3>Routing</h3>
-                    <p>With support for route prefix grouping, named routes, throttle route, middleware assignment, and RESTful resource routing, Doppar gives developers full control over how requests are handled.</p>
-                </a>
-                <a href="https://doppar.com/versions/3.x/authentication" className="doppar-card">
-                    <h3>Authentication</h3>
-                    <p>Doppar simplifies this process by providing built-in tools and scaffolding to help you implement user authentication quickly and securely.</p>
-                </a>
-            </section>
-            <div className="doppar-btn-group">
-                <a href="https://github.com/doppar" className="doppar-btn">GitHub</a>
-                <a href="https://doppar.com" className="doppar-btn">Website</a>
+        <div className="doppar-welcome">
+            <div className="doppar-brand">
+                <img src={runtime.logoUrl ?? '/logo.png'} alt="Doppar" />
+                <span>Doppar</span>
             </div>
-            <div className="doppar-footer">{runtime.phpVersion ?? ''}</div>
-        </main>
+
+            <div className="doppar-card">
+                <div className="doppar-panel">
+                    <div className="doppar-eyebrow"><span className="doppar-dot"></span> Application ready</div>
+
+                    <h1 className="doppar-heading">Let's build something.</h1>
+
+                    <div className="doppar-steps">
+                        <div className="doppar-step">
+                            <span className="doppar-step-marker"></span>
+                            <div className="doppar-step-label">01 &middot; Learn</div>
+                            <a href="https://doppar.com/versions/4.x/installation" target="_blank" rel="noopener">Read the documentation <span className="doppar-arrow">&#8599;</span></a>
+                        </div>
+                        <div className="doppar-step">
+                            <span className="doppar-step-marker"></span>
+                            <div className="doppar-step-label">02 &middot; Explore</div>
+                            <a href="https://doppar.com/versions/4.x/releases" target="_blank" rel="noopener">See what's new in 4.x <span className="doppar-arrow">&#8599;</span></a>
+                        </div>
+                        <div className="doppar-step">
+                            <span className="doppar-step-marker"></span>
+                            <div className="doppar-step-label">03 &middot; Connect</div>
+                            <a href="https://github.com/doppar" target="_blank" rel="noopener">Star the project on GitHub <span className="doppar-arrow">&#8599;</span></a>
+                        </div>
+                    </div>
+
+                    <a href="https://doppar.com/versions/4.x/installation" className="doppar-cta">Get Started</a>
+
+                    <div className="doppar-meta">
+                        {runtime.version ?? 'Doppar'} &middot; {runtime.phpVersion ?? ''} &middot;
+                        {' '}
+                        <a href="https://doppar.com/versions/4.x/releases" target="_blank" rel="noopener">View release notes &#8599;</a>
+                    </div>
+                </div>
+
+                <div className="doppar-art">
+                    <svg viewBox="0 0 480 620" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
+                        <defs>
+                            <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
+                                <stop offset="0%" stopColor="#34d399" />
+                                <stop offset="100%" stopColor="#10b981" />
+                            </linearGradient>
+                            <linearGradient id="g2" x1="0" y1="0" x2="1" y2="1">
+                                <stop offset="0%" stopColor="#fb923c" />
+                                <stop offset="100%" stopColor="#f97316" />
+                            </linearGradient>
+                            <linearGradient id="g3" x1="0" y1="1" x2="1" y2="0">
+                                <stop offset="0%" stopColor="#807dfc" />
+                                <stop offset="100%" stopColor="#a78bfa" />
+                            </linearGradient>
+                            <pattern id="dots" width="26" height="26" patternUnits="userSpaceOnUse">
+                                <circle cx="1.3" cy="1.3" r="1.3" fill="rgba(255,255,255,0.06)" />
+                            </pattern>
+                        </defs>
+
+                        <rect width="480" height="620" fill="#0a0a0a" />
+                        <rect width="480" height="620" fill="url(#dots)" />
+
+                        <text x="500" y="470" textAnchor="end" fontFamily="'Space Grotesk', sans-serif" fontWeight="700" fontSize="480" fill="none" stroke="rgba(255,255,255,0.08)" strokeWidth="2">4</text>
+
+                        <g opacity="0.95">
+                            <rect x="0" y="0" width="150" height="150" rx="22" fill="url(#g1)" transform="translate(60 90) rotate(45)" />
+                            <rect x="0" y="0" width="92" height="92" rx="16" fill="url(#g2)" opacity="0.92" transform="translate(300 60) rotate(45)" />
+                            <rect x="0" y="0" width="64" height="64" rx="12" fill="url(#g3)" opacity="0.85" transform="translate(120 330) rotate(45)" />
+                            <rect x="0" y="0" width="118" height="118" rx="18" fill="none" stroke="url(#g1)" strokeWidth="2.5" opacity="0.7" transform="translate(270 400) rotate(45)" />
+                            <rect x="0" y="0" width="46" height="46" rx="10" fill="url(#g2)" opacity="0.9" transform="translate(60 500) rotate(45)" />
+                        </g>
+
+                        <g stroke="rgba(255,255,255,0.18)" strokeWidth="1.5" fill="none">
+                            <path d="M90 165 L90 260 L190 260" />
+                            <path d="M300 145 L300 220 L230 220" />
+                        </g>
+                        <circle cx="90" cy="260" r="3.5" fill="#34d399" />
+                        <circle cx="190" cy="260" r="3.5" fill="#fb923c" />
+                        <circle cx="230" cy="220" r="3.5" fill="#a78bfa" />
+
+                        <g fontFamily="'JetBrains Mono', monospace" fontSize="12" fontWeight="600" letterSpacing="2" fill="rgba(255,255,255,0.5)">
+                            <text x="34" y="580">DOPPAR/4.X</text>
+                        </g>
+                    </svg>
+                </div>
+            </div>
+        </div>
     );
 }

--- a/src/Phaseolies/Console/Commands/stubs/frontend/components/react.tsx.stub
+++ b/src/Phaseolies/Console/Commands/stubs/frontend/components/react.tsx.stub
@@ -8,38 +8,92 @@ const runtime = (window as Window & { __DOPPAR_FRONTEND__?: DopparRuntime }).__D
 
 export default function App() {
     return (
-        <main className="doppar-welcome-shell">
-            <header className="doppar-welcome-header">
-                <img className="doppar-welcome-logo" src={runtime.logoUrl ?? '/logo.png'} alt="Logo" />
-                <h2>Welcome to Doppar</h2>
-            </header>
-            <section className="doppar-cta-box">
-                <h3>{runtime.version ?? 'Doppar'}</h3>
-                <p>Craft Fast-Loading PHP Application</p>
-            </section>
-            <section className="doppar-grid">
-                <a href="https://doppar.com/versions/3.x/starter-kits" className="doppar-card">
-                    <h3>Starter kits</h3>
-                    <p>To give you a head start building your new Doppar application, we are happy to offer application starter kits.</p>
-                </a>
-                <a href="https://doppar.com/versions/3.x/architecture-concept" className="doppar-card">
-                    <h3>System Architecture</h3>
-                    <p>Doppar follows the Model-View-Controller (MVC) architectural pattern, a widely accepted standard in web application development.</p>
-                </a>
-                <a href="https://doppar.com/versions/3.x/routing" className="doppar-card">
-                    <h3>Routing</h3>
-                    <p>With support for route prefix grouping, named routes, throttle route, middleware assignment, and RESTful resource routing, Doppar gives developers full control over how requests are handled.</p>
-                </a>
-                <a href="https://doppar.com/versions/3.x/authentication" className="doppar-card">
-                    <h3>Authentication</h3>
-                    <p>Doppar simplifies this process by providing built-in tools and scaffolding to help you implement user authentication quickly and securely.</p>
-                </a>
-            </section>
-            <div className="doppar-btn-group">
-                <a href="https://github.com/doppar" className="doppar-btn">GitHub</a>
-                <a href="https://doppar.com" className="doppar-btn">Website</a>
+        <div className="doppar-welcome">
+            <div className="doppar-brand">
+                <img src={runtime.logoUrl ?? '/logo.png'} alt="Doppar" />
+                <span>Doppar</span>
             </div>
-            <div className="doppar-footer">{runtime.phpVersion ?? ''}</div>
-        </main>
+
+            <div className="doppar-card">
+                <div className="doppar-panel">
+                    <div className="doppar-eyebrow"><span className="doppar-dot"></span> Application ready</div>
+
+                    <h1 className="doppar-heading">Let's build something.</h1>
+
+                    <div className="doppar-steps">
+                        <div className="doppar-step">
+                            <span className="doppar-step-marker"></span>
+                            <div className="doppar-step-label">01 &middot; Learn</div>
+                            <a href="https://doppar.com/versions/4.x/installation" target="_blank" rel="noopener">Read the documentation <span className="doppar-arrow">&#8599;</span></a>
+                        </div>
+                        <div className="doppar-step">
+                            <span className="doppar-step-marker"></span>
+                            <div className="doppar-step-label">02 &middot; Explore</div>
+                            <a href="https://doppar.com/versions/4.x/releases" target="_blank" rel="noopener">See what's new in 4.x <span className="doppar-arrow">&#8599;</span></a>
+                        </div>
+                        <div className="doppar-step">
+                            <span className="doppar-step-marker"></span>
+                            <div className="doppar-step-label">03 &middot; Connect</div>
+                            <a href="https://github.com/doppar" target="_blank" rel="noopener">Star the project on GitHub <span className="doppar-arrow">&#8599;</span></a>
+                        </div>
+                    </div>
+
+                    <a href="https://doppar.com/versions/4.x/installation" className="doppar-cta">Get Started</a>
+
+                    <div className="doppar-meta">
+                        {runtime.version ?? 'Doppar'} &middot; {runtime.phpVersion ?? ''} &middot;
+                        {' '}
+                        <a href="https://doppar.com/versions/4.x/releases" target="_blank" rel="noopener">View release notes &#8599;</a>
+                    </div>
+                </div>
+
+                <div className="doppar-art">
+                    <svg viewBox="0 0 480 620" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
+                        <defs>
+                            <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
+                                <stop offset="0%" stopColor="#34d399" />
+                                <stop offset="100%" stopColor="#10b981" />
+                            </linearGradient>
+                            <linearGradient id="g2" x1="0" y1="0" x2="1" y2="1">
+                                <stop offset="0%" stopColor="#fb923c" />
+                                <stop offset="100%" stopColor="#f97316" />
+                            </linearGradient>
+                            <linearGradient id="g3" x1="0" y1="1" x2="1" y2="0">
+                                <stop offset="0%" stopColor="#807dfc" />
+                                <stop offset="100%" stopColor="#a78bfa" />
+                            </linearGradient>
+                            <pattern id="dots" width="26" height="26" patternUnits="userSpaceOnUse">
+                                <circle cx="1.3" cy="1.3" r="1.3" fill="rgba(255,255,255,0.06)" />
+                            </pattern>
+                        </defs>
+
+                        <rect width="480" height="620" fill="#0a0a0a" />
+                        <rect width="480" height="620" fill="url(#dots)" />
+
+                        <text x="500" y="470" textAnchor="end" fontFamily="'Space Grotesk', sans-serif" fontWeight="700" fontSize="480" fill="none" stroke="rgba(255,255,255,0.08)" strokeWidth="2">4</text>
+
+                        <g opacity="0.95">
+                            <rect x="0" y="0" width="150" height="150" rx="22" fill="url(#g1)" transform="translate(60 90) rotate(45)" />
+                            <rect x="0" y="0" width="92" height="92" rx="16" fill="url(#g2)" opacity="0.92" transform="translate(300 60) rotate(45)" />
+                            <rect x="0" y="0" width="64" height="64" rx="12" fill="url(#g3)" opacity="0.85" transform="translate(120 330) rotate(45)" />
+                            <rect x="0" y="0" width="118" height="118" rx="18" fill="none" stroke="url(#g1)" strokeWidth="2.5" opacity="0.7" transform="translate(270 400) rotate(45)" />
+                            <rect x="0" y="0" width="46" height="46" rx="10" fill="url(#g2)" opacity="0.9" transform="translate(60 500) rotate(45)" />
+                        </g>
+
+                        <g stroke="rgba(255,255,255,0.18)" strokeWidth="1.5" fill="none">
+                            <path d="M90 165 L90 260 L190 260" />
+                            <path d="M300 145 L300 220 L230 220" />
+                        </g>
+                        <circle cx="90" cy="260" r="3.5" fill="#34d399" />
+                        <circle cx="190" cy="260" r="3.5" fill="#fb923c" />
+                        <circle cx="230" cy="220" r="3.5" fill="#a78bfa" />
+
+                        <g fontFamily="'JetBrains Mono', monospace" fontSize="12" fontWeight="600" letterSpacing="2" fill="rgba(255,255,255,0.5)">
+                            <text x="34" y="580">DOPPAR/4.X</text>
+                        </g>
+                    </svg>
+                </div>
+            </div>
+        </div>
     );
 }

--- a/src/Phaseolies/Console/Commands/stubs/frontend/components/svelte.stub
+++ b/src/Phaseolies/Console/Commands/stubs/frontend/components/svelte.stub
@@ -2,36 +2,89 @@
     const runtime = window.__DOPPAR_FRONTEND__ ?? {};
 </script>
 
-<main class="doppar-welcome-shell">
-    <header class="doppar-welcome-header">
-        <img class="doppar-welcome-logo" src={runtime.logoUrl ?? '/logo.png'} alt="Logo" />
-        <h2>Welcome to Doppar</h2>
-    </header>
-    <section class="doppar-cta-box">
-        <h3>{runtime.version ?? 'Doppar'}</h3>
-        <p>Craft Fast-Loading PHP Application</p>
-    </section>
-    <section class="doppar-grid">
-        <a href="https://doppar.com/versions/3.x/starter-kits" class="doppar-card">
-            <h3>Starter kits</h3>
-            <p>To give you a head start building your new Doppar application, we are happy to offer application starter kits.</p>
-        </a>
-        <a href="https://doppar.com/versions/3.x/architecture-concept" class="doppar-card">
-            <h3>System Architecture</h3>
-            <p>Doppar follows the Model-View-Controller (MVC) architectural pattern, a widely accepted standard in web application development.</p>
-        </a>
-        <a href="https://doppar.com/versions/3.x/routing" class="doppar-card">
-            <h3>Routing</h3>
-            <p>With support for route prefix grouping, named routes, throttle route, middleware assignment, and RESTful resource routing, Doppar gives developers full control over how requests are handled.</p>
-        </a>
-        <a href="https://doppar.com/versions/3.x/authentication" class="doppar-card">
-            <h3>Authentication</h3>
-            <p>Doppar simplifies this process by providing built-in tools and scaffolding to help you implement user authentication quickly and securely.</p>
-        </a>
-    </section>
-    <div class="doppar-btn-group">
-        <a href="https://github.com/doppar" class="doppar-btn">GitHub</a>
-        <a href="https://doppar.com" class="doppar-btn">Website</a>
+<div class="doppar-welcome">
+    <div class="doppar-brand">
+        <img src={runtime.logoUrl ?? '/logo.png'} alt="Doppar" />
+        <span>Doppar</span>
     </div>
-    <div class="doppar-footer">{runtime.phpVersion ?? ''}</div>
-</main>
+
+    <div class="doppar-card">
+        <div class="doppar-panel">
+            <div class="doppar-eyebrow"><span class="doppar-dot"></span> Application ready</div>
+
+            <h1 class="doppar-heading">Let's build something.</h1>
+
+            <div class="doppar-steps">
+                <div class="doppar-step">
+                    <span class="doppar-step-marker"></span>
+                    <div class="doppar-step-label">01 &middot; Learn</div>
+                    <a href="https://doppar.com/versions/4.x/installation" target="_blank" rel="noopener">Read the documentation <span class="doppar-arrow">&#8599;</span></a>
+                </div>
+                <div class="doppar-step">
+                    <span class="doppar-step-marker"></span>
+                    <div class="doppar-step-label">02 &middot; Explore</div>
+                    <a href="https://doppar.com/versions/4.x/releases" target="_blank" rel="noopener">See what's new in 4.x <span class="doppar-arrow">&#8599;</span></a>
+                </div>
+                <div class="doppar-step">
+                    <span class="doppar-step-marker"></span>
+                    <div class="doppar-step-label">03 &middot; Connect</div>
+                    <a href="https://github.com/doppar" target="_blank" rel="noopener">Star the project on GitHub <span class="doppar-arrow">&#8599;</span></a>
+                </div>
+            </div>
+
+            <a href="https://doppar.com/versions/4.x/installation" class="doppar-cta">Get Started</a>
+
+            <div class="doppar-meta">
+                {runtime.version ?? 'Doppar'} &middot; {runtime.phpVersion ?? ''} &middot;
+                <a href="https://doppar.com/versions/4.x/releases" target="_blank" rel="noopener">View release notes &#8599;</a>
+            </div>
+        </div>
+
+        <div class="doppar-art">
+            <svg viewBox="0 0 480 620" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
+                <defs>
+                    <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
+                        <stop offset="0%" stop-color="#34d399" />
+                        <stop offset="100%" stop-color="#10b981" />
+                    </linearGradient>
+                    <linearGradient id="g2" x1="0" y1="0" x2="1" y2="1">
+                        <stop offset="0%" stop-color="#fb923c" />
+                        <stop offset="100%" stop-color="#f97316" />
+                    </linearGradient>
+                    <linearGradient id="g3" x1="0" y1="1" x2="1" y2="0">
+                        <stop offset="0%" stop-color="#807dfc" />
+                        <stop offset="100%" stop-color="#a78bfa" />
+                    </linearGradient>
+                    <pattern id="dots" width="26" height="26" patternUnits="userSpaceOnUse">
+                        <circle cx="1.3" cy="1.3" r="1.3" fill="rgba(255,255,255,0.06)" />
+                    </pattern>
+                </defs>
+
+                <rect width="480" height="620" fill="#0a0a0a" />
+                <rect width="480" height="620" fill="url(#dots)" />
+
+                <text x="500" y="470" text-anchor="end" font-family="'Space Grotesk', sans-serif" font-weight="700" font-size="480" fill="none" stroke="rgba(255,255,255,0.08)" stroke-width="2">4</text>
+
+                <g opacity="0.95">
+                    <rect x="0" y="0" width="150" height="150" rx="22" fill="url(#g1)" transform="translate(60 90) rotate(45)" />
+                    <rect x="0" y="0" width="92" height="92" rx="16" fill="url(#g2)" opacity="0.92" transform="translate(300 60) rotate(45)" />
+                    <rect x="0" y="0" width="64" height="64" rx="12" fill="url(#g3)" opacity="0.85" transform="translate(120 330) rotate(45)" />
+                    <rect x="0" y="0" width="118" height="118" rx="18" fill="none" stroke="url(#g1)" stroke-width="2.5" opacity="0.7" transform="translate(270 400) rotate(45)" />
+                    <rect x="0" y="0" width="46" height="46" rx="10" fill="url(#g2)" opacity="0.9" transform="translate(60 500) rotate(45)" />
+                </g>
+
+                <g stroke="rgba(255,255,255,0.18)" stroke-width="1.5" fill="none">
+                    <path d="M90 165 L90 260 L190 260" />
+                    <path d="M300 145 L300 220 L230 220" />
+                </g>
+                <circle cx="90" cy="260" r="3.5" fill="#34d399" />
+                <circle cx="190" cy="260" r="3.5" fill="#fb923c" />
+                <circle cx="230" cy="220" r="3.5" fill="#a78bfa" />
+
+                <g font-family="'JetBrains Mono', monospace" font-size="12" font-weight="600" letter-spacing="2" fill="rgba(255,255,255,0.5)">
+                    <text x="34" y="580">DOPPAR/4.X</text>
+                </g>
+            </svg>
+        </div>
+    </div>
+</div>

--- a/src/Phaseolies/Console/Commands/stubs/frontend/components/vue.stub
+++ b/src/Phaseolies/Console/Commands/stubs/frontend/components/vue.stub
@@ -3,37 +3,90 @@ const runtime = window.__DOPPAR_FRONTEND__ ?? {};
 </script>
 
 <template>
-    <main class="doppar-welcome-shell">
-        <header class="doppar-welcome-header">
-            <img class="doppar-welcome-logo" :src="runtime.logoUrl ?? '/logo.png'" alt="Logo" />
-            <h2>Welcome to Doppar</h2>
-        </header>
-        <section class="doppar-cta-box">
-            <h3>{{ runtime.version ?? 'Doppar' }}</h3>
-            <p>Craft Fast-Loading PHP Application</p>
-        </section>
-        <section class="doppar-grid">
-            <a href="https://doppar.com/versions/3.x/starter-kits" class="doppar-card">
-                <h3>Starter kits</h3>
-                <p>To give you a head start building your new Doppar application, we are happy to offer application starter kits.</p>
-            </a>
-            <a href="https://doppar.com/versions/3.x/architecture-concept" class="doppar-card">
-                <h3>System Architecture</h3>
-                <p>Doppar follows the Model-View-Controller (MVC) architectural pattern, a widely accepted standard in web application development.</p>
-            </a>
-            <a href="https://doppar.com/versions/3.x/routing" class="doppar-card">
-                <h3>Routing</h3>
-                <p>With support for route prefix grouping, named routes, throttle route, middleware assignment, and RESTful resource routing, Doppar gives developers full control over how requests are handled.</p>
-            </a>
-            <a href="https://doppar.com/versions/3.x/authentication" class="doppar-card">
-                <h3>Authentication</h3>
-                <p>Doppar simplifies this process by providing built-in tools and scaffolding to help you implement user authentication quickly and securely.</p>
-            </a>
-        </section>
-        <div class="doppar-btn-group">
-            <a href="https://github.com/doppar" class="doppar-btn">GitHub</a>
-            <a href="https://doppar.com" class="doppar-btn">Website</a>
+    <div class="doppar-welcome">
+        <div class="doppar-brand">
+            <img :src="runtime.logoUrl ?? '/logo.png'" alt="Doppar" />
+            <span>Doppar</span>
         </div>
-        <div class="doppar-footer">{{ runtime.phpVersion ?? '' }}</div>
-    </main>
+
+        <div class="doppar-card">
+            <div class="doppar-panel">
+                <div class="doppar-eyebrow"><span class="doppar-dot"></span> Application ready</div>
+
+                <h1 class="doppar-heading">Let's build something.</h1>
+
+                <div class="doppar-steps">
+                    <div class="doppar-step">
+                        <span class="doppar-step-marker"></span>
+                        <div class="doppar-step-label">01 &middot; Learn</div>
+                        <a href="https://doppar.com/versions/4.x/installation" target="_blank" rel="noopener">Read the documentation <span class="doppar-arrow">&#8599;</span></a>
+                    </div>
+                    <div class="doppar-step">
+                        <span class="doppar-step-marker"></span>
+                        <div class="doppar-step-label">02 &middot; Explore</div>
+                        <a href="https://doppar.com/versions/4.x/releases" target="_blank" rel="noopener">See what's new in 4.x <span class="doppar-arrow">&#8599;</span></a>
+                    </div>
+                    <div class="doppar-step">
+                        <span class="doppar-step-marker"></span>
+                        <div class="doppar-step-label">03 &middot; Connect</div>
+                        <a href="https://github.com/doppar" target="_blank" rel="noopener">Star the project on GitHub <span class="doppar-arrow">&#8599;</span></a>
+                    </div>
+                </div>
+
+                <a href="https://doppar.com/versions/4.x/installation" class="doppar-cta">Get Started</a>
+
+                <div class="doppar-meta">
+                    {{ runtime.version ?? 'Doppar' }} &middot; {{ runtime.phpVersion ?? '' }} &middot;
+                    <a href="https://doppar.com/versions/4.x/releases" target="_blank" rel="noopener">View release notes &#8599;</a>
+                </div>
+            </div>
+
+            <div class="doppar-art">
+                <svg viewBox="0 0 480 620" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
+                    <defs>
+                        <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
+                            <stop offset="0%" stop-color="#34d399" />
+                            <stop offset="100%" stop-color="#10b981" />
+                        </linearGradient>
+                        <linearGradient id="g2" x1="0" y1="0" x2="1" y2="1">
+                            <stop offset="0%" stop-color="#fb923c" />
+                            <stop offset="100%" stop-color="#f97316" />
+                        </linearGradient>
+                        <linearGradient id="g3" x1="0" y1="1" x2="1" y2="0">
+                            <stop offset="0%" stop-color="#807dfc" />
+                            <stop offset="100%" stop-color="#a78bfa" />
+                        </linearGradient>
+                        <pattern id="dots" width="26" height="26" patternUnits="userSpaceOnUse">
+                            <circle cx="1.3" cy="1.3" r="1.3" fill="rgba(255,255,255,0.06)" />
+                        </pattern>
+                    </defs>
+
+                    <rect width="480" height="620" fill="#0a0a0a" />
+                    <rect width="480" height="620" fill="url(#dots)" />
+
+                    <text x="500" y="470" text-anchor="end" font-family="'Space Grotesk', sans-serif" font-weight="700" font-size="480" fill="none" stroke="rgba(255,255,255,0.08)" stroke-width="2">4</text>
+
+                    <g opacity="0.95">
+                        <rect x="0" y="0" width="150" height="150" rx="22" fill="url(#g1)" transform="translate(60 90) rotate(45)" />
+                        <rect x="0" y="0" width="92" height="92" rx="16" fill="url(#g2)" opacity="0.92" transform="translate(300 60) rotate(45)" />
+                        <rect x="0" y="0" width="64" height="64" rx="12" fill="url(#g3)" opacity="0.85" transform="translate(120 330) rotate(45)" />
+                        <rect x="0" y="0" width="118" height="118" rx="18" fill="none" stroke="url(#g1)" stroke-width="2.5" opacity="0.7" transform="translate(270 400) rotate(45)" />
+                        <rect x="0" y="0" width="46" height="46" rx="10" fill="url(#g2)" opacity="0.9" transform="translate(60 500) rotate(45)" />
+                    </g>
+
+                    <g stroke="rgba(255,255,255,0.18)" stroke-width="1.5" fill="none">
+                        <path d="M90 165 L90 260 L190 260" />
+                        <path d="M300 145 L300 220 L230 220" />
+                    </g>
+                    <circle cx="90" cy="260" r="3.5" fill="#34d399" />
+                    <circle cx="190" cy="260" r="3.5" fill="#fb923c" />
+                    <circle cx="230" cy="220" r="3.5" fill="#a78bfa" />
+
+                    <g font-family="'JetBrains Mono', monospace" font-size="12" font-weight="600" letter-spacing="2" fill="rgba(255,255,255,0.5)">
+                        <text x="34" y="580">DOPPAR/4.X</text>
+                    </g>
+                </svg>
+            </div>
+        </div>
+    </div>
 </template>

--- a/src/Phaseolies/Console/Commands/stubs/frontend/css/bootstrap.stub
+++ b/src/Phaseolies/Console/Commands/stubs/frontend/css/bootstrap.stub
@@ -1,11 +1,18 @@
 @import "bootstrap/dist/css/bootstrap.min.css";
 
 :root {
-    --primary: #10b981;
-    --background: #f9fafb;
+    --bg: #fbfbf9;
     --card-bg: #ffffff;
-    --text-color: #111827;
-    --border: #d1d5db;
+    --card-border: #ececea;
+    --text-color: #18181b;
+    --muted: #6b7280;
+    --line: #e7e5e4;
+    --emerald: #10b981;
+    --emerald-soft: #34d399;
+    --orange: #fb923c;
+    --violet: #807dfc;
+    --yellow: #facc15;
+    --panel-bg: #0a0a0a;
     color-scheme: light;
 }
 
@@ -17,17 +24,16 @@ body {
     margin: 0;
     padding: 40px 20px;
     min-height: 100vh;
-    font-family: Poppins, "Segoe UI", sans-serif;
-    background:
-        radial-gradient(circle at top left, rgba(16, 185, 129, 0.12), transparent 30%),
-        radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.12), transparent 35%),
-        var(--background);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: var(--bg);
     color: var(--text-color);
 }
 
 a {
     color: inherit;
-    text-decoration: none;
 }
 
 code {
@@ -37,103 +43,211 @@ code {
     font-family: "JetBrains Mono", monospace;
 }
 
-.doppar-welcome-shell {
-    max-width: 960px;
-    margin: 0 auto;
-    text-align: center;
-}
-
-.doppar-welcome-header {
-    margin-bottom: 20px;
-}
-
-.doppar-welcome-logo {
-    width: 48px;
-    height: auto;
-    margin-bottom: 10px;
-}
-
-.doppar-welcome-title {
-    margin: 0;
-    font-size: 2rem;
-    font-weight: 700;
-}
-
-.doppar-cta-box {
-    margin: 0 auto 40px;
-    max-width: 600px;
+.doppar-welcome {
     width: 100%;
-    border: 2px solid var(--primary);
-    border-radius: 12px;
-    padding: 20px;
-    background: #ecfdf5;
+    max-width: 980px;
 }
 
-.doppar-cta-box h3 {
-    margin: 0 0 10px;
-    font-size: 1.2rem;
+.doppar-brand {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin: 0 4px 18px;
 }
 
-.doppar-cta-box p {
-    margin: 0;
+.doppar-brand img {
+    width: 24px;
+    height: auto;
 }
 
-.doppar-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: 20px;
-    max-width: 800px;
-    margin: 0 auto 40px;
+.doppar-brand span {
+    font-family: "Space Grotesk", sans-serif;
+    font-weight: 700;
+    font-size: 15px;
 }
 
 .doppar-card {
+    display: grid;
+    grid-template-columns: 1.05fr 0.95fr;
     background: var(--card-bg);
-    padding: 20px;
-    border: 1px solid var(--border);
-    border-radius: 12px;
-    text-align: left;
-    transition: box-shadow .2s;
+    border: 1px solid var(--card-border);
+    border-radius: 28px;
+    overflow: hidden;
+    box-shadow: 0 50px 100px -40px rgba(15, 23, 42, 0.18);
 }
 
-.doppar-card:hover {
-    box-shadow: 0 4px 12px rgba(0, 0, 0, .05);
+.doppar-panel {
+    padding: 56px 52px;
 }
 
-.doppar-card h3 {
-    margin: 0 0 8px;
-    font-size: 1rem;
+.doppar-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--emerald);
+    margin-bottom: 18px;
 }
 
-.doppar-card p {
-    margin: 0;
-    font-size: 14px;
-    color: #4b5563;
+.doppar-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--emerald);
+    box-shadow: 0 0 8px rgba(16, 185, 129, 0.7);
 }
 
-.doppar-btn-group {
-    margin-top: 20px;
+.doppar-heading {
+    font-family: "Space Grotesk", sans-serif;
+    font-weight: 700;
+    font-size: 1.85rem;
+    line-height: 1.2;
+    margin: 0 0 30px;
 }
 
-.doppar-btn {
-    display: inline-block;
-    margin: 0 10px;
-    padding: 10px 18px;
-    background-color: #fff;
-    color: #111827;
-    text-decoration: none;
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    font-weight: 500;
-    transition: background .2s;
+.doppar-steps {
+    margin-bottom: 34px;
 }
 
-.doppar-btn:hover {
-    background-color: #c4c9c8;
+.doppar-step {
+    position: relative;
+    padding-left: 30px;
+    padding-bottom: 22px;
 }
 
-.doppar-footer {
-    margin-top: 50px;
-    font-size: 13px;
+.doppar-step:last-child {
+    padding-bottom: 0;
+}
+
+.doppar-step::before {
+    content: "";
+    position: absolute;
+    left: 5px;
+    top: 20px;
+    bottom: -2px;
+    width: 1px;
+    background: var(--line);
+}
+
+.doppar-step:last-child::before {
+    display: none;
+}
+
+.doppar-step-marker {
+    position: absolute;
+    left: 0;
+    top: 2px;
+    width: 11px;
+    height: 11px;
+    border-radius: 50%;
+    border: 1.5px solid var(--emerald-soft);
+    background: #fff;
+}
+
+.doppar-step-marker::after {
+    content: "";
+    position: absolute;
+    inset: 2.5px;
+    border-radius: 50%;
+    background: var(--emerald-soft);
+}
+
+.doppar-step-label {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
     color: #9ca3af;
-    text-align: center;
+    margin-bottom: 4px;
+}
+
+.doppar-step a {
+    font-size: 14.5px;
+    font-weight: 600;
+    color: var(--text-color);
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.doppar-step a:hover {
+    color: var(--emerald);
+}
+
+.doppar-arrow {
+    font-size: 12px;
+    color: var(--orange);
+}
+
+.doppar-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 13px 26px;
+    border-radius: 999px;
+    background: var(--yellow);
+    color: #171717;
+    text-decoration: none;
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.01em;
+    box-shadow: 0 14px 30px -12px rgba(250, 204, 21, 0.65);
+    transition: transform .15s ease, box-shadow .15s ease;
+}
+
+.doppar-cta:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 18px 34px -12px rgba(250, 204, 21, 0.8);
+}
+
+.doppar-meta {
+    margin-top: 30px;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 12px;
+    color: #9ca3af;
+}
+
+.doppar-meta a {
+    color: var(--muted);
+    text-decoration: none;
+    border-bottom: 1px solid var(--line);
+}
+
+.doppar-meta a:hover {
+    color: var(--orange);
+    border-color: var(--orange);
+}
+
+.doppar-art {
+    position: relative;
+    background: var(--panel-bg);
+    min-height: 460px;
+}
+
+.doppar-art svg {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+}
+
+@media (max-width: 860px) {
+    .doppar-card {
+        grid-template-columns: 1fr;
+    }
+
+    .doppar-panel {
+        padding: 40px 28px;
+        order: 2;
+    }
+
+    .doppar-art {
+        min-height: 200px;
+        order: 1;
+    }
 }

--- a/src/Phaseolies/Console/Commands/stubs/frontend/css/none.stub
+++ b/src/Phaseolies/Console/Commands/stubs/frontend/css/none.stub
@@ -1,9 +1,16 @@
 :root {
-    --primary: #10b981;
-    --background: #f9fafb;
+    --bg: #fbfbf9;
     --card-bg: #ffffff;
-    --text-color: #111827;
-    --border: #d1d5db;
+    --card-border: #ececea;
+    --text-color: #18181b;
+    --muted: #6b7280;
+    --line: #e7e5e4;
+    --emerald: #10b981;
+    --emerald-soft: #34d399;
+    --orange: #fb923c;
+    --violet: #807dfc;
+    --yellow: #facc15;
+    --panel-bg: #0a0a0a;
     color-scheme: light;
 }
 
@@ -15,17 +22,16 @@ body {
     margin: 0;
     padding: 40px 20px;
     min-height: 100vh;
-    font-family: Poppins, "Segoe UI", sans-serif;
-    background:
-        radial-gradient(circle at top left, rgba(16, 185, 129, 0.12), transparent 30%),
-        radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.12), transparent 35%),
-        var(--background);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: var(--bg);
     color: var(--text-color);
 }
 
 a {
     color: inherit;
-    text-decoration: none;
 }
 
 code {
@@ -35,103 +41,211 @@ code {
     font-family: "JetBrains Mono", monospace;
 }
 
-.doppar-welcome-shell {
-    max-width: 960px;
-    margin: 0 auto;
-    text-align: center;
-}
-
-.doppar-welcome-header {
-    margin-bottom: 20px;
-}
-
-.doppar-welcome-logo {
-    width: 48px;
-    height: auto;
-    margin-bottom: 10px;
-}
-
-.doppar-welcome-title {
-    margin: 0;
-    font-size: 2rem;
-    font-weight: 700;
-}
-
-.doppar-cta-box {
-    margin: 0 auto 40px;
-    max-width: 600px;
+.doppar-welcome {
     width: 100%;
-    border: 2px solid var(--primary);
-    border-radius: 12px;
-    padding: 20px;
-    background: #ecfdf5;
+    max-width: 980px;
 }
 
-.doppar-cta-box h3 {
-    margin: 0 0 10px;
-    font-size: 1.2rem;
+.doppar-brand {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin: 0 4px 18px;
 }
 
-.doppar-cta-box p {
-    margin: 0;
+.doppar-brand img {
+    width: 24px;
+    height: auto;
 }
 
-.doppar-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: 20px;
-    max-width: 800px;
-    margin: 0 auto 40px;
+.doppar-brand span {
+    font-family: "Space Grotesk", sans-serif;
+    font-weight: 700;
+    font-size: 15px;
 }
 
 .doppar-card {
+    display: grid;
+    grid-template-columns: 1.05fr 0.95fr;
     background: var(--card-bg);
-    padding: 20px;
-    border: 1px solid var(--border);
-    border-radius: 12px;
-    text-align: left;
-    transition: box-shadow .2s;
+    border: 1px solid var(--card-border);
+    border-radius: 28px;
+    overflow: hidden;
+    box-shadow: 0 50px 100px -40px rgba(15, 23, 42, 0.18);
 }
 
-.doppar-card:hover {
-    box-shadow: 0 4px 12px rgba(0, 0, 0, .05);
+.doppar-panel {
+    padding: 56px 52px;
 }
 
-.doppar-card h3 {
-    margin: 0 0 8px;
-    font-size: 1rem;
+.doppar-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--emerald);
+    margin-bottom: 18px;
 }
 
-.doppar-card p {
-    margin: 0;
-    font-size: 14px;
-    color: #4b5563;
+.doppar-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--emerald);
+    box-shadow: 0 0 8px rgba(16, 185, 129, 0.7);
 }
 
-.doppar-btn-group {
-    margin-top: 20px;
+.doppar-heading {
+    font-family: "Space Grotesk", sans-serif;
+    font-weight: 700;
+    font-size: 1.85rem;
+    line-height: 1.2;
+    margin: 0 0 30px;
 }
 
-.doppar-btn {
-    display: inline-block;
-    margin: 0 10px;
-    padding: 10px 18px;
-    background-color: #fff;
-    color: #111827;
-    text-decoration: none;
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    font-weight: 500;
-    transition: background .2s;
+.doppar-steps {
+    margin-bottom: 34px;
 }
 
-.doppar-btn:hover {
-    background-color: #c4c9c8;
+.doppar-step {
+    position: relative;
+    padding-left: 30px;
+    padding-bottom: 22px;
 }
 
-.doppar-footer {
-    margin-top: 50px;
-    font-size: 13px;
+.doppar-step:last-child {
+    padding-bottom: 0;
+}
+
+.doppar-step::before {
+    content: "";
+    position: absolute;
+    left: 5px;
+    top: 20px;
+    bottom: -2px;
+    width: 1px;
+    background: var(--line);
+}
+
+.doppar-step:last-child::before {
+    display: none;
+}
+
+.doppar-step-marker {
+    position: absolute;
+    left: 0;
+    top: 2px;
+    width: 11px;
+    height: 11px;
+    border-radius: 50%;
+    border: 1.5px solid var(--emerald-soft);
+    background: #fff;
+}
+
+.doppar-step-marker::after {
+    content: "";
+    position: absolute;
+    inset: 2.5px;
+    border-radius: 50%;
+    background: var(--emerald-soft);
+}
+
+.doppar-step-label {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
     color: #9ca3af;
-    text-align: center;
+    margin-bottom: 4px;
+}
+
+.doppar-step a {
+    font-size: 14.5px;
+    font-weight: 600;
+    color: var(--text-color);
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.doppar-step a:hover {
+    color: var(--emerald);
+}
+
+.doppar-arrow {
+    font-size: 12px;
+    color: var(--orange);
+}
+
+.doppar-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 13px 26px;
+    border-radius: 999px;
+    background: var(--yellow);
+    color: #171717;
+    text-decoration: none;
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.01em;
+    box-shadow: 0 14px 30px -12px rgba(250, 204, 21, 0.65);
+    transition: transform .15s ease, box-shadow .15s ease;
+}
+
+.doppar-cta:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 18px 34px -12px rgba(250, 204, 21, 0.8);
+}
+
+.doppar-meta {
+    margin-top: 30px;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 12px;
+    color: #9ca3af;
+}
+
+.doppar-meta a {
+    color: var(--muted);
+    text-decoration: none;
+    border-bottom: 1px solid var(--line);
+}
+
+.doppar-meta a:hover {
+    color: var(--orange);
+    border-color: var(--orange);
+}
+
+.doppar-art {
+    position: relative;
+    background: var(--panel-bg);
+    min-height: 460px;
+}
+
+.doppar-art svg {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+}
+
+@media (max-width: 860px) {
+    .doppar-card {
+        grid-template-columns: 1fr;
+    }
+
+    .doppar-panel {
+        padding: 40px 28px;
+        order: 2;
+    }
+
+    .doppar-art {
+        min-height: 200px;
+        order: 1;
+    }
 }

--- a/src/Phaseolies/Console/Commands/stubs/frontend/css/tailwind.stub
+++ b/src/Phaseolies/Console/Commands/stubs/frontend/css/tailwind.stub
@@ -3,11 +3,18 @@
 @source "../../views";
 
 :root {
-    --primary: #10b981;
-    --background: #f9fafb;
+    --bg: #fbfbf9;
     --card-bg: #ffffff;
-    --text-color: #111827;
-    --border: #d1d5db;
+    --card-border: #ececea;
+    --text-color: #18181b;
+    --muted: #6b7280;
+    --line: #e7e5e4;
+    --emerald: #10b981;
+    --emerald-soft: #34d399;
+    --orange: #fb923c;
+    --violet: #807dfc;
+    --yellow: #facc15;
+    --panel-bg: #0a0a0a;
     color-scheme: light;
 }
 
@@ -19,17 +26,16 @@ body {
     margin: 0;
     padding: 40px 20px;
     min-height: 100vh;
-    font-family: Poppins, "Segoe UI", sans-serif;
-    background:
-        radial-gradient(circle at top left, rgba(16, 185, 129, 0.12), transparent 30%),
-        radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.12), transparent 35%),
-        var(--background);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: var(--bg);
     color: var(--text-color);
 }
 
 a {
     color: inherit;
-    text-decoration: none;
 }
 
 code {
@@ -39,103 +45,211 @@ code {
     font-family: "JetBrains Mono", monospace;
 }
 
-.doppar-welcome-shell {
-    max-width: 960px;
-    margin: 0 auto;
-    text-align: center;
-}
-
-.doppar-welcome-header {
-    margin-bottom: 20px;
-}
-
-.doppar-welcome-logo {
-    width: 48px;
-    height: auto;
-    margin-bottom: 10px;
-}
-
-.doppar-welcome-title {
-    margin: 0;
-    font-size: 2rem;
-    font-weight: 700;
-}
-
-.doppar-cta-box {
-    margin: 0 auto 40px;
-    max-width: 600px;
+.doppar-welcome {
     width: 100%;
-    border: 2px solid var(--primary);
-    border-radius: 12px;
-    padding: 20px;
-    background: #ecfdf5;
+    max-width: 980px;
 }
 
-.doppar-cta-box h3 {
-    margin: 0 0 10px;
-    font-size: 1.2rem;
+.doppar-brand {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin: 0 4px 18px;
 }
 
-.doppar-cta-box p {
-    margin: 0;
+.doppar-brand img {
+    width: 24px;
+    height: auto;
 }
 
-.doppar-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: 20px;
-    max-width: 800px;
-    margin: 0 auto 40px;
+.doppar-brand span {
+    font-family: "Space Grotesk", sans-serif;
+    font-weight: 700;
+    font-size: 15px;
 }
 
 .doppar-card {
+    display: grid;
+    grid-template-columns: 1.05fr 0.95fr;
     background: var(--card-bg);
-    padding: 20px;
-    border: 1px solid var(--border);
-    border-radius: 12px;
-    text-align: left;
-    transition: box-shadow .2s;
+    border: 1px solid var(--card-border);
+    border-radius: 28px;
+    overflow: hidden;
+    box-shadow: 0 50px 100px -40px rgba(15, 23, 42, 0.18);
 }
 
-.doppar-card:hover {
-    box-shadow: 0 4px 12px rgba(0, 0, 0, .05);
+.doppar-panel {
+    padding: 56px 52px;
 }
 
-.doppar-card h3 {
-    margin: 0 0 8px;
-    font-size: 1rem;
+.doppar-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--emerald);
+    margin-bottom: 18px;
 }
 
-.doppar-card p {
-    margin: 0;
-    font-size: 14px;
-    color: #4b5563;
+.doppar-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--emerald);
+    box-shadow: 0 0 8px rgba(16, 185, 129, 0.7);
 }
 
-.doppar-btn-group {
-    margin-top: 20px;
+.doppar-heading {
+    font-family: "Space Grotesk", sans-serif;
+    font-weight: 700;
+    font-size: 1.85rem;
+    line-height: 1.2;
+    margin: 0 0 30px;
 }
 
-.doppar-btn {
-    display: inline-block;
-    margin: 0 10px;
-    padding: 10px 18px;
-    background-color: #fff;
-    color: #111827;
-    text-decoration: none;
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    font-weight: 500;
-    transition: background .2s;
+.doppar-steps {
+    margin-bottom: 34px;
 }
 
-.doppar-btn:hover {
-    background-color: #c4c9c8;
+.doppar-step {
+    position: relative;
+    padding-left: 30px;
+    padding-bottom: 22px;
 }
 
-.doppar-footer {
-    margin-top: 50px;
-    font-size: 13px;
+.doppar-step:last-child {
+    padding-bottom: 0;
+}
+
+.doppar-step::before {
+    content: "";
+    position: absolute;
+    left: 5px;
+    top: 20px;
+    bottom: -2px;
+    width: 1px;
+    background: var(--line);
+}
+
+.doppar-step:last-child::before {
+    display: none;
+}
+
+.doppar-step-marker {
+    position: absolute;
+    left: 0;
+    top: 2px;
+    width: 11px;
+    height: 11px;
+    border-radius: 50%;
+    border: 1.5px solid var(--emerald-soft);
+    background: #fff;
+}
+
+.doppar-step-marker::after {
+    content: "";
+    position: absolute;
+    inset: 2.5px;
+    border-radius: 50%;
+    background: var(--emerald-soft);
+}
+
+.doppar-step-label {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
     color: #9ca3af;
-    text-align: center;
+    margin-bottom: 4px;
+}
+
+.doppar-step a {
+    font-size: 14.5px;
+    font-weight: 600;
+    color: var(--text-color);
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.doppar-step a:hover {
+    color: var(--emerald);
+}
+
+.doppar-arrow {
+    font-size: 12px;
+    color: var(--orange);
+}
+
+.doppar-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 13px 26px;
+    border-radius: 999px;
+    background: var(--yellow);
+    color: #171717;
+    text-decoration: none;
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.01em;
+    box-shadow: 0 14px 30px -12px rgba(250, 204, 21, 0.65);
+    transition: transform .15s ease, box-shadow .15s ease;
+}
+
+.doppar-cta:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 18px 34px -12px rgba(250, 204, 21, 0.8);
+}
+
+.doppar-meta {
+    margin-top: 30px;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 12px;
+    color: #9ca3af;
+}
+
+.doppar-meta a {
+    color: var(--muted);
+    text-decoration: none;
+    border-bottom: 1px solid var(--line);
+}
+
+.doppar-meta a:hover {
+    color: var(--orange);
+    border-color: var(--orange);
+}
+
+.doppar-art {
+    position: relative;
+    background: var(--panel-bg);
+    min-height: 460px;
+}
+
+.doppar-art svg {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+}
+
+@media (max-width: 860px) {
+    .doppar-card {
+        grid-template-columns: 1fr;
+    }
+
+    .doppar-panel {
+        padding: 40px 28px;
+        order: 2;
+    }
+
+    .doppar-art {
+        min-height: 200px;
+        order: 1;
+    }
 }

--- a/src/Phaseolies/Console/Commands/stubs/frontend/views/layouts/app.stub
+++ b/src/Phaseolies/Console/Commands/stubs/frontend/views/layouts/app.stub
@@ -5,7 +5,8 @@
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>#yield('title')</title>
         <meta name="csrf-token" content="[[ csrf_token() ]]" />
-        <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@500;600&display=swap" rel="stylesheet">
         <script>
             window.__DOPPAR_FRONTEND__ = {
                 version: "[[ 'v' . Application::VERSION ]]",

--- a/src/Phaseolies/Console/Commands/stubs/frontend/views/welcome/plain.stub
+++ b/src/Phaseolies/Console/Commands/stubs/frontend/views/welcome/plain.stub
@@ -3,39 +3,90 @@
     Doppar
 #endsection
 #section('content')
-<main class="doppar-welcome-shell">
-    <header class="doppar-welcome-header">
-        <img class="doppar-welcome-logo" src="[[ enqueue('logo.png') ]]" alt="Logo" />
-        <h2 class="doppar-welcome-title">Welcome to Doppar</h2>
-    </header>
-    <section class="doppar-cta-box">
-        <h3>[[ trans('messages.welcome', ['version' => 'v' . Application::VERSION]) ]]</h3>
-        <p>Craft Fast-Loading PHP Application</p>
-    </section>
-    <section class="doppar-grid">
-        <a href="https://doppar.com/versions/3.x/starter-kits" class="doppar-card">
-            <h3>Starter kits</h3>
-            <p>To give you a head start building your new Doppar application, we are happy to offer application starter kits.</p>
-        </a>
-        <a href="https://doppar.com/versions/3.x/architecture-concept" class="doppar-card">
-            <h3>System Architecture</h3>
-            <p>Doppar follows the Model-View-Controller (MVC) architectural pattern, a widely accepted standard in web application development.</p>
-        </a>
-        <a href="https://doppar.com/versions/3.x/routing" class="doppar-card">
-            <h3>Routing</h3>
-            <p>With support for route prefix grouping, named routes, throttle route, middleware assignment, and RESTful resource routing, Doppar gives developers full control over how requests are handled.</p>
-        </a>
-        <a href="https://doppar.com/versions/3.x/authentication" class="doppar-card">
-            <h3>Authentication</h3>
-            <p>Doppar simplifies this process by providing built-in tools and scaffolding to help you implement user authentication quickly and securely.</p>
-        </a>
-    </section>
-    <div class="doppar-btn-group">
-        <a href="https://github.com/doppar" class="doppar-btn">GitHub</a>
-        <a href="https://doppar.com" class="doppar-btn">Website</a>
+<div class="doppar-welcome">
+    <div class="doppar-brand">
+        <img src="[[ enqueue('logo.png') ]]" alt="Doppar" />
+        <span>Doppar</span>
     </div>
-    <div class="doppar-footer">
-        PHP [[ phpversion() ]]
+
+    <div class="doppar-card">
+        <div class="doppar-panel">
+            <div class="doppar-eyebrow"><span class="doppar-dot"></span> Application ready</div>
+
+            <h1 class="doppar-heading">Let's build something.</h1>
+
+            <div class="doppar-steps">
+                <div class="doppar-step">
+                    <span class="doppar-step-marker"></span>
+                    <div class="doppar-step-label">01 &middot; Learn</div>
+                    <a href="https://doppar.com/versions/4.x/installation" target="_blank" rel="noopener">Read the documentation <span class="doppar-arrow">&#8599;</span></a>
+                </div>
+                <div class="doppar-step">
+                    <span class="doppar-step-marker"></span>
+                    <div class="doppar-step-label">02 &middot; Explore</div>
+                    <a href="https://doppar.com/versions/4.x/releases" target="_blank" rel="noopener">See what's new in 4.x <span class="doppar-arrow">&#8599;</span></a>
+                </div>
+                <div class="doppar-step">
+                    <span class="doppar-step-marker"></span>
+                    <div class="doppar-step-label">03 &middot; Connect</div>
+                    <a href="https://github.com/doppar" target="_blank" rel="noopener">Star the project on GitHub <span class="doppar-arrow">&#8599;</span></a>
+                </div>
+            </div>
+
+            <a href="https://doppar.com/versions/4.x/installation" class="doppar-cta">Get Started</a>
+
+            <div class="doppar-meta">
+                v[[ Application::VERSION ]] &middot; PHP [[ phpversion() ]] &middot;
+                <a href="https://doppar.com/versions/4.x/releases" target="_blank" rel="noopener">View release notes &#8599;</a>
+            </div>
+        </div>
+
+        <div class="doppar-art">
+            <svg viewBox="0 0 480 620" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
+                <defs>
+                    <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
+                        <stop offset="0%" stop-color="#34d399" />
+                        <stop offset="100%" stop-color="#10b981" />
+                    </linearGradient>
+                    <linearGradient id="g2" x1="0" y1="0" x2="1" y2="1">
+                        <stop offset="0%" stop-color="#fb923c" />
+                        <stop offset="100%" stop-color="#f97316" />
+                    </linearGradient>
+                    <linearGradient id="g3" x1="0" y1="1" x2="1" y2="0">
+                        <stop offset="0%" stop-color="#807dfc" />
+                        <stop offset="100%" stop-color="#a78bfa" />
+                    </linearGradient>
+                    <pattern id="dots" width="26" height="26" patternUnits="userSpaceOnUse">
+                        <circle cx="1.3" cy="1.3" r="1.3" fill="rgba(255,255,255,0.06)" />
+                    </pattern>
+                </defs>
+
+                <rect width="480" height="620" fill="#0a0a0a" />
+                <rect width="480" height="620" fill="url(#dots)" />
+
+                <text x="500" y="470" text-anchor="end" font-family="'Space Grotesk', sans-serif" font-weight="700" font-size="480" fill="none" stroke="rgba(255,255,255,0.08)" stroke-width="2">4</text>
+
+                <g opacity="0.95">
+                    <rect x="0" y="0" width="150" height="150" rx="22" fill="url(#g1)" transform="translate(60 90) rotate(45)" />
+                    <rect x="0" y="0" width="92" height="92" rx="16" fill="url(#g2)" opacity="0.92" transform="translate(300 60) rotate(45)" />
+                    <rect x="0" y="0" width="64" height="64" rx="12" fill="url(#g3)" opacity="0.85" transform="translate(120 330) rotate(45)" />
+                    <rect x="0" y="0" width="118" height="118" rx="18" fill="none" stroke="url(#g1)" stroke-width="2.5" opacity="0.7" transform="translate(270 400) rotate(45)" />
+                    <rect x="0" y="0" width="46" height="46" rx="10" fill="url(#g2)" opacity="0.9" transform="translate(60 500) rotate(45)" />
+                </g>
+
+                <g stroke="rgba(255,255,255,0.18)" stroke-width="1.5" fill="none">
+                    <path d="M90 165 L90 260 L190 260" />
+                    <path d="M300 145 L300 220 L230 220" />
+                </g>
+                <circle cx="90" cy="260" r="3.5" fill="#34d399" />
+                <circle cx="190" cy="260" r="3.5" fill="#fb923c" />
+                <circle cx="230" cy="220" r="3.5" fill="#a78bfa" />
+
+                <g font-family="'JetBrains Mono', monospace" font-size="12" font-weight="600" letter-spacing="2" fill="rgba(255,255,255,0.5)">
+                    <text x="34" y="580">DOPPAR/4.X</text>
+                </g>
+            </svg>
+        </div>
     </div>
-</main>
+</div>
 #endsection


### PR DESCRIPTION
### Description
The framework-shipped welcome page (plain.stub, the React/Vue/Svelte components, and the none/tailwind/bootstrap CSS stubs) still had the 3.x layout — a feature-grid of cards linking to 3.x docs, styled with Poppins. This replaces it with the finalized 4.x design across every install path: a split card with a numbered-steps panel (docs / release notes / GitHub) and a yellow CTA on the left, and a dark SVG art panel (rotated diamond tiles + outlined "4" watermark) on the right, on Space Grotesk/Inter/JetBrains Mono.

